### PR TITLE
Fixed missing space in get_icon method when using sprites

### DIFF
--- a/lib/class/ui.class.php
+++ b/lib/class/ui.class.php
@@ -220,7 +220,7 @@ END;
             $hover_url = self::_find_icon($hover_name);
         }
         if ($bUseSprite) {
-            $tag = '<span class="sprite sprite-icon_'.$name.'"';
+            $tag = '<span class="sprite sprite-icon_'.$name.'" ';
         } else {
             $tag = '<img src="' . $icon_url . '" ';
         }


### PR DESCRIPTION
Added missing space between the entered CSS class attribute and the next attribute in that tag.

This is mostly cosmetics (browsers can handle this mistake), but it is marked as "broken" when looking at the page source in FireFox.