### PR TITLE
Wrong named sample rate variables fixed + config and db update

### DIFF
--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -7,7 +7,7 @@
 ; if this config file is up to date
 ; this is compared against a value hard-coded
 ; into the init script
-config_version = 31
+config_version = 32
 
 
 ;#########################################################
@@ -886,7 +886,7 @@ transcode_player_customize = "true"
 
 ; Command configuration. Substitutions will be made as follows:
 ; %FILE% => filename
-; %SAMPLE% => target sample rate
+; %BITRATE% => target bit rate
 ; You can do fancy things like VBR, but consider whether the consequences are
 ; acceptable in your environment.
 
@@ -915,11 +915,11 @@ transcode_input = "-i %FILE%"
 ; For each output format, you should provide the necessary arguments for
 ; your transcode_cmd.
 ; encode_args_TYPE = TRANSCODE_CMD_ARGS
-encode_args_mp3 = "-vn -b:a %SAMPLE%K -c:a libmp3lame -f mp3 pipe:1"
-encode_args_ogg = "-vn -b:a %SAMPLE%K -c:a libvorbis -f ogg pipe:1"
-encode_args_m4a = "-vn -b:a %SAMPLE%K -c:a libfdk_aac -f adts pipe:1"
-encode_args_wav = "-vn -b:a %SAMPLE%K -c:a pcm_s16le -f wav pipe:1"
-encode_args_flv = "-b:a %SAMPLE%K -ar 44100 -ac 2 -v 0 -f flv -c:v libx264 -preset superfast -threads 0 pipe:1"
+encode_args_mp3 = "-vn -b:a %BITRATE%K -c:a libmp3lame -f mp3 pipe:1"
+encode_args_ogg = "-vn -b:a %BITRATE%K -c:a libvorbis -f ogg pipe:1"
+encode_args_m4a = "-vn -b:a %BITRATE%K -c:a libfdk_aac -f adts pipe:1"
+encode_args_wav = "-vn -b:a %BITRATE%K -c:a pcm_s16le -f wav pipe:1"
+encode_args_flv = "-b:a %BITRATE%K -ar 44100 -ac 2 -v 0 -f flv -c:v libx264 -preset superfast -threads 0 pipe:1"
 encode_args_webm = "-q %QUALITY% -f webm -c:v libvpx -maxrate %MAXBITRATE%k -preset superfast -threads 0 pipe:1"
 encode_args_ts = "-q %QUALITY% -s %RESOLUTION% -f mpegts -c:v libx264 -c:a libmp3lame -maxrate %MAXBITRATE%k -preset superfast -threads 0 pipe:1"
 

--- a/lib/class/stream.class.php
+++ b/lib/class/stream.class.php
@@ -82,11 +82,11 @@ class Stream
         $max_bitrate = AmpConfig::get('max_bit_rate');
         $min_bitrate = AmpConfig::get('min_bit_rate');
         // FIXME: This should be configurable for each output type
-        $user_sample_rate = AmpConfig::get('sample_rate');
+        $user_bit_rate = AmpConfig::get('transcode_bitrate');
 
         // If the user's crazy, that's no skin off our back
