### PR TITLE
Some bugfixes and optimizations for UPNP

### DIFF
--- a/lib/class/plugin.class.php
+++ b/lib/class/plugin.class.php
@@ -73,7 +73,12 @@ class Plugin
      */
     public static function get_plugins($type='')
     {
-        $results = array();
+        // make static cache for optimization when multiple call
+        static $plugins_list;
+        if (!is_null($plugins_list))
+            return $plugins_list;
+
+        $plugins_list = array();
 
         // Open up the plugin dir
         $handle = opendir(AmpConfig::get('prefix') . '/modules/plugins');
@@ -104,13 +109,13 @@ class Plugin
                 }
             }
             // It's a plugin record it
-            $results[$plugin_name] = $plugin_name;
+            $plugins_list[$plugin_name] = $plugin_name;
         } // end while
 
         // Little stupid but hey
-        ksort($results);
+        ksort($plugins_list);
 
-        return $results;
+        return $plugins_list;
 
     } // get_plugins
 

--- a/lib/class/upnp_api.class.php
+++ b/lib/class/upnp_api.class.php
@@ -172,8 +172,19 @@ class Upnp_Api
             return $xmlDoc;
         }
 
+        # sometimes here comes only one single item, not an array. Convert it to array. (TODO - UGLY)
+        if ( (count($prmItems) > 0) && (!is_array($prmItems[0])) ) {
+            $prmItems = array($prmItems);
+        }
+
         # Add each item in $prmItems array to $ndDIDL:
         foreach ($prmItems as $item) {
+            if (!is_array($item)) {
+                debug_event('upnp_class', 'item is not array', 2);
+                debug_event('upnp_class', $item, '5');
+                continue;
+            }
+
             if ($item['upnp:class']	== 'object.container') {
                 $ndItem = $xmlDoc->createElement('container');
             } else {

--- a/upnp/MediaServerServiceDesc.php
+++ b/upnp/MediaServerServiceDesc.php
@@ -8,9 +8,10 @@ if (!AmpConfig::get('upnp_backend')) {
 }
 
 header ("Content-Type:text/xml");
-$web_path = AmpConfig::get('raw_web_path');
+$web_path = AmpConfig::get('local_web_path');
+
+echo '<?xml version="1.0" encoding="UTF-8"?>';
 ?>
-<?xml version="1.0" encoding="UTF-8"?>
 <root xmlns="urn:schemas-upnp-org:device-1-0">
     <specVersion>
         <major>1</major>

--- a/upnp/index.php
+++ b/upnp/index.php
@@ -1,7 +1,25 @@
+<?php
+define('NO_SESSION','1');
+require_once '../lib/init.php';
+
+if (!AmpConfig::get('upnp_backend')) {
+    echo "Disabled.";
+    exit;
+}
+
+if (($_GET['btnSend']) || ($_GET['btnSendAuto'])) {
+    Upnp_Api::sddpSend($msIP);
+}
+?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<?php
+    if ($_GET['btnSendAuto']) {
+        echo '<meta http-equiv="refresh" content="10">';
+    }
+?>
 <title>Ampache UPnP</title>
 <style type="text/css" media="screen">
 body {
@@ -16,15 +34,6 @@ body {
 </head>
 
 <body>
-<?php
-define('NO_SESSION','1');
-require_once '../lib/init.php';
-
-if (!AmpConfig::get('upnp_backend')) {
-    echo "Disabled.";
-    exit;
-}
-?>
 <form method="get" action="">
   <label>Ampache UPnP backend enabled.
   </label>
@@ -32,11 +41,11 @@ if (!AmpConfig::get('upnp_backend')) {
   <br />
   <br />
   <input type="submit" name="btnSend" id="id-btnSend" value="Send SSDP broadcast" />
+  <input type="submit" name="btnSendAuto" id="id-btnSendAuto" value="Send SSDP broadcast every 10 sec" />
 </form>
 <br />
 <?php
-if ($_GET['btnSend']) {
-    Upnp_Api::sddpSend($msIP);
+if (($_GET['btnSend']) || ($_GET['btnSendAuto'])) {
     echo 'SSDP sent at '.date('H:i:s').'.';
 }
 ?>


### PR DESCRIPTION
UPNP fixes:
1) MediaServerServiceDesc.php - fix exception on "<?xml..." parse when php option - short tags - is set

2) bug fix: in createDIDL method sometimes comes single item, not array. But array is expected. And method crashes.
Fix: detect if single item is come and convert it to array.

UPNP improvements:
3) upnp broadcast packet sending page - added button for automatically periodical page refresh for sending broadcast packets without using cron, for development purposes.
When press additional button, page will refresh and send broadcast packet every 10 seconds

Common improvement
4) Plugins class, method get_plugins, make static cache for optimization when multiple calls of this method.
Every time when calling this method the plugins folder was scanned and analyzed for installed and active plugins.
For example - when adding songs to catalog, this method was called thousands times, for every added song.
Now it's doing only once, at first call.
