### PR TITLE
Converting Boolean compare to identical operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Recommended Version
 
 Currently, the recommended version is [git HEAD](https://github.com/ampache/ampache/archive/master.tar.gz).
 [![Build Status](https://api.travis-ci.org/ampache/ampache.png?branch=master)](https://travis-ci.org/ampache/ampache)
+[![Code Climate](https://codeclimate.com/github/ampache/ampache/badges/gpa.svg)](https://codeclimate.com/github/ampache/ampache)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/ampache/ampache/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/ampache/ampache/?branch=master)
 
 Latest changes but unstable is [develop branch](https://github.com/ampache/ampache/archive/develop.tar.gz).

--- a/lib/class/mailer.class.php
+++ b/lib/class/mailer.class.php
@@ -169,7 +169,7 @@ class Mailer
                 $mail->IsSMTP();
                 $mail->Host = $mailhost;
                 $mail->Port = $mailport;
-                if ($mailauth == true) {
+                if ($mailauth === true) {
                     $mail->SMTPAuth = true;
                     $mail->Username = $mailuser;
                     $mail->Password = $mailpass;
@@ -189,7 +189,7 @@ class Mailer
         }
 
         $retval = $mail->send();
-        if ($retval == true) {
+        if ($retval === true) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
Comparisons against Booleans should use the identical operator to compare to avoid any inconsistencies or false positives. I found this issue using Code Climate to evaluate the code, so I added the Code Climate badge to the README.