### PR TITLE
Fix metadata errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -318,5 +318,11 @@
             "replace": false,
             "merge-extra": false
         }
-    }
+    },
+
+	"autoload": {
+		"psr-4": {
+			"Lib\\": "lib/class"
+		}
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		}
     },
     "require": {
-		"php": ">=5.3.0",
+		"php": ">=5.4.0",
 		"wikimedia/composer-merge-plugin": "1.*",
 		
         "james-heinrich/getid3": "1.9.*",

--- a/lib/class/DatabaseObject.php
+++ b/lib/class/DatabaseObject.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace lib;
+namespace Lib;
 
 /**
  * Description of Model

--- a/lib/class/Interfaces/Model.php
+++ b/lib/class/Interfaces/Model.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace lib\Interfaces;
+namespace Lib\Interfaces;
 
 /**
  * Description of Model

--- a/lib/class/Metadata/Metadata.php
+++ b/lib/class/Metadata/Metadata.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace lib\Metadata;
+namespace Lib\Metadata;
 
 /**
  * Description of metadata
@@ -59,8 +59,8 @@ trait Metadata
      */
     protected function initializeMetadata()
     {
-        $this->metadataRepository      = new \lib\Metadata\Repository\Metadata();
-        $this->metadataFieldRepository = new \lib\Metadata\Repository\MetadataField();
+        $this->metadataRepository      = new \Lib\Metadata\Repository\Metadata();
+        $this->metadataFieldRepository = new \Lib\Metadata\Repository\MetadataField();
     }
 
 
@@ -84,12 +84,12 @@ trait Metadata
 
     /**
      *
-     * @param \lib\Metadata\Model\MetadataField $field
+     * @param \Lib\Metadata\Model\MetadataField $field
      * @param type $data
      */
-    public function addMetadata(\lib\Metadata\Model\MetadataField $field, $data)
+    public function addMetadata(\Lib\Metadata\Model\MetadataField $field, $data)
     {
-        $metadata = new \lib\Metadata\Model\Metadata();
+        $metadata = new \Lib\Metadata\Model\Metadata();
         $metadata->setField($field);
         $metadata->setObjectId($this->id);
         $metadata->setType(get_class($this));
@@ -97,7 +97,7 @@ trait Metadata
         $this->metadataRepository->add($metadata);
     }
 
-    public function updateOrInsertMetadata(\lib\Metadata\Model\MetadataField $field, $data)
+    public function updateOrInsertMetadata(\Lib\Metadata\Model\MetadataField $field, $data)
     {
         /* @var $metadata Model\Metadata */
         $metadata = $this->metadataRepository->findByObjectIdAndFieldAndType($this->id, $field, get_class($this));
@@ -114,11 +114,11 @@ trait Metadata
      *
      * @param type $name
      * @param type $public
-     * @return \lib\Metadata\Model\MetadataField
+     * @return \Lib\Metadata\Model\MetadataField
      */
     protected function createField($name, $public)
     {
-        $field = new \lib\Metadata\Model\MetadataField();
+        $field = new \Lib\Metadata\Model\MetadataField();
         $field->setName($name);
         if (!$public) {
             $field->hide();

--- a/lib/class/Metadata/Model/Metadata.php
+++ b/lib/class/Metadata/Model/Metadata.php
@@ -21,14 +21,14 @@
  *
  */
 
-namespace lib\Metadata\Model;
+namespace Lib\Metadata\Model;
 
 /**
  * Description of metadata
  *
  * @author raziel
  */
-class Metadata extends \lib\DatabaseObject implements \lib\Interfaces\Model
+class Metadata extends \Lib\DatabaseObject implements \Lib\Interfaces\Model
 {
     /**
      * Database ID
@@ -44,7 +44,7 @@ class Metadata extends \lib\DatabaseObject implements \lib\Interfaces\Model
 
     /**
      * Tag Field
-     * @var Metadata_field
+     * @var MetadataField
      */
     protected $field;
 
@@ -66,7 +66,7 @@ class Metadata extends \lib\DatabaseObject implements \lib\Interfaces\Model
      * can initialize objects the right way
      */
     protected $fieldClassRelations = array(
-        'field' => '\lib\Metadata\Repository\MetadataField'
+        'field' => '\Lib\Metadata\Repository\MetadataField'
     );
 
     /**
@@ -107,9 +107,9 @@ class Metadata extends \lib\DatabaseObject implements \lib\Interfaces\Model
 
     /**
      *
-     * @param Metadata_field $field
+     * @param MetadataField $field
      */
-    public function setField(Metadata_field $field)
+    public function setField(MetadataField $field)
     {
         $this->field = $field;
     }

--- a/lib/class/Metadata/Model/Metadata.php
+++ b/lib/class/Metadata/Model/Metadata.php
@@ -98,9 +98,9 @@ class Metadata extends \Lib\DatabaseObject implements \Lib\Interfaces\Model
 
     /**
      *
-     * @param \library_item $object
+     * @param integer $object
      */
-    public function setObjectId(\library_item $object)
+    public function setObjectId($object)
     {
         $this->objectId = $object;
     }

--- a/lib/class/Metadata/Model/MetadataField.php
+++ b/lib/class/Metadata/Model/MetadataField.php
@@ -21,14 +21,14 @@
  *
  */
 
-namespace lib\Metadata\Model;
+namespace Lib\Metadata\Model;
 
 /**
  * Description of metadata_field
  *
  * @author raziel
  */
-class MetadataField extends \lib\DatabaseObject implements \lib\Interfaces\Model
+class MetadataField extends \Lib\DatabaseObject implements \Lib\Interfaces\Model
 {
     /**
      * Database ID

--- a/lib/class/Metadata/Repository/Metadata.php
+++ b/lib/class/Metadata/Repository/Metadata.php
@@ -21,16 +21,16 @@
  *
  */
 
-namespace lib\Metadata\Repository;
+namespace Lib\Metadata\Repository;
 
 /**
  * Description of Metadata
  *
  * @author raziel
  */
-class Metadata extends \lib\Repository
+class Metadata extends \Lib\Repository
 {
-    protected $modelClassName = '\lib\Metadata\Model\Metadata';
+    protected $modelClassName = '\Lib\Metadata\Model\Metadata';
 
     public static function gc()
     {

--- a/lib/class/Metadata/Repository/MetadataField.php
+++ b/lib/class/Metadata/Repository/MetadataField.php
@@ -21,16 +21,16 @@
  *
  */
 
-namespace lib\Metadata\Repository;
+namespace Lib\Metadata\Repository;
 
 /**
  * Description of Metadata_field
  *
  * @author raziel
  */
-class MetadataField extends \lib\Repository
+class MetadataField extends \Lib\Repository
 {
-    protected $modelClassName = '\lib\Metadata\Model\MetadataField';
+    protected $modelClassName = '\Lib\Metadata\Model\MetadataField';
 
     public static function gc()
     {

--- a/lib/class/Repository.php
+++ b/lib/class/Repository.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace lib;
+namespace Lib;
 
 /**
  * Description of Repository

--- a/lib/class/Repository.php
+++ b/lib/class/Repository.php
@@ -23,6 +23,8 @@
 
 namespace Lib;
 
+use Lib\Interfaces\Model;
+
 /**
  * Description of Repository
  *
@@ -178,7 +180,7 @@ class Repository
      * @param string $property
      * @param mixed $value
      */
-    protected function setPrivateProperty(Object $object, $property, $value)
+    protected function setPrivateProperty(Model $object, $property, $value)
     {
         $reflectionClass    = new \ReflectionClass(get_class($object));
         $ReflectionProperty = $reflectionClass->getProperty($property);

--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -1684,8 +1684,8 @@ abstract class Catalog extends database_object
         Tag::gc();
         
         // TODO: use InnoDB with foreign keys and on delete cascade to get rid of garbage collection
-        \lib\Metadata\Repository\Metadata::gc();
-        \lib\Metadata\Repository\MetadataField::gc();
+        \Lib\Metadata\Repository\Metadata::gc();
+        \Lib\Metadata\Repository\MetadataField::gc();
         debug_event('catalog', 'Database cleanup ended', 5);
     }
 
@@ -2219,4 +2219,3 @@ abstract class Catalog extends database_object
 }
 
 // end of catalog class
-

--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -2219,3 +2219,4 @@ abstract class Catalog extends database_object
 }
 
 // end of catalog class
+

--- a/lib/class/search.class.php
+++ b/lib/class/search.class.php
@@ -395,7 +395,7 @@ class Search extends playlist_object
             );
 
             $metadataFields          = array();
-            $metadataFieldRepository = new \lib\Metadata\Repository\MetadataField();
+            $metadataFieldRepository = new \Lib\Metadata\Repository\MetadataField();
             foreach ($metadataFieldRepository->findAll() as $metadata) {
                 $metadataFields[$metadata->getId()] = $metadata->getName();
             }

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -853,6 +853,11 @@ class Song extends database_object implements media, library_item
 
         // Foreach them
         foreach ($fields as $key=>$value) {
+            // Skip the item if it is no string nor something we can turn into a string
+            if (!is_string($song->$key) || (is_object($song->$key) && method_exists($song->key, '__toString'))) {
+                continue;
+            }
+
             $key = trim($key);
             if (empty($key) || in_array($key,$skip_array)) {
                 continue;
@@ -2031,3 +2036,4 @@ class Song extends database_object implements media, library_item
         return $deleted;
     }
 } // end of song class
+

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -22,7 +22,7 @@
 
 class Song extends database_object implements media, library_item
 {
-    use \lib\Metadata\Metadata;
+    use \Lib\Metadata\Metadata;
 
     /* Variables from DB */
 
@@ -2031,4 +2031,3 @@ class Song extends database_object implements media, library_item
         return $deleted;
     }
 } // end of song class
-

--- a/modules/catalog/local/local.catalog.php
+++ b/modules/catalog/local/local.catalog.php
@@ -616,8 +616,8 @@ class Catalog_local extends Catalog
             }
         }
 
-        \lib\Metadata\Repository\Metadata::gc();
-        \lib\Metadata\Repository\MetadataField::gc();
+        \Lib\Metadata\Repository\Metadata::gc();
+        \Lib\Metadata\Repository\MetadataField::gc();
         return $dead_total;
     }
 
@@ -869,4 +869,3 @@ class Catalog_local extends Catalog
         }
     }
 } // end of local catalog class
