### PR TITLE
Added functionality for streaming playlists to support track numbers

### DIFF
--- a/lib/class/stream_playlist.class.php
+++ b/lib/class/stream_playlist.class.php
@@ -142,6 +142,7 @@ class Stream_Playlist
                         $url['info_url'] = $object->f_link;
                         $url['image_url'] = Art::url($object->album, 'album', $api_session, (AmpConfig::get('ajax_load') ? 3 : 4));
                         $url['album'] = $object->f_album_full;
+                        $url['track_num'] = $object->f_track;
                     break;
                     case 'video':
                         $url['title'] = 'Video - ' . $object->title;
@@ -393,6 +394,9 @@ class Stream_Playlist
             }
             if ($url->album) {
                 $xml['track']['album'] = $url->album;
+            }
+            if ($url->track_num) {
+                $xml['track']['trackNum'] = $url->track_num;
             }
 
             $result .= XML_Data::keyed_array($xml, true);

--- a/lib/class/stream_url.class.php
+++ b/lib/class/stream_url.class.php
@@ -25,7 +25,7 @@
 
 class Stream_URL extends memory_object
 {
-    public $properties = array('url', 'title', 'author', 'time', 'info_url', 'image_url', 'album', 'type', 'codec');
+    public $properties = array('url', 'title', 'author', 'time', 'info_url', 'image_url', 'album', 'type', 'codec', 'track_num');
 
     /**
      * parse

--- a/lib/class/update.class.php
+++ b/lib/class/update.class.php
@@ -504,6 +504,9 @@ class Update
 
         $update_string = " - Add option on user fullname to show/hide it publicly.<br />";
         $version[] = array('version' => '370035','description' => $update_string);
+        
+        $update_string = " - Add track number field to stream_playlist table.<br />";
+        $version[] = array('version' => '370036','description' => $update_string);
 
         return $version;
     }
@@ -3503,6 +3506,21 @@ class Update
         $retval = true;
 
         $sql = "ALTER TABLE `user` ADD COLUMN `fullname_public` TINYINT( 1 ) UNSIGNED NOT NULL DEFAULT '0'";
+        $retval = Dba::write($sql) ? $retval : false;
+
+        return $retval;
+    }
+    
+    /**
+     * update_370036
+     *
+     * Add option on user fullname to show/hide it publicly
+     */
+    public static function update_370036()
+    {
+        $retval = true;
+
+        $sql = "ALTER TABLE `stream_playlist` ADD COLUMN `track_num` SMALLINT( 5 ) DEFAULT '0'";
         $retval = Dba::write($sql) ? $retval : false;
 
         return $retval;

--- a/lib/class/update.class.php
+++ b/lib/class/update.class.php
@@ -3514,7 +3514,7 @@ class Update
     /**
      * update_370036
      *
-     * Add option on user fullname to show/hide it publicly
+     * Add field for track number when generating streaming playlists
      */
     public static function update_370036()
     {

--- a/sql/ampache.sql
+++ b/sql/ampache.sql
@@ -908,7 +908,6 @@ CREATE TABLE IF NOT EXISTS `stream_playlist` (
   `type` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `time` smallint(5) DEFAULT NULL,
   `codec` varchar(32) CHARACTER SET utf8 DEFAULT NULL,
-  `track_num` smallint(5) DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `sid` (`sid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;
@@ -1075,7 +1074,7 @@ CREATE TABLE IF NOT EXISTS `update_info` (
 --
 
 INSERT INTO `update_info` (`key`, `value`) VALUES
-('db_version', '370035'),
+('db_version', '370036'),
 ('Plugin_Last.FM', '000004');
 
 -- --------------------------------------------------------

--- a/sql/ampache.sql
+++ b/sql/ampache.sql
@@ -1074,7 +1074,7 @@ CREATE TABLE IF NOT EXISTS `update_info` (
 --
 
 INSERT INTO `update_info` (`key`, `value`) VALUES
-('db_version', '370036'),
+('db_version', '370035'),
 ('Plugin_Last.FM', '000004');
 
 -- --------------------------------------------------------

--- a/sql/ampache.sql
+++ b/sql/ampache.sql
@@ -908,6 +908,7 @@ CREATE TABLE IF NOT EXISTS `stream_playlist` (
   `type` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
   `time` smallint(5) DEFAULT NULL,
   `codec` varchar(32) CHARACTER SET utf8 DEFAULT NULL,
+  `track_num` smallint(5) DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `sid` (`sid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1 ;


### PR DESCRIPTION
* New column 'track_num' added to table stream_playlist
* Added new item 'track_num' to properties array within Stream_URL
* Added track number for xspf playlist format

xspf playlist generation now includes track numbers (if track numbers are included in the song) for streaming. This functionality should be feasible to add to other playlist formats provided the playlist supports track numbering.