### PR TITLE
Make unrated songs appear as 0 rating

### DIFF
--- a/lib/class/search.class.php
+++ b/lib/class/search.class.php
@@ -969,7 +969,7 @@ class Search extends playlist_object
                         $where[] = "COALESCE(`rating`.`rating`,0) $sql_match_operator '$input'";
                     } else {
                         $group[] = "`album`.`id`";
-                        $having[] = "ROUND(AVG(`rating`.`rating`)) $sql_match_operator '$input'";
+                        $having[] = "ROUND(AVG(ifnull(`rating`.`rating`,0))) $sql_match_operator '$input'";
                     }
                     $join['rating'] = true;
                 break;
@@ -1230,7 +1230,7 @@ class Search extends playlist_object
                         $where[] = "COALESCE(`rating`.`rating`,0) $sql_match_operator '$input'";
                     } else {
                         $group[] = "`song`.`id`";
-                        $having[] = "ROUND(AVG(`rating`.`rating`)) $sql_match_operator '$input'";
+                        $having[] = "ROUND(AVG(ifnull(`rating`.`rating`,0))) $sql_match_operator '$input'";
                     }
                     $join['rating'] = true;
                 break;

--- a/lib/class/search.class.php
+++ b/lib/class/search.class.php
@@ -969,7 +969,7 @@ class Search extends playlist_object
                         $where[] = "COALESCE(`rating`.`rating`,0) $sql_match_operator '$input'";
                     } else {
                         $group[] = "`album`.`id`";
-                        $having[] = "ROUND(AVG(ifnull(`rating`.`rating`,0))) $sql_match_operator '$input'";
+                        $having[] = "ROUND(AVG(IFNULL(`rating`.`rating`,0))) $sql_match_operator '$input'";
                     }
                     $join['rating'] = true;
                 break;
@@ -1230,7 +1230,7 @@ class Search extends playlist_object
                         $where[] = "COALESCE(`rating`.`rating`,0) $sql_match_operator '$input'";
                     } else {
                         $group[] = "`song`.`id`";
-                        $having[] = "ROUND(AVG(ifnull(`rating`.`rating`,0))) $sql_match_operator '$input'";
+                        $having[] = "ROUND(AVG(IFNULL(`rating`.`rating`,0))) $sql_match_operator '$input'";
                     }
                     $join['rating'] = true;
                 break;


### PR DESCRIPTION
This makes it possible to search for rating < 1 to build a smart
playlist of unrated songs. Fixes #819.

Signed-off-by: Byron Marohn <combustible@live.com>