### PR TITLE
Add rating based on POPM id3 tag

### DIFF
--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -1546,8 +1546,7 @@ abstract class Catalog extends database_object
         // If song rating tag exists and is well formed (array user=>rating), update it
         if ($song->id && array_key_exists('rating', $results) && is_array($results['rating'])) {
             // For each user's ratings, call the function
-            foreach ($results['rating'] as $user => $rating)
-            {
+            foreach ($results['rating'] as $user => $rating) {
                 debug_event('Rating', "Updating rating for Song ".$song->id." to $rating for user $user", 5);
                 $o_rating = new Rating($song->id, 'song');
                 $o_rating->set_rating($rating, $user);

--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -1543,6 +1543,16 @@ abstract class Catalog extends database_object
             debug_event('update', "$song->file : no differences found", 5);
         }
 
+        // If song rating tag exists and is well formed (array user=>rating), update it
+        if ($song->id && array_key_exists('rating', $results) && is_array($results['rating'])) {
+            // For each user's ratings, call the function
+            foreach ($results['rating'] as $user => $rating)
+            {
+                debug_event('Rating', "Updating rating for Song ".$song->id." to $rating for user $user", 5);
+                $o_rating = new Rating($song->id, 'song');
+                $o_rating->set_rating($rating, $user);
+            }
+        }
         return $info;
     } // update_song_from_tags
 

--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -901,6 +901,11 @@ class vainfo
                         $parsed['rating'][$user->id] = $popm['rating'] / 255 * 5;
                     }
                 }
+                // Rating made by an unknow user, adding it to super user (id=-1)
+                else
+                {
+                	$parsed['rating'][-1] = $popm['rating'] / 255 * 5;
+                }
             }
         }
 

--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -902,9 +902,8 @@ class vainfo
                     }
                 }
                 // Rating made by an unknow user, adding it to super user (id=-1)
-                else
-                {
-                	$parsed['rating'][-1] = $popm['rating'] / 255 * 5;
+                else {
+                    $parsed['rating'][-1] = $popm['rating'] / 255 * 5;
                 }
             }
         }

--- a/modules/catalog/local.catalog.php
+++ b/modules/catalog/local.catalog.php
@@ -696,8 +696,7 @@ class Catalog_local extends Catalog
         // If song rating tag exists and is well formed (array user=>rating), add it
         if ($id && array_key_exists('rating', $results) && is_array($results['rating'])) {
             // For each user's ratings, call the function
-            foreach ($results['rating'] as $user => $rating)
-            {
+            foreach ($results['rating'] as $user => $rating) {
                 debug_event('Rating', "Setting rating for Song $id to $rating for user $user", 5);
                 $o_rating = new Rating($id, 'song');
                 $o_rating->set_rating($rating, $user);

--- a/modules/catalog/local.catalog.php
+++ b/modules/catalog/local.catalog.php
@@ -693,6 +693,16 @@ class Catalog_local extends Catalog
         }
 
         $id = Song::insert($results);
+        // If song rating tag exists and is well formed (array user=>rating), add it
+        if ($id && array_key_exists('rating', $results) && is_array($results['rating'])) {
+            // For each user's ratings, call the function
+            foreach ($results['rating'] as $user => $rating)
+            {
+                debug_event('Rating', "Setting rating for Song $id to $rating for user $user", 5);
+                $o_rating = new Rating($id, 'song');
+                $o_rating->set_rating($rating, $user);
+            }
+        }
         // Extended metadata loading is not deferred, retrieve it now
         if ($id && !AmpConfig::get('deferred_ext_metadata')) {
             $song = new Song($id);


### PR DESCRIPTION
Add function to set song rating based on POPM id3 tag when create or update catalog (resolve ampache/ampache#919)
If no Ampache user mail matches with the one in POPM mail, use super user rating (id = -1)

Change-Id: I83b94153655ab21d8dede3cade4fb260459df3c3
Signed-off-by: nioc <nioc@users.noreply.github.com>