### PR TITLE
Subsonic API Impl: Deliver album art if the song does not have a custom picture

### DIFF
--- a/lib/class/subsonic_api.class.php
+++ b/lib/class/subsonic_api.class.php
@@ -1091,8 +1091,8 @@ class Subsonic_Api
             $art = new Art(Subsonic_XML_Data::getAmpacheId($id), "song");
             if ($art != null && $art->id == null) {
                 // in most cases the song doesn't have a picture, but the album where it belongs to has
-        // if this is the case, we take the album art
-                 $song = new Song(Subsonic_XML_Data::getAmpacheId(Subsonic_XML_Data::getAmpacheId($id)));
+                // if this is the case, we take the album art
+                $song = new Song(Subsonic_XML_Data::getAmpacheId(Subsonic_XML_Data::getAmpacheId($id)));
                 $art = new Art(Subsonic_XML_Data::getAmpacheId($song->album), "album");
             }
         }

--- a/lib/class/subsonic_api.class.php
+++ b/lib/class/subsonic_api.class.php
@@ -1085,13 +1085,15 @@ class Subsonic_Api
         $art = null;
         if (Subsonic_XML_Data::isArtist($id)) {
             $art = new Art(Subsonic_XML_Data::getAmpacheId($id), "artist");
-        } else {
-            if (Subsonic_XML_Data::isAlbum($id)) {
-                $art = new Art(Subsonic_XML_Data::getAmpacheId($id), "album");
-            } else {
-                if (Subsonic_XML_Data::isSong($id)) {
-                    $art = new Art(Subsonic_XML_Data::getAmpacheId($id), "song");
-                }
+        } elseif (Subsonic_XML_Data::isAlbum($id)) {
+            $art = new Art(Subsonic_XML_Data::getAmpacheId($id), "album");
+        } elseif (Subsonic_XML_Data::isSong($id)) {
+            $art = new Art(Subsonic_XML_Data::getAmpacheId($id), "song");
+            if ($art != null && $art->id == null) {
+                // in most cases the song doesn't have a picture, but the album where it belongs to has
+        // if this is the case, we take the album art
+                 $song = new Song(Subsonic_XML_Data::getAmpacheId(Subsonic_XML_Data::getAmpacheId($id)));
+                $art = new Art(Subsonic_XML_Data::getAmpacheId($song->album), "album");
             }
         }
 


### PR DESCRIPTION
When trying to get an cover art using the Subsonic API implementation, no image is delivered if the given ID is a song ID.

In the subsonic API docs is defined, that you can call getCoverArt with an ID which is either an albumID, artistID or songID.

When doing this with ampache, you only get a cover art when using the album ID.
This is caused by the SQL query generated in Art()->get_db(). 
The query tries to find images in the image table with 'kind' = "song" and the song ID.

I guess most of the time, there is no entry for 'kind' = 'song' (or for the song ID), because the cover art is the same as for the album to which the song belongs.
So that information is only available when querying with 'kind' = 'album' and the proper album ID.

To work around that behaviour, I implemented a second check, which will try to get the album ID and then use the album cover art if there war no cover art for the song.

I also changed the if...else block to use if...elseif...else, which is better to read and understand than nested 'if' statements.