### PR TITLE
Subsonic API: search2 ignores song/artist/albumCount = 0

### DIFF
--- a/lib/class/subsonic_api.class.php
+++ b/lib/class/subsonic_api.class.php
@@ -755,11 +755,11 @@ class Subsonic_Api
             }
         }
 
-        $artistCount = $input['artistCount'];
+        $artistCount = isset($input['artistCount']) ? $input['artistCount'] : 20;
         $artistOffset = $input['artistOffset'];
-        $albumCount = $input['albumCount'];
+        $albumCount = isset($input['albumCount']) ? $input['albumCount'] : 20;
         $albumOffset = $input['albumOffset'];
-        $songCount = $input['songCount'];
+        $songCount = isset($input['songCount']) ? $input['songCount'] : 20;
         $songOffset = $input['songOffset'];
 
         $sartist = array();
@@ -771,7 +771,9 @@ class Subsonic_Api
         $sartist['rule_1_operator'] = $operator;
         $sartist['rule_1'] = "name";
         $sartist['type'] = "artist";
-        $artists = Search::run($sartist);
+	if ($artistCount > 0) {
+	        $artists = Search::run($sartist);
+	}
 
         $salbum = array();
         $salbum['limit'] = $albumCount;
@@ -782,7 +784,9 @@ class Subsonic_Api
         $salbum['rule_1_operator'] = $operator;
         $salbum['rule_1'] = "title";
         $salbum['type'] = "album";
-        $albums = Search::run($salbum);
+	if ($albumCount > 0) {
+	        $albums = Search::run($salbum);
+	}
 
         $ssong = array();
         $ssong['limit'] = $songCount;
@@ -793,7 +797,9 @@ class Subsonic_Api
         $ssong['rule_1_operator'] = $operator;
         $ssong['rule_1'] = "anywhere";
         $ssong['type'] = "song";
-        $songs = Search::run($ssong);
+	if ($songCount > 0) {
+	        $songs = Search::run($ssong);
+	}
 
         $r = Subsonic_XML_Data::createSuccessResponse();
         Subsonic_XML_Data::addSearchResult($r, $artists, $albums, $songs, $elementName);

--- a/lib/class/subsonic_api.class.php
+++ b/lib/class/subsonic_api.class.php
@@ -771,9 +771,9 @@ class Subsonic_Api
         $sartist['rule_1_operator'] = $operator;
         $sartist['rule_1'] = "name";
         $sartist['type'] = "artist";
-	if ($artistCount > 0) {
-	        $artists = Search::run($sartist);
-	}
+        if ($artistCount > 0) {
+            $artists = Search::run($sartist);
+        }
 
         $salbum = array();
         $salbum['limit'] = $albumCount;
@@ -784,9 +784,9 @@ class Subsonic_Api
         $salbum['rule_1_operator'] = $operator;
         $salbum['rule_1'] = "title";
         $salbum['type'] = "album";
-	if ($albumCount > 0) {
-	        $albums = Search::run($salbum);
-	}
+        if ($albumCount > 0) {
+            $albums = Search::run($salbum);
+        }
 
         $ssong = array();
         $ssong['limit'] = $songCount;
@@ -797,9 +797,9 @@ class Subsonic_Api
         $ssong['rule_1_operator'] = $operator;
         $ssong['rule_1'] = "anywhere";
         $ssong['type'] = "song";
-	if ($songCount > 0) {
-	        $songs = Search::run($ssong);
-	}
+        if ($songCount > 0) {
+            $songs = Search::run($ssong);
+        }
 
         $r = Subsonic_XML_Data::createSuccessResponse();
         Subsonic_XML_Data::addSearchResult($r, $artists, $albums, $songs, $elementName);


### PR DESCRIPTION
In comparsion with the original subsonic API, the implementation of Ampache does not honor the *Count= parameter if it is set to 0.

When using original subsonic with a query like:
```
http://demo.subsonic.org/rest/search2.view?u=guest1&p=guest&c=nothing&v=1.8.0&query=bilk&albumCount=0&songCount=0
```

The result is a list containing just one artist:
```xml
<subsonic-response status="ok" version="1.13.0">
   <searchResult2>
      <artist id="8" name="bilk"/>
   </searchResult2>
</subsonic-response>
```
When using this parameters with ampache, you get a complete list of songs, albums, artists matching your search term:
```
http://localhost/rest/search2.view?v=1.8.0&c=sampleClient&u=apiuser&p=veryStrongPassword&query=ACDC&albumCount=0&songCount=0
```
```xml
<subsonic-response type="ampache" version="1.11.0" status="ok">
   <searchResult2>
      <artist id="100001990" name="ACDC"/>
      <song id="300083527" parent="200007132" title="Stand Up" isDir="false" isVideo="false" type="music" albumId="200007132" album="Fly On The Wall" artistId="100001990" artist="ACDC" coverArt="200007132" duration="233" bitRate="128" track="7" year="1985" genre="Hard Rock" size="3752983" suffix="mp3" contentType="audio/mpeg" path="sampleTracks/07. ACDC - Stand Up.mp3"/>
[...]
```

The problem is caused by Search::run, which will simply skip the 'LIMIT ' part of the SQL query if the LIMIT is 0.

So to avoid breaking other stuff, I fixed this behavior by taking care of the given parameters in subsonic_api.class.php.

This patch fixes the issue by skipping Search::run if *Count parameter is set to 0.
It also sets a default if the *Count parameter is not set (which is 20 according to subsonic API doc).