### PR TITLE
Add 10px margin to the bottom of the install page

### DIFF
--- a/templates/install-doped.css
+++ b/templates/install-doped.css
@@ -1,13 +1,13 @@
 .requirements {
-	padding-top: 20px;
+    padding-top: 20px;
 }
 
 .navbar-brand {
-	padding-top: 0px;
+    padding-top: 0px;
 }
 .navbar-brand img {
-	height: 48px;
-	width: 48px;
+    height: 48px;
+    width: 48px;
 }
 
 .panel-heading a:after {

--- a/templates/install-doped.css
+++ b/templates/install-doped.css
@@ -20,3 +20,7 @@
 .panel-heading a.collapsed:after {
     content: "\e080";
 }
+
+body {
+    margin-bottom: 10px;
+}


### PR DESCRIPTION
This is just a minor aesthetic change, but it always annoyed me when I installed ampache. 
I also cleaned up the indentation in install-doped.css

![Before and After](http://i.imgur.com/nmCk7Ye.png)
