### PR TITLE
Update default.css because of multilining of text through expand/collaps pics on the sidebar.

### DIFF
--- a/themes/reborn/templates/default.css
+++ b/themes/reborn/templates/default.css
@@ -593,7 +593,7 @@ input[type=button]:focus:active, input[type=submit]:focus:active {
 
 #sidebar-tabs li.sb1 {
     float: left;
-    margin-right: 3px;
+    margin-right: 8px;
     height: 25px;
 }
 


### PR DESCRIPTION
I think 175px is a good compromise for now... I was also thinking about 200px but that's ~fat
Is it not possible to make those variable-through-translation-areas more dynamical without killing the whole style? I was trying it by myself but ... yeah... quite much rules in there XD
Here are the pics :-)

<pre>
before:                         after:                        after 2nd commit
</pre>

![before width](https://cloud.githubusercontent.com/assets/6222200/3266465/9f7cfae2-f2b0-11e3-9b15-b830c998017f.png).![after width](https://cloud.githubusercontent.com/assets/6222200/3266466/a7bce1f4-f2b0-11e3-9056-e3ce036bc1d3.png).![final width](https://cloud.githubusercontent.com/assets/6222200/3266514/9285392e-f2b2-11e3-9bd7-dc5485db6640.png)
