### PR TITLE
Fixed ability to catalog TV shows.

### DIFF
--- a/lib/class/tvshow.class.php
+++ b/lib/class/tvshow.class.php
@@ -298,7 +298,7 @@ class TVShow extends database_object implements library_item
         }
 
         $sql = 'INSERT INTO `tvshow` (`name`, `prefix`, `year`) ' .
-            'VALUES(?, ?)';
+            'VALUES(?, ?, ?)';
 
         $db_results = Dba::write($sql, array($name, $prefix, $year));
         if (!$db_results) {

--- a/lib/class/tvshow_episode.class.php
+++ b/lib/class/tvshow_episode.class.php
@@ -68,17 +68,17 @@ class TVShow_Episode extends Video
      */
     public static function insert(array $data, $gtypes = array(), $options = array())
     {
-        if (empty($data['tvshow'])) {
-            $data['tvshow'] = T_('Unknown');
+        if (empty($data['tv_show_name'])) {
+            $data['tv_show_name'] = T_('Unknown');
         }
         $tags = $data['genre'];
 
-        $tvshow = TVShow::check($data['tvshow'], $data['tvshow_year']);
+        $tvshow = TVShow::check($data['tv_show_name'], $data['year']);
         if ($options['gather_art'] && $tvshow && $data['tvshow_art'] && !Art::has_db($tvshow, 'tvshow')) {
             $art = new Art($tvshow, 'tvshow');
             $art->insert_url($data['tvshow_art']);
         }
-        $tvshow_season = TVShow_Season::check($tvshow, $data['tvshow_season']);
+        $tv_season_id = TVShow_Season::check($tvshow, $data['tv_season']);
         if ($options['gather_art'] && $tvshow_season && $data['tvshow_season_art'] && !Art::has_db($tvshow_season, 'tvshow_season')) {
             $art = new Art($tvshow_season, 'tvshow_season');
             $art->insert_url($data['tvshow_season_art']);
@@ -88,7 +88,7 @@ class TVShow_Episode extends Video
             foreach ($tags as $tag) {
                 $tag = trim($tag);
                 if (!empty($tag)) {
-                    Tag::add('tvshow_season', $tvshow_season, $tag, false);
+                    Tag::add('tvshow_season', $tv_season_id, $tag, false);
                     Tag::add('tvshow', $tvshow, $tag, false);
                 }
             }
@@ -97,7 +97,7 @@ class TVShow_Episode extends Video
         $sdata = $data;
         // Replace relation name with db ids
         $sdata['tvshow'] = $tvshow;
-        $sdata['tvshow_season'] = $tvshow_season;
+        $sdata['tv_season_id'] = $tv_season_id;
         return self::create($sdata);
     }
 
@@ -109,7 +109,7 @@ class TVShow_Episode extends Video
     {
         $sql = "INSERT INTO `tvshow_episode` (`id`, `original_name`, `season`, `episode_number`, `summary`) " .
             "VALUES (?, ?, ?, ?, ?)";
-        Dba::write($sql, array($data['id'], $data['original_name'], $data['tvshow_season'], $data['tvshow_episode'], $data['summary']));
+        Dba::write($sql, array($data['id'], $data['original_name'], $data['tv_season_id'], $data['tv_episode'], $data['summary']));
 
         return $data['id'];
 

--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -390,9 +390,10 @@ class vainfo
             $info['description'] = $info['description'] ?: trim($tags['description']);
 
             $info['tvshow'] = $info['tvshow'] ?: trim($tags['tvshow']);
+           $info['tv_show_name'] = $info['tv_show_name'] ?: trim($tags['tv_show_name']);
             $info['tvshow_year'] = $info['tvshow_year'] ?: trim($tags['tvshow_year']);
-            $info['tvshow_season'] = $info['tvshow_season'] ?: trim($tags['tvshow_season']);
-            $info['tvshow_episode'] = $info['tvshow_episode'] ?: trim($tags['tvshow_episode']);
+            $info['tv_season'] = $info['tv_season'] ?: trim($tags['tv_season']);
+            $info['tv_episode'] = $info['tv_episode'] ?: trim($tags['tv_episode']);
             $info['release_date'] = $info['release_date'] ?: trim($tags['release_date']);
 
             $info['tvshow_art'] = $info['tvshow_art'] ?: trim($tags['tvshow_art']);


### PR DESCRIPTION
Corrected typo in lib/class/tvshow.class.php

In  lib/class/vainfo.class.php changed $info elements to agree with $Tag elements because tv info was getting lost in successive passes.  The elements of the $tag array are what are provided by the getID3 library.

$tvshow was being used as both string and int and is ultimately used as id for storage in table. So added:
" $info['tv_show_name'] = $info['tv_show_name'] ?: trim($tags['tv_show_name']);"

In lib/class/tvshow_episode.class.php changed $tvshow_season to tv_season_id to avoid confusion with tv show season number.

Still trying to decide how to handle "tv show art", "tv season art", and "art" as the mp4/ITunes specs make no differentation between different kinds of art.  The cover art would be delineated by the stored season/episode number.
