### PR TITLE
Fix calculate_art_size binary so that it works with new configurations

### DIFF
--- a/bin/calculate_art_size.inc
+++ b/bin/calculate_art_size.inc
@@ -28,12 +28,18 @@ require_once $prefix . '/lib/init.php';
 // Turn off output buffering we don't need it for a command line script
 ob_end_clean(); 
 
-$sql = "SELECT `image`,`id` FROM `image`";
+$inDisk = AmpConfig::get('album_art_store_disk');
+
+$sql = "SELECT `image`,`id`,object_id,object_type,size FROM `image`";
 $db_results = Dba::read($sql);
 $results = array();
 
 while ($row = Dba::fetch_assoc($db_results)) {
-    $source = $row['image'];
+    if ($inDisk)
+	    $source = Art::get_from_source(array('file' => Art::get_dir_on_disk($row['object_type'], $row['object_id'], 'default').'art-'.$row['size'].'.jpg'), $row['object_type']);
+    else
+        $source = $row['image'];
+
     $id = $row['id'];
         $dimensions = Core::image_dimensions($source);
         if ($dimensions) {

--- a/lib/class/art.class.php
+++ b/lib/class/art.class.php
@@ -432,7 +432,7 @@ class Art extends database_object
         return true;
     }
 
-    private static function get_dir_on_disk($type, $uid, $kind = '', $autocreate = false)
+    public static function get_dir_on_disk($type, $uid, $kind = '', $autocreate = false)
     {
         $path = AmpConfig::get('local_metadata_dir');
         if (!$path) {


### PR DESCRIPTION
calculate_art_size does not have into account the new possibility ampache has to store metadata on disk. With this changes this binary works again.