### PR TITLE
[FEATURE] Create and update splitted tags

### DIFF
--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -362,6 +362,10 @@ class vainfo
             $info['composer'] = $info['composer'] ?: trim($tags['composer']);
             $info['publisher'] = $info['publisher'] ?: trim($tags['publisher']);
 
+            
+            if(count($tags['genre']) == 1) {
+                $tags['genre'] = preg_split('/[\s]?[,|;][\s?]/', reset($tags['genre'])) ?: $tags['genre'];
+            }
             $info['genre'] = self::clean_array_tag('genre', $info, $tags);
 
             $info['mb_trackid'] = $info['mb_trackid'] ?: trim($tags['mb_trackid']);

--- a/modules/Beets/Handler.php
+++ b/modules/Beets/Handler.php
@@ -65,7 +65,7 @@ abstract class Handler
             list($key, $format) = $to;
             $song[$key] = sprintf($format, $song[$from]);
         }
-        $song['genre'] = explode(',', $song['genre']);
+        $song['genre'] = preg_split('/[\s]?[,|;][\s?]/', $song['genre']);
 
         return $song;
     }


### PR DESCRIPTION
Hey there

I discovered some odds with the tagging system, so I quickly fixed the most important (for me) with this Pull Request.

First: Some tagging softwares (like beets' LastGenre plugin) can add multiple genres to a song. But they are written in one single tag divided by a separator.
So I divide them if there is only one genre tag by some common separators ( , and ; )

Second: There is apparently nothing that updates the song genre when the catalog gets updated.
At this time, I have only updated the tags from a song.

This could be a first step for #469, I have not tested it with real multiple tags though.