-

--- a/modules/catalog/local/local.catalog.php
+++ b/modules/catalog/local/local.catalog.php
@@ -813,16 +813,13 @@ class Catalog_local extends Catalog
      */
     protected function getCleanMetadata(library_item $libraryItem, $metadata)
     {
-        $tags = array_diff($metadata, get_object_vars($libraryItem));
-        $keys = array_merge(
-            isset($libraryItem::$aliases) ? $libraryItem::$aliases : array(),
-            array_keys(get_object_vars($libraryItem))
+        $tags = array_diff_key(
+            $metadata,
+            get_object_vars($libraryItem),
+            array_flip($libraryItem::$aliases ?: array())
         );
-        foreach ($keys as $key) {
-            unset($tags[$key]);
-        }
 
-        return $tags;
+        return array_filter($tags);
     }
 
     /**
@@ -861,7 +858,7 @@ class Catalog_local extends Catalog
 
         $tags = $this->getCleanMetadata($media, $results);
         if (method_exists($media, 'updateOrInsertMetadata') && $media::isCustomMetadataEnabled()) {
-            $tags = array_diff_key($results, array_flip($media->getDisabledMetadataFields()));
+            $tags = array_diff_key($tags, array_flip($media->getDisabledMetadataFields()));
             foreach ($tags as $tag => $value) {
                 $field = $media->getField($tag);
                 $media->updateOrInsertMetadata($field, $value);
@@ -869,3 +866,4 @@ class Catalog_local extends Catalog
         }
     }
 } // end of local catalog class
+

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -20,7 +20,7 @@ else
 	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
 
-FIXERS='indentation,linefeed,trailing_spaces,short_tag,braces,controls_spaces,eof_ending,visibility'
+FIXERS='indentation,linefeed,trailing_spaces,short_tag,braces,controls_spaces,eof_ending,visibility,align_equals,concat_with_spaces,elseif,line_after_namespace,lowercase_constants,lowercase_keywords'
 
 ST=0 # Global exit status
 
@@ -34,7 +34,7 @@ for file in $(git diff-index --name-only $against); do
 	PARSEROUT=$(php --syntax-check "$file" 2>&1 | egrep -v 'No syntax errors|Errors parsing'; exit ${PIPESTATUS[0]})
 	PARSERST=$?
 
-	echo -e -n "\r${file}..."
+	echo -e -n "\r${file} ... "
 	if [ $FIXERST != 0 ]; then
 		echo $FIXEROUT
 	elif [ $PARSERST != 0 ]; then
@@ -44,5 +44,9 @@ for file in $(git diff-index --name-only $against); do
 	fi
 	ST=$(($ST | $FIXERST | $PARSERST))
 done
+
+if [ $ST != 0 ]; then
+	echo "Use 'php-cs-fixer fix -v --fixers=$FIXERS <file>' to correct"
+fi
 
 exit $ST


### PR DESCRIPTION
Hi again

This one fixes the errors introduced with the Metadata feature.

Main changes:
- Switch class loading to composer (psr-4). The old classloader was still working somehow (at least the import still worked for me), but the composer one threw errors.
- Fixed some typehints and similar stuff. Probably introduced this when I refactored some of my code.
- Improved filtering of metadata. The old one was not working as intended because I did something stupid...so just all data got imported. If you already imported songs with the new metadata feature, you could just truncate the `metadata` and `metadata_field` tables and update your library.
- updated needed PHP version to PHP 5.4 because this feature is using traits

Please make sure to run a `composer dumpautoload` after checking out the feature.

Hope I have found all introduced errors :-)