### PR TITLE
Git helper for Coding standard

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -11,6 +11,7 @@ auxiliary.org-netbeans-modules-editor-indent.CodeStyle.project.tab-size=4
 auxiliary.org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width=80
 auxiliary.org-netbeans-modules-editor-indent.CodeStyle.project.text-line-wrap=none
 auxiliary.org-netbeans-modules-editor-indent.CodeStyle.usedProfile=project
+auxiliary.org-netbeans-modules-editor-indent.text.x-php5.CodeStyle.project.blankLinesAfterFunction=0
 auxiliary.org-netbeans-modules-editor-indent.text.x-php5.CodeStyle.project.blankLinesBeforeField=0
 auxiliary.org-netbeans-modules-editor-indent.text.x-php5.CodeStyle.project.classDeclBracePlacement=NEW_LINE
 auxiliary.org-netbeans-modules-editor-indent.text.x-php5.CodeStyle.project.expand-tabs=true

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Hook for git which can test code for each commit.
+# To install and use it just copy or symlink it to .git/hooks/pre-commit
+# example (project base dir): pushd .git/hooks/; ln -s ../../scripts/hooks/pre-commit .; popd
+
+if [ -e "php-cs-fixer.phar" ]
+then
+    PHPCSFIXER="php php-cs-fixer.phar"
+elif hash php-cs-fixer
+then
+    PHPCSFIXER="php-cs-fixer"
+fi
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+FIXERS='indentation,linefeed,trailing_spaces,short_tag,braces,controls_spaces,eof_ending,visibility'
+
+ST=0 # Global exit status
+
+# Loop through all committed files
+for file in $(git diff-index --name-only $against); do
+	echo -n "testing $file..."
+
+	FIXEROUT=$(php-cs-fixer fix --dry-run -v --fixers=$FIXERS "$file" | grep -P '\d\)' | sed -r "s~^.*?${file} ~~"; exit ${PIPESTATUS[0]})
+	FIXERST=$?
+
+	PARSEROUT=$(php --syntax-check "$file" 2>&1 | egrep -v 'No syntax errors|Errors parsing'; exit ${PIPESTATUS[0]})
+	PARSERST=$?
+
+	echo -e -n "\r${file}..."
+	if [ $FIXERST != 0 ]; then
+		echo $FIXEROUT
+	elif [ $PARSERST != 0 ]; then
+		echo $PARSEROUT
+	else
+		echo "OK          "
+	fi
+	ST=$(($ST | $FIXERST | $PARSERST))
+done
+
+exit $ST


### PR DESCRIPTION
I created a Git hook for me because I have some problems to get the coding guidelines to my code.
It just checks all files you want to commit before you can write a commit message.

I just throw it in here, maybe someone can use it :-)

At this time it is only partially useful because a lot of files have already issues. When I execute scripts/tests/codestyle.sh I get problems on ~260 files. Maybe we can fix this soon, so anyone that is not used to this syntax can rely on some scripts.

I also change the Netbeans project properties from time to time to get it closer to psr-2, so php-cs-fixer does not have to complain :-)
It is still not perfect, but we are getting closer with the Netbeans code formatter.

EDIT: Just for showcase, it gives you something like this when you hit git commit:
b.php...PHP Parse error: syntax error, unexpected '}' in b.php on line 5
lib/class/catalog.class.php...OK          
modules/Beets/Handler.php...(braces)