### PR TITLE
Use "Encoding" parameter for asx file

### DIFF
--- a/lib/class/stream_playlist.class.php
+++ b/lib/class/stream_playlist.class.php
@@ -288,7 +288,8 @@ class Stream_Playlist {
     public function create_asx() {
 
         echo '<ASX version = "3.0" BANNERBAR="AUTO">' . "\n";
-        echo "<TITLE>Ampache ASX Playlist</TITLE>";
+        echo "<TITLE>Ampache ASX Playlist</TITLE>\n";
+        echo '<PARAM NAME="Encoding" VALUE="utf-8" />' . "\n";
 
         foreach ($this->urls as $url) {
             echo "<ENTRY>\n";


### PR DESCRIPTION
http://msdn.microsoft.com/library/windows/desktop/dd563989%28v=vs.85%29.aspx

This is needed for my environment.
When this tag does not exist, WMP interprets a file by a default character code(MS932 for me).

It may be necessary to convert tag information(I don't know).  My tags are written by utf-8.
