### PR TITLE
Parse ID3v2 genres translating IDs into names.

### DIFF
--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -887,18 +887,7 @@ class vainfo
                     $tcid['data'] = str_replace("\xFE", "", $tcid['data']);
 
                     if (!empty($tcid['data'])) {
-                        // Parsing string with the null character
-                        $genres = explode("\0", $tcid['data']);
-                        $parsed_genres = array();
-                        foreach ($genres as $g) {
-                            if (strlen($g) > 2) {   // Only allow tags with at least 3 characters
-                                $parsed_genres[] = $g;
-                            }
-                        }
-
-                        if (count($parsed_genres)) {
-                            $parsed['genre'] = $parsed_genres;
-                        }
+                        $parsed['genre'] = getid3_id3v2::ParseID3v2GenreString($tcid['data']);
                     }
                 }
                 break;


### PR DESCRIPTION
In the develop tree, ID3v2 genres of the form '(<id>)' are acquired as is. They're not interpreted into names.
The functionality to interpret ids into names exists already in `modules/getid3/module.tag.id3v2.php`.

I don't know if you're in the middle of restructuring id3v2 parsing and this pull request uses old code that is meant to go at some point. If that's the case, feel free to ignore this pull request.
