### PR TITLE
Fixed getAlbumList2 to always return a album list

### DIFF
--- a/lib/class/subsonic_api.class.php
+++ b/lib/class/subsonic_api.class.php
@@ -584,11 +584,11 @@ class Subsonic_Api
             }
         }
 
+        $r = Subsonic_XML_Data::createSuccessResponse();
         if (count($albums)) {
-            $r = Subsonic_XML_Data::createSuccessResponse();
             Subsonic_XML_Data::addAlbumList($r, $albums, $elementName);
         } else {
-            $r = Subsonic_XML_Data::createError(Subsonic_XML_Data::SSERROR_DATA_NOTFOUND);
+            $r->addChild(htmlspecialchars($elementName));
         }
 
         self::apiOutput($input, $r);


### PR DESCRIPTION
getAlbumList2 now correctly returns an empty album list,
if the requested offset is larger than the album count in catalog.

This is required for some players (like clementine) to allow fetching
of all albums.