### PR TITLE
Patch for wrong file size in database

### DIFF
--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -349,7 +349,7 @@ class vainfo
             $info['bitrate'] = $info['bitrate'] ?: intval($tags['bitrate']);
             $info['rate'] = $info['rate'] ?: intval($tags['rate']);
             $info['mode'] = $info['mode'] ?: $tags['mode'];
-            $info['size'] = $info['size'] ?: $tags['size'];
+            // size will be added later, because of conflicts between real file size and getID3 reported filesize
             $info['mime'] = $info['mime'] ?: $tags['mime'];
             $info['encoding'] = $info['encoding'] ?: $tags['encoding'];
             $info['rating'] = $info['rating'] ?: $tags['rating'];
@@ -421,6 +421,16 @@ class vainfo
             unset($info['disk']);
             unset($info['totaldisks']);
         }
+
+	// Determine the correct file size, do not get fooled by the size which may be returned by id3v2!
+	$size = -1;
+        if (isset($results['general']['size'])) {
+                $size = $results['general']['size'];
+        } else {
+                $size = Core::get_filesize($filename);
+        }
+
+        $info['size'] = $info['size'] ?: $size;
 
         return $info;
     }

--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -423,7 +423,6 @@ class vainfo
         }
 
 	// Determine the correct file size, do not get fooled by the size which may be returned by id3v2!
-	$size = -1;
         if (isset($results['general']['size'])) {
                 $size = $results['general']['size'];
         } else {

--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -422,11 +422,11 @@ class vainfo
             unset($info['totaldisks']);
         }
 
-	// Determine the correct file size, do not get fooled by the size which may be returned by id3v2!
+    // Determine the correct file size, do not get fooled by the size which may be returned by id3v2!
         if (isset($results['general']['size'])) {
-                $size = $results['general']['size'];
+            $size = $results['general']['size'];
         } else {
-                $size = Core::get_filesize($filename);
+            $size = Core::get_filesize($filename);
         }
 
         $info['size'] = $info['size'] ?: $size;


### PR DESCRIPTION
Patch which fixes the wrong size saved in database, as discussed in Ticket #912.

In short, Ampache stores the file size as found in some id3v2 tags. I have some songs which contains a "size" frame in the comment area of the id3v2 tag. Sadly the saved size is not the real file size, which could cause the song to stop playing too early when listening through Ampache.

I'm not sure if this patch is the ultimate solution. It works for me, but it may not work if the catalog is remote or something like that.
As I only have local catalogs, I cannot test it with other options.