### PR TITLE
Add advanced_search api call

### DIFF
--- a/lib/class/api.class.php
+++ b/lib/class/api.class.php
@@ -706,6 +706,23 @@ class Api
     } // search_songs
 
     /**
+     * advanced_search
+     * Perform an advanced search given passed rules
+     * @param array $input
+     */
+    public static function advanced_search($input)
+    {
+        ob_end_clean();
+
+        XML_Data::set_offset($input['offset']);
+        XML_Data::set_limit($input['limit']);
+
+        $results = Search::run($input);
+
+        echo XML_Data::songs($results);
+    } // advanced_search
+
+    /**
      * videos
      * This returns video objects!
      * @param array $input


### PR DESCRIPTION
This allows using the xml api with the full advanced search possibilities.  It does require understanding how the parameters relate to the search performed however, which requires looking at the code.  Something more self documenting would be more code, but easier to use.  Another option would be adding some documentation to the wiki detailing the possible parameters to this call.