### PR TITLE
Set http status code from the curl request

### DIFF
--- a/lib/class/subsonic_api.class.php
+++ b/lib/class/subsonic_api.class.php
@@ -91,6 +91,11 @@ class Subsonic_Api
             if ($rhpart[0] != "Transfer-Encoding") {
                 header($rheader);
             }
+        } else {
+            if (substr($header, 0, 5) === "HTTP/") {
+                // if $header starts with HTTP/ assume it's the status line
+                http_response_code(curl_getinfo($ch,CURLINFO_HTTP_CODE));
+            }
         }
         return strlen($header);
     }


### PR DESCRIPTION
Need to pass through the http status code from the underlying request in order to properly answer with a 206 when skipping bytes.  This needs to go here because this is where the response body starts, so setting it later won't work.

This will fix issues with gstreamer where it reported that ampache couldn't seek because of the 200 response code that was previously being returned.  I've also tested that seeking still works in VLC with this.