### PR TITLE
Speed up (a lot) subsonic getArtists method

### DIFF
--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -943,7 +943,8 @@ abstract class Catalog extends database_object
             $sql_limit = "LIMIT " . $offset . ", 18446744073709551615";
         }
 
-        $sql = "SELECT `artist`.id, `artist`.`name`, `artist`.`summary` FROM `song` LEFT JOIN `artist` ON `artist`.`id` = `song`.`artist` " .
+        $sql = "SELECT `artist`.id, `artist`.`name`, `artist`.`summary`, (SELECT COUNT(DISTINCT album) from `song` as `inner_song` WHERE `inner_song`.`artist` = `song`.`artist`) AS `albums`" .
+                "FROM `song` LEFT JOIN `artist` ON `artist`.`id` = `song`.`artist` " .
                 $sql_where .
                 "GROUP BY `song`.artist ORDER BY `artist`.`name` " .
                 $sql_limit;

--- a/lib/class/subsonic_api.class.php
+++ b/lib/class/subsonic_api.class.php
@@ -429,7 +429,7 @@ class Subsonic_Api
 
         $r = Subsonic_XML_Data::createSuccessResponse();
         $artists = Catalog::get_artists(Catalog::get_catalogs());
-        Subsonic_XML_Data::addArtistsRoot($r, $artists);
+        Subsonic_XML_Data::addArtistsRoot($r, $artists, true);
         self::apiOutput($input, $r);
     }
 

--- a/lib/class/subsonic_xml_data.class.php
+++ b/lib/class/subsonic_xml_data.class.php
@@ -212,13 +212,13 @@ class Subsonic_XML_Data
         self::addArtists($xindexes, $artists);
     }
 
-    public static function addArtistsRoot($xml, $artists)
+    public static function addArtistsRoot($xml, $artists, $albumsSet = false)
     {
         $xartists = $xml->addChild('artists');
-        self::addArtists($xartists, $artists, true);
+        self::addArtists($xartists, $artists, true, $albumsSet);
     }
 
-    public static function addArtists($xml, $artists, $extra=false)
+    public static function addArtists($xml, $artists, $extra=false, $albumsSet = false)
     {
         $xlastcat = null;
         $xsharpcat = null;
@@ -250,25 +250,29 @@ class Subsonic_XML_Data
             }
 
             if ($xlastcat != null) {
-                self::addArtist($xlastcat, $artist, $extra);
+                self::addArtist($xlastcat, $artist, $extra, false, $albumsSet);
             }
         }
     }
 
-    public static function addArtist($xml, $artist, $extra=false, $albums=false)
+    public static function addArtist($xml, $artist, $extra=false, $albums=false, $albumsSet = false)
     {
         $xartist = $xml->addChild('artist');
         $xartist->addAttribute('id', self::getArtistId($artist->id));
         $xartist->addAttribute('name', $artist->name);
 
         $allalbums = array();
-        if ($extra || $albums) {
+        if (($extra && !$albumsSet) || $albums) {
             $allalbums = $artist->get_albums(null, true);
         }
 
         if ($extra) {
             //$xartist->addAttribute('coverArt');
-            $xartist->addAttribute('albumCount', count($allalbums));
+            if ($albumsSet) {
+                $xartist->addAttribute('albumCount', $artist->albums);
+            } else {
+                $xartist->addAttribute('albumCount', count($allalbums));
+            }
         }
         if ($albums) {
             foreach ($allalbums as $id) {


### PR DESCRIPTION
- Make Catalog::get_artists return an album count as "albums".
- Pass through to subsonic api calls to avoid running query for every
artist to count albums (as was happening previously)