### PR TITLE
Fix shoutbox not displaying (#656)

### DIFF
--- a/templates/show_add_shout.inc.php
+++ b/templates/show_add_shout.inc.php
@@ -32,7 +32,7 @@ if ($data) {
 UI::show_box_top($boxtitle, 'box box_add_shout');
 ?>
 <form method="post" enctype="multipart/form-data" action="<?php echo AmpConfig::get('web_path'); ?>/shout.php?action=add_shout">
-<table class="tabledata" cellpadding="0" cellspacing="0">
+<table id="shoutbox-input" cellpadding="0" cellspacing="0">
 <tr>
     <td><strong><?php echo T_('Comment:'); ?></strong>
 </tr>

--- a/themes/reborn/templates/default.css
+++ b/themes/reborn/templates/default.css
@@ -978,6 +978,10 @@ table.tabledata .cel_agent img:hover {
     cursor: help;
 }
 
+#shoutbox-input {
+    font-size: 14px;
+}
+
 .box_preferences h4 {
     font-size: 15px;
     margin-bottom: 10px;


### PR DESCRIPTION
This addresses issue #656.

jQuery-mediaTables (for some reason) was stopping the shoutbox from showing. It  turns out that mediaTables makes no difference to the shoutbox, so the simple solution is not to use mediaTables for it.