### PR TITLE
Changes enable gathering track numbers from quicktime (m4a) files.

### DIFF
--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -378,7 +378,12 @@ class vainfo
                         '<br />',
                         strip_tags($tags['lyrics']));
 
-            $info['track'] = $info['track'] ?: intval($tags['track']);
+            if ($key == 'quicktime') {
+                $info['track'] = $info['track'] ?: intval($tags['track_number']);
+            } elseif ($key == 'getID3') {
+                $info['track'] = $info['track'] ?: intval($tags['track']);
+            }
+
             $info['resolution_x'] = $info['resolution_x'] ?: intval($tags['resolution_x']);
             $info['resolution_y'] = $info['resolution_y'] ?: intval($tags['resolution_y']);
             $info['display_x'] = $info['display_x'] ?: intval($tags['display_x']);


### PR DESCRIPTION
I consider this a "work-around" because I don't see a need to automatically require a quicktime file to be searched for id3v2 tags. The getID3 library seems to do a pretty good job of determining the correct means for gathering the data from the varying types of multimedia files from itheir signatures.   I'm not sure that "getid3_tag_order" needs to  even be in the config file to confuse the user.  I know it sure does confuse me,   

Also, there are a number of people with very large collections that take hours to process: Removing the redundancy, may reduce the catalog management time maybe by half.  Expecially with a large collection of 1+ gb mp4's.  

Of course if there is a real need for the duplicity, then "Never Mind...."
Ernie D
