### PR TITLE
Add implode in array

### DIFF
--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -826,7 +826,9 @@ class Song extends database_object implements media, library_item
             if (in_array($key,$string_array)) {
                 if (trim(stripslashes($song->$key)) != trim(stripslashes($new_song->$key))) {
                     $array['change'] = true;
-                    $array['element'][$key] = 'OLD: ' . $song->$key . ' --> ' . $new_song->$key;
+                    $songData = is_array($song->$key) ? implode(" ", $song->$key) : $song->$key;
+                    $newSongData = is_array($new_song->$key) ? implode(" ", $new_song->$key) : $new_song->$key;
+                    $array['element'][$key] = 'OLD:' . $songData . ' --> ' . $newSongData;
                 }
             } // in array of stringies
             else {


### PR DESCRIPTION
As I suggested in a bug report, implode should be added here to and not only in the "else"