### PR TITLE
Added cookies to remember how the collapsed menu were placed.

### DIFF
--- a/templates/sidebar.inc.php
+++ b/templates/sidebar.inc.php
@@ -75,8 +75,35 @@ $(function() {
         //open up the content needed - toggle the slide- if visible, slide up, if not slidedown.
         $content.slideToggle(500, function() {
             $header.children().toggleClass("expanded collapsed");
+            if ($header.children().hasClass("collapsed")) {
+                document.cookie = $header.children().attr('id') + "=collapsed";
+            } else {
+                document.cookie = $header.children().attr('id') + "=expanded";
+            }
         });
 
     });
+});
+
+$(document).ready(function() {
+    // Get a string of all the cookies.
+    var cookieArray = document.cookie.split(";");
+    var result = new Array();
+    // Create a key/value array with the individual cookies.
+    for (var elem in cookieArray) {
+        var temp = cookieArray[elem].split("=");
+        // There is always the cookie ampache, we don't need this one.
+        if (temp[0] != "ampache") {
+            // We need to trim whitespaces.
+            result[$.trim(temp[0])] = $.trim(temp[1]);
+        }
+    }
+    // Finds the elements and if the cookie is collapsed, it
+    // collapsed the found element.
+    for (var key in result) {
+        if ($("#" + key).length && result[key] == "collapsed") {
+            $("#" + key).parent().next().slideToggle(0);
+        }
+    }
 });
 </script>

--- a/templates/sidebar_admin.inc.php
+++ b/templates/sidebar_admin.inc.php
@@ -21,26 +21,26 @@
  */
 ?>
 <ul class="sb2" id="sb_admin">
