### PR TITLE
Added support for additional ID3v2 genre delimiters.

### DIFF
--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -295,6 +295,12 @@ metadata_order = "getID3,filename"
 ; DEFAULT: filename getID3
 metadata_order_video = "filename,getID3"
 
+; Some taggers use delimiters other than \0 for ID3v2 fields
+; This list specifies possible delimiters additional to \0
+; Comma delimiters are not supported at this point
+DEFAULT: ; / // \
+additional_id3v2_genre_delimiters = ";,/,//,\"
+
 ; This determines if a preview image should be retrieved from video files
 ; It requires encode_get_image transcode settings.
 ; DEFAULT: false

--- a/lib/class/preference.class.php
+++ b/lib/class/preference.class.php
@@ -365,7 +365,7 @@ class Preference extends database_object
         $arrays = array(
             'auth_methods', 'getid3_tag_order', 'metadata_order',
             'metadata_order_video', 'art_order', 'registration_display_fields',
-            'registration_mandatory_fields'
+            'registration_mandatory_fields', 'additional_id3v2_genre_delimiters'
         );
 
         foreach ($arrays as $item) {

--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -804,7 +804,20 @@ class vainfo
 
             switch ($tag) {
                 case 'genre':
-                    // Pass the array through
+                    // read additional id3v2 delimiters from config
+                    $delimiters = (array) AmpConfig::get('additional_id3v2_genre_delimiters');
+                    if (isset($data) && is_array($data) &&
+                        isset($delimiters) && is_array($delimiters)) {
+                        // if there is only one element in the array,
+                        // iterate through the delimiters
+                        // until the genre string splits into several elements
+                        $i = 0;
+                        while (count($data) === 1 && $i < count($delimiters)) {
+                            $data = explode($delimiters[$i], $data[0]);
+                            $i++;
+                        }
+                    }
+                    // assign genre array
                     $parsed['genre'] = $data;
                 break;
                 case 'part_of_a_set':


### PR DESCRIPTION
This is the first stab at adding support for additional ID3v2 genre delimiters.

I've seen in other places in the code that config checking (in this case using isset and is_array) is not done - I don't know if this is done somewhere else. So this code could be slimmed down a bit.

I've used the following files to test the code:
http://www.filedropper.com/additionalid3v2genredelimitertest

Unfortunately, I don't know how representative that test is.

I'd really appreciate, if someone with that issue could test it.