-        if ($user_sample_rate < $min_bitrate) {
-            $min_bitrate = $user_sample_rate;
+        if ($user_bit_rate < $min_bitrate) {
+            $min_bitrate = $user_bit_rate;
         }
 
         // Are there site-wide constraints? (Dynamic downsampling.)
@@ -109,25 +109,25 @@ class Stream
             // We count as one for the algorithm
             // FIXME: Should this reflect the actual bit rates?
             $active_streams++;
-            $sample_rate = floor($max_bitrate / $active_streams);
+            $bit_rate = floor($max_bitrate / $active_streams);
 
             // Exit if this would be insane
-            if ($sample_rate < ($min_bitrate ?: 8)) {
+            if ($bit_rate < ($min_bitrate ?: 8)) {
                 debug_event('stream', 'Max transcode bandwidth already allocated. Active streams: ' . $active_streams, 2);
                 header('HTTP/1.1 503 Service Temporarily Unavailable');
                 exit();
             }
 
             // Never go over the user's sample rate
-            if ($sample_rate > $user_sample_rate) {
-                $sample_rate = $user_sample_rate;
+            if ($bit_rate > $user_bit_rate) {
+                $bit_rate = $user_bit_rate;
             }
         } // end if we've got bitrates
         else {
-            $sample_rate = $user_sample_rate;
+            $bit_rate = $user_bit_rate;
         }
 
-        return $sample_rate;
+        return $bit_rate;
     }
 
     /**
@@ -149,21 +149,21 @@ class Stream
 
         //$media_rate = $media->video_bitrate ?: $media->bitrate;
         if (!$options['bitrate']) {
-            $sample_rate = self::get_allowed_bitrate($media);
-            debug_event('stream', 'Configured bitrate is ' . $sample_rate, 5);
+            $bit_rate = self::get_allowed_bitrate($media);
+            debug_event('stream', 'Configured bitrate is ' . $bit_rate, 5);
             // Validate the bitrate
-            $sample_rate = self::validate_bitrate($sample_rate);
+            $bit_rate = self::validate_bitrate($bit_rate);
         } else {
-            $sample_rate = $options['bitrate'];
+            $bit_rate = $options['bitrate'];
         }
 
         // Never upsample a media
-        if ($media->type == $transcode_settings['format'] && ($sample_rate * 1000) > $media->bitrate) {
-            debug_event('stream', 'Clamping bitrate to avoid upsampling to ' . $sample_rate, 5);
-            $sample_rate = self::validate_bitrate($media->bitrate / 1000);
+        if ($media->type == $transcode_settings['format'] && ($bit_rate * 1000) > $media->bitrate) {
+            debug_event('stream', 'Clamping bitrate to avoid upsampling to ' . $bit_rate, 5);
+            $bit_rate = self::validate_bitrate($media->bitrate / 1000);
         }
 
-        debug_event('stream', 'Final transcode bitrate is ' . $sample_rate, 5);
+        debug_event('stream', 'Final transcode bitrate is ' . $bit_rate, 5);
 
         $song_file = scrub_arg($media->file);
 
@@ -172,7 +172,7 @@ class Stream
 
         $string_map = array(
             '%FILE%'   => $song_file,
-            '%SAMPLE%' => $sample_rate
+            '%BITRATE%' => $bit_rate
         );
         if (isset($options['maxbitrate'])) {
             $string_map['%MAXBITRATE%'] = $options['maxbitrate'];
@@ -298,9 +298,9 @@ class Stream
     public static function validate_bitrate($bitrate)
     {
         /* Round to standard bitrates */
-        $sample_rate = 16*(floor($bitrate/16));
+        $bit_rate = 16*(floor($bitrate/16));
 
-        return $sample_rate;
+        return $bit_rate;
     }
 
     /**

--- a/lib/class/update.class.php
+++ b/lib/class/update.class.php
@@ -514,6 +514,9 @@ class Update
         $update_string = " - Add theme color option.<br />";
         $version[] = array('version' => '370038','description' => $update_string);
 
+        $update_string = " - Renamed false named sample_rate option name in preference table.<br />";
+        $version[] = array('version' => '370039','description' => $update_string);
+
         return $version;
     }
 
@@ -3516,7 +3519,7 @@ class Update
 
         return $retval;
     }
-    
+
     /**
      * update_370036
      *
@@ -3531,7 +3534,7 @@ class Update
 
         return $retval;
     }
-    
+
     /**
      * update_370037
      *
@@ -3546,7 +3549,7 @@ class Update
 
         return $retval;
     }
-    
+
     /**
      * update_370038
      *
@@ -3562,6 +3565,21 @@ class Update
         $id = Dba::insert_id();
         $sql = "INSERT INTO `user_preference` VALUES (-1,?,'dark')";
         $retval = Dba::write($sql, array($id)) ? $retval : false;
+
+        return $retval;
+    }
+
+    /**
+     * update_370039
+     *
+     * Renamed false named sample_rate option name in preference table
+     */
+    public static function update_370039()
+    {
+        $retval = true;
+
+        $sql = "UPDATE `preference` SET `name` = 'transcode_bitrate' WHERE `preference`.`id` = 19";
+        $retval = Dba::write($sql) ? $retval : false;
 
         return $retval;
     }

--- a/lib/init.php
+++ b/lib/init.php
@@ -66,7 +66,7 @@ if (!empty($link)) {
 $results['load_time_begin'] = $load_time_begin;
 /** This is the version.... fluf nothing more... **/
 $results['version']        = '3.8.1-develop';
-$results['int_config_version'] = '31';
+$results['int_config_version'] = '32';
 
 if (!empty($results['force_ssl'])) {
     $http_type = 'https://';

--- a/lib/preferences.php
+++ b/lib/preferences.php
@@ -55,7 +55,7 @@ function update_preferences($pref_id=0)
 
         /* Some preferences require some extra checks to be performed */
         switch ($name) {
-            case 'sample_rate':
+            case 'transcode_bitrate':
                 $value = Stream::validate_bitrate($value);
             break;
             default:


### PR DESCRIPTION
config/ampache.cfg.php.dist
+ updated version because the changes depend on database and base code
changes
+ renamed variable `%SAMPLE%` -> `%BITRATE%`

lib/class/stream.class.php
+ changed `AmpConfig::get('sample_rate');` ->
`AmpConfig::get('transcode_bitrate');` due to db changes
+ renamed variable `%SAMPLE%` -> `%BITRATE`
+ renamed variable `$sample_rate` -> `$bit_rate`
+ renamed variable `$user_sample_rate` -> `$user_bit_rate`

lib/class/update.class.php
+ New update function to change preference name `sample_rate` ->
`transcode_bitrate`

lib/init.php
+ changed config file version for config autoupdate

lib/preference.php
+ changed case `sample_rate` -> `transcode_bitrate` due to db changes

I hope, I didn't forge anything in the source.
I've tested webplayer and streaming. Works as expected on my side

EDIT: This PR depends on #961

EDIT: Title changed bacause the PR has nothing todo with the bit rate handling. O.o