### PR TITLE
add curl to requirements as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ receives the most testing:
     * hash
     * session
     * json
+    * curl (This is not strictly necessary, but may result in a better experience.)
 
 * MySQL 5.x
 


### PR DESCRIPTION
Since I notices the installer checks for `curl` it might as well be listed as an optional requirement.
