### PR TITLE
Fix subsonic lastModified element returning SI units in some circumstances

### DIFF
--- a/lib/class/subsonic_xml_data.class.php
+++ b/lib/class/subsonic_xml_data.class.php
@@ -203,7 +203,7 @@ class Subsonic_XML_Data
     public static function addArtistsIndexes($xml, $artists, $lastModified)
     {
         $xindexes = $xml->addChild('indexes');
-        $xindexes->addAttribute('lastModified', $lastModified * 1000);
+        $xindexes->addAttribute('lastModified', number_format($lastModified * 1000, 0, '.', ''));
         self::addArtists($xindexes, $artists);
     }
 


### PR DESCRIPTION
In my environment $lastModified \* 1000 is returned in SI units when converted to a string by addAttribute (eg: lastModified="1.405776772E+12"), which breaks my subsonic android client.

This change forces return in normal units.

I suspect that this may only happen on 32 bit systems based on int sizing.