-  <li><h4 class="header"><?php echo T_('Catalogs'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4>
+  <li><h4 class="header"><?php echo T_('Catalogs'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['catalogs']) ? $_COOKIE['catalogs'] : 'expanded'; ?>" id="catalogs" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4>
    <ul class="sb3" id="sb_admin_catalogs">
     <li id="sb_admin_catalogs_Add"><a href="<?php echo $web_path; ?>/admin/catalog.php?action=show_add_catalog"><?php echo T_('Add a Catalog'); ?></a></li>
     <li id="sb_admin_catalogs_Show"><a href="<?php echo $web_path; ?>/admin/catalog.php?action=show_catalogs"><?php echo T_('Show Catalogs'); ?></a></li>
    </ul>
   </li>
 
-  <li><h4 class="header"><?php echo T_('User Tools'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4>
+  <li><h4 class="header"><?php echo T_('User Tools'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['user_tools']) ? $_COOKIE['user_tools'] : 'expanded'; ?>" id="user_tools" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4>
     <ul class="sb3" id="sb_admin_ut">
       <li id="sb_admin_ut_AddUser"><a href="<?php echo $web_path; ?>/admin/users.php?action=show_add_user"><?php echo T_('Add User'); ?></a></li>
       <li id="sb_admin_ut_BrowseUsers"><a href="<?php echo $web_path; ?>/admin/users.php"><?php echo T_('Browse Users'); ?></a></li>
     </ul>
   </li>
-  <li><h4 class="header"><?php echo T_('Access Control'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4>
+  <li><h4 class="header"><?php echo T_('Access Control'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['access_control']) ? $_COOKIE['access_control'] : 'expanded'; ?>" id="access_control" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4>
     <ul class="sb3" id="sb_admin_acl">
       <li id="sb_admin_acl_AddAccess"><a href="<?php echo $web_path; ?>/admin/access.php?action=show_add_advanced"><?php echo T_('Add ACL'); ?></a></li>
       <li id="sb_admin_acl_ShowAccess"><a href="<?php echo $web_path; ?>/admin/access.php"><?php echo T_('Show ACL(s)'); ?></a></li>
     </ul>
   </li>
-  <li><h4 class="header"><?php echo T_('Other Tools'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4>
+  <li><h4 class="header"><?php echo T_('Other Tools'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['ad_other_tools']) ? $_COOKIE['ad_other_tools'] : 'expanded'; ?>" id="ad_other_tools" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4>
     <ul class="sb3" id="sb_admin_ot">
       <li id="sb_admin_ot_Debug"><a href="<?php echo $web_path; ?>/admin/system.php?action=show_debug"><?php echo T_('Ampache Debug'); ?></a></li>
       <li id="sb_admin_ot_ClearNowPlaying"><a href="<?php echo $web_path; ?>/admin/catalog.php?action=clear_now_playing"><?php echo T_('Clear Now Playing'); ?></a></li>
@@ -51,7 +51,7 @@
     </ul>
   </li>
 <?php if (Access::check('interface','100')) { ?>
-  <li><h4 class="header"><?php echo T_('Server Config'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4>
+  <li><h4 class="header"><?php echo T_('Server Config'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['server_config']) ? $_COOKIE['server_config'] : 'expanded'; ?>" id="server_config" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4>
     <ul class="sb3" id="sb_preferences_sc">
 <?php
     $catagories = Preference::get_catagories();

--- a/templates/sidebar_home.inc.php
+++ b/templates/sidebar_home.inc.php
@@ -21,7 +21,7 @@
  */
 ?>
 <ul class="sb2" id="sb_home">
-    <li><h4 class="header"><?php echo T_('Browse'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
+    <li><h4 class="header"><?php echo T_('Browse'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['browse']) ? $_COOKIE['browse'] : 'expanded'; ?>" id="browse" lt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
         <?php
         if (isset($_REQUEST['action'])) {
             $text = scrub_in($_REQUEST['action']) . '_ac';
@@ -46,7 +46,7 @@
     <?php Ajax::start_container('browse_filters'); ?>
     <?php Ajax::end_container(); ?>
     <li>
-        <h4 class="header"><?php echo T_('Playlist'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
+        <h4 class="header"><?php echo T_('Playlist'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['playlist']) ? $_COOKIE['playlist'] : 'expanded'; ?>" id="playlist" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
         <ul class="sb3" id="sb_home_info">
             <li id="sb_home_info_CurrentlyPlaying"><a href="<?php echo AmpConfig::get('web_path') . ((AmpConfig::get('iframes')) ? '/?framed=1' : ''); ?>"><?php echo T_('Currently Playing'); ?></a></li>
             <?php if (AmpConfig::get('allow_democratic_playback')) { ?>
@@ -65,7 +65,7 @@
         </ul>
     </li>
     <li>
-        <h4 class="header"><?php echo T_('Random'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
+        <h4 class="header"><?php echo T_('Random'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['random']) ? $_COOKIE['random'] : 'expanded'; ?>" id="random" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
         <ul class="sb3" id="sb_home_random">
             <li id="sb_home_random_album"><?php echo Ajax::text('?page=random&action=song', T_('Song'),'home_random_song'); ?></li>
             <li id="sb_home_random_album"><?php echo Ajax::text('?page=random&action=album', T_('Album'),'home_random_album'); ?></li>
@@ -75,7 +75,7 @@
         </ul>
     </li>
     <li>
-        <h4 class="header"><?php echo T_('Information'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
+        <h4 class="header"><?php echo T_('Information'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['information']) ? $_COOKIE['information'] : 'expanded'; ?>" id="information" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
         <ul class="sb3" id="sb_home_info">
             <li id="sb_home_info_Recent"><a href="<?php echo $web_path; ?>/stats.php?action=recent"><?php echo T_('Recent'); ?></a></li>
             <li id="sb_home_info_Newest"><a href="<?php echo $web_path; ?>/stats.php?action=newest"><?php echo T_('Newest'); ?></a></li>
@@ -96,7 +96,7 @@
         </ul>
     </li>
     <li>
-        <h4 class="header"><?php echo T_('Search'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
+        <h4 class="header"><?php echo T_('Search'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['search']) ? $_COOKIE['search'] : 'expanded'; ?>" id="search" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
         <ul class="sb3" id="sb_home_search">
           <li id="sb_home_search_song"><a href="<?php echo $web_path; ?>/search.php?type=song"><?php echo T_('Songs'); ?></a></li>
           <li id="sb_home_search_album"><a href="<?php echo $web_path; ?>/search.php?type=album"><?php echo T_('Albums'); ?></a></li>

--- a/templates/sidebar_localplay.inc.php
+++ b/templates/sidebar_localplay.inc.php
@@ -35,7 +35,7 @@ if ($server_allow && $controller && $access_check) {
     $class = $current_instance ? '' : ' class="active_instance"';
 ?>
 <?php if (Access::check('localplay','25')) { ?>
-  <li><h4 class="header"><?php echo T_('Localplay'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4>
+  <li><h4 class="header"><?php echo T_('Localplay'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['localplay']) ? $_COOKIE['localplay'] : 'expanded'; ?>" id="localplay" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4>
     <ul class="sb3" id="sb_localplay_info">
 <?php if (Access::check('localplay','75')) { ?>
     <li id="sb_localplay_info_add_instance"><a href="<?php echo $web_path; ?>/localplay.php?action=show_add_instance"><?php echo T_('Add Instance'); ?></a></li>
@@ -45,7 +45,7 @@ if ($server_allow && $controller && $access_check) {
     </ul>
   </li>
 <?php } ?>
-  <li><h4 class="header"><?php echo T_('Active Instance'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4>
+  <li><h4 class="header"><?php echo T_('Active Instance'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['active_instance']) ? $_COOKIE['active_instance'] : 'expanded'; ?>" id="active_instance" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4>
     <ul class="sb3" id="sb_localplay_instances">
     <li id="sb_localplay_instances_none"<?php echo $class; ?>><?php echo Ajax::text('?page=localplay&action=set_instance&instance=0', T_('None'),'localplay_instance_none');  ?></li>
     <?php
@@ -63,7 +63,7 @@ if ($server_allow && $controller && $access_check) {
     </ul>
   </li>
 <?php } else { ?>
-  <li><h4 class="header"><?php echo T_('Localplay Disabled'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4></li>
+  <li><h4 class="header"><?php echo T_('Localplay Disabled'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['localplay_disabled']) ? $_COOKIE['localplay_disabled'] : 'expanded'; ?>" id="localplay_disabled" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></h4></li>
   <?php if (!$server_allow) { ?>
     <li><?php echo T_('Allow Localplay set to False'); ?></li>
   <?php } elseif (!$controller) { ?>

--- a/templates/sidebar_modules.inc.php
+++ b/templates/sidebar_modules.inc.php
@@ -21,14 +21,14 @@
  */
 ?>
 <ul class="sb2" id="sb_modules">
-<li><h4 class="header"><?php echo T_('Modules'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
+<li><h4 class="header"><?php echo T_('Modules'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['modules']) ? $_COOKIE['modules'] : 'expanded'; ?>" id="modules" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
         <ul class="sb3" id="sb_Modules">
         <li id="sb_preferences_mo_localplay"><a href="<?php echo $web_path; ?>/admin/modules.php?action=show_localplay"><?php echo T_('Localplay Modules'); ?></a></li>
         <li id="sb_preferences_mo_catalog_types"><a href="<?php echo $web_path; ?>/admin/modules.php?action=show_catalog_types"><?php echo T_('Catalog Modules'); ?></a></li>
         <li id="sb_preferences_mo_plugins"><a href="<?php echo $web_path; ?>/admin/modules.php?action=show_plugins"><?php echo T_('Available Plugins'); ?></a></li>
         </ul>
 </li>
-  <li><h4 class="header"><?php echo T_('Other Tools'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
+  <li><h4 class="header"><?php echo T_('Other Tools'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['md_other_tools']) ? $_COOKIE['md_other_tools'] : 'expanded'; ?>" id="md_other_tools" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
     <ul class="sb3" id="sb_admin_ot">
       <li id="sb_admin_ot_Duplicates"><a href="<?php echo $web_path; ?>/admin/duplicates.php"><?php echo T_('Find Duplicates'); ?></a></li>
       <li id="sb_admin_ot_Mail"><a href="<?php echo $web_path; ?>/admin/mail.php"><?php echo T_('Mail Users'); ?></a></li>

--- a/templates/sidebar_preferences.inc.php
+++ b/templates/sidebar_preferences.inc.php
@@ -27,7 +27,7 @@
 $catagories = Preference::get_catagories();
 ?>
 <ul class="sb2" id="sb_preferences">
-  <li><h4 class="header"><?php echo T_('Preferences'); ?><span class="sprite sprite-icon_all expanded" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
+  <li><h4 class="header"><?php echo T_('Preferences'); ?><span class="sprite sprite-icon_all <?php echo isset($_COOKIE['preferences']) ? $_COOKIE['preferences'] : 'expanded'; ?>" id="preferences" alt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>"></span></h4>
     <ul class="sb3" id="sb_preferences_sections">
 <?php
     foreach ($catagories as $name) {


### PR DESCRIPTION
It automatically replaces the menu based on the cookie value. Also
the icon is placed accordingly. The JS is in the sidebar.inc.php
file due to the fact that changing from home to admin for instance
is actually an Ajax call and if the JS is not within the content
rendered with the Ajax call, it no longer works.

I couldn't get it to work for the Filters menu, as it's no rendered
by the sidebar.
