### PR TITLE
Improved support for the opus audio format

### DIFF
--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -602,6 +602,8 @@ class Song extends database_object implements media, library_item
             case 'spx':
             case 'ogg':
                 return 'application/ogg';
+            case 'opus':
+                return 'audio/ogg; codecs=opus';
             case 'wma':
             case 'asf':
                 return 'audio/x-ms-wma';

--- a/lib/class/webplayer.class.php
+++ b/lib/class/webplayer.class.php
@@ -114,7 +114,7 @@ class WebPlayer
             }
 
             if ($urlinfo['type'] == 'song') {
-                if ($types['real'] == "ogg") $types['player'] = "oga";
+                if ($types['real'] == "ogg" || $types['real'] == "opus") $types['player'] = "oga";
                 else if ($types['real'] == "mp4") $types['player'] = "m4a";
             } else if ($urlinfo['type'] == 'video') {
                 if ($types['real'] == "ogg") $types['player'] = "ogv";
@@ -123,7 +123,7 @@ class WebPlayer
             }
         } else if ($item->type == 'live_stream') {
             $types['real'] = $item->codec;
-            if ($types['real'] == "ogg") $types['player'] = "oga";
+            if ($types['real'] == "ogg" || $types['real'] == "opus") $types['player'] = "oga";
         } else {
             $ext = pathinfo($item->url, PATHINFO_EXTENSION);
             if (!empty($ext)) $types['real'] = $ext;


### PR DESCRIPTION
This patch enables playback of *.opus files in the web player (tested with current versions of firefox and chrome).