### PR TITLE
Optional Now Playing filtered by user option

### DIFF
--- a/lib/class/stream.class.php
+++ b/lib/class/stream.class.php
@@ -219,8 +219,11 @@ class Stream {
     public static function get_now_playing($filter=NULL) {
 
         $sql = 'SELECT `session`.`agent`, `now_playing`.* FROM `now_playing` ' .
-            'LEFT JOIN `session` ON `session`.`id` = `now_playing`.`id` ' .
-            'ORDER BY `now_playing`.`expire` DESC';
+            'LEFT JOIN `session` ON `session`.`id` = `now_playing`.`id` ';
+        if (Config::get('now_playing_per_user')) {
+            $sql .= 'GROUP BY `now_playing`.`user` ';
+        }
+        $sql .= 'ORDER BY `now_playing`.`expire` DESC';
         $db_results = Dba::read($sql);
 
         $results = array();

--- a/lib/class/update.class.php
+++ b/lib/class/update.class.php
@@ -286,6 +286,9 @@ class Update {
 
         $update_string = '- Increase the length of sessionids again.<br />';
         $version[] = array('version' => '360014', 'description' => $update_string);
+        
+        $update_string = '- Optionally filter Now Playing to return only the last song per user.<br />';
+        $version[] = array('version' => '360016', 'description' => $update_string);
 
         return $version;
 
@@ -1478,6 +1481,24 @@ class Update {
         $retval = Dba::write('ALTER TABLE `session` CHANGE `id` `id` VARCHAR(256) NOT NULL') ? $retval : false;
 
         return $retval;
+    }
+    
+    /**
+     * update_360016
+     *
+     * Add Now Playing filtered per user preference option
+     */
+    public static function update_360016() {
+        $sql = "INSERT INTO `preference` (`name`,`value`,`description`,`level`,`type`,`catagory`) " .
+            "VALUES ('now_playing_per_user','0','Now playing filtered per user',50,'boolean','interface')";
+        Dba::write($sql);
+        
+        $id = Dba::insert_id();
+
+        $sql = "INSERT INTO `user_preference` VALUES (-1,?,'0')";
+        Dba::write($sql, array($id));
+
+        return true;
     }
 
 }

--- a/lib/preferences.php
+++ b/lib/preferences.php
@@ -166,6 +166,7 @@ function create_preference_input($name,$value) {
         case 'rio_track_stats':
         case 'rio_global_stats':
         case 'direct_link':
+        case 'now_playing_per_user':
             if ($value == '1') { $is_true = "selected=\"selected\""; }
             else { $is_false = "selected=\"selected\""; }
             echo "<select name=\"$name\">\n";


### PR DESCRIPTION
With web player and external clients, the session id often changes and Playing Now can return several songs for the same user. Depending how you use Ampache, this came frequently and can become real noise on the home page.
This pull request add a new interface option to only return the last played song per user.

The db update is update_360016 because update_360015 is already used by the other pending pull request #69.
