### PR TITLE
Add missing separator between track & album in localplay playlist

### DIFF
--- a/templates/show_localplay_status.inc.php
+++ b/templates/show_localplay_status.inc.php
@@ -23,7 +23,7 @@
 $status = $localplay->status();
 $now_playing = $status['track_title'];
 if (!empty($status['track_album'])) {
-    $now_playing .=  $status['track_album'] . ' - ' . $status['track_artist'];
+    $now_playing .= ' - ' .  $status['track_album'] . ' - ' . $status['track_artist'];
 }
 ?>
 <?php Ajax::start_container('localplay_status'); ?>


### PR DESCRIPTION
Not a big deal. In localplay playlist, current song & album were not separated.