### PR TITLE
Lib needs to be lib on GNU/Linux

### DIFF
--- a/lib/class/Interfaces/Model.php
+++ b/lib/class/Interfaces/Model.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Lib\Interfaces;
+namespace lib\Interfaces;
 
 /**
  * Description of Model

--- a/lib/class/Metadata/Metadata.php
+++ b/lib/class/Metadata/Metadata.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Lib\Metadata;
+namespace lib\Metadata;
 
 /**
  * Description of metadata
@@ -59,8 +59,8 @@ trait Metadata
      */
     protected function initializeMetadata()
     {
-        $this->metadataRepository      = new \Lib\Metadata\Repository\Metadata();
-        $this->metadataFieldRepository = new \Lib\Metadata\Repository\MetadataField();
+        $this->metadataRepository      = new \lib\Metadata\Repository\Metadata();
+        $this->metadataFieldRepository = new \lib\Metadata\Repository\MetadataField();
     }
 
 
@@ -84,12 +84,12 @@ trait Metadata
 
     /**
      *
-     * @param \Lib\Metadata\Model\MetadataField $field
+     * @param \lib\Metadata\Model\MetadataField $field
      * @param type $data
      */
-    public function addMetadata(\Lib\Metadata\Model\MetadataField $field, $data)
+    public function addMetadata(\lib\Metadata\Model\MetadataField $field, $data)
     {
-        $metadata = new \Lib\Metadata\Model\Metadata();
+        $metadata = new \lib\Metadata\Model\Metadata();
         $metadata->setField($field);
         $metadata->setObjectId($this->id);
         $metadata->setType(get_class($this));
@@ -97,7 +97,7 @@ trait Metadata
         $this->metadataRepository->add($metadata);
     }
 
-    public function updateOrInsertMetadata(\Lib\Metadata\Model\MetadataField $field, $data)
+    public function updateOrInsertMetadata(\lib\Metadata\Model\MetadataField $field, $data)
     {
         /* @var $metadata Model\Metadata */
         $metadata = $this->metadataRepository->findByObjectIdAndFieldAndType($this->id, $field, get_class($this));
@@ -114,11 +114,11 @@ trait Metadata
      *
      * @param type $name
      * @param type $public
-     * @return \Lib\Metadata\Model\MetadataField
+     * @return \lib\Metadata\Model\MetadataField
      */
     protected function createField($name, $public)
     {
-        $field = new \Lib\Metadata\Model\MetadataField();
+        $field = new \lib\Metadata\Model\MetadataField();
         $field->setName($name);
         if (!$public) {
             $field->hide();

--- a/lib/class/Metadata/Model/Metadata.php
+++ b/lib/class/Metadata/Model/Metadata.php
@@ -21,14 +21,14 @@
  *
  */
 
-namespace Lib\Metadata\Model;
+namespace lib\Metadata\Model;
 
 /**
  * Description of metadata
  *
  * @author raziel
  */
-class Metadata extends \Lib\DatabaseObject implements \Lib\Interfaces\Model
+class Metadata extends \lib\DatabaseObject implements \lib\Interfaces\Model
 {
     /**
      * Database ID
@@ -66,7 +66,7 @@ class Metadata extends \Lib\DatabaseObject implements \Lib\Interfaces\Model
      * can initialize objects the right way
      */
     protected $fieldClassRelations = array(
-        'field' => '\Lib\Metadata\Repository\MetadataField'
+        'field' => '\lib\Metadata\Repository\MetadataField'
     );
 
     /**

--- a/lib/class/Metadata/Model/MetadataField.php
+++ b/lib/class/Metadata/Model/MetadataField.php
@@ -21,14 +21,14 @@
  *
  */
 
-namespace Lib\Metadata\Model;
+namespace lib\Metadata\Model;
 
 /**
  * Description of metadata_field
  *
  * @author raziel
  */
-class MetadataField extends \Lib\DatabaseObject implements \Lib\Interfaces\Model
+class MetadataField extends \lib\DatabaseObject implements \lib\Interfaces\Model
 {
     /**
      * Database ID

--- a/lib/class/Metadata/Repository/Metadata.php
+++ b/lib/class/Metadata/Repository/Metadata.php
@@ -21,16 +21,16 @@
  *
  */
 
-namespace Lib\Metadata\Repository;
+namespace lib\Metadata\Repository;
 
 /**
  * Description of Metadata
  *
  * @author raziel
  */
-class Metadata extends \Lib\Repository
+class Metadata extends \lib\Repository
 {
-    protected $modelClassName = '\Lib\Metadata\Model\Metadata';
+    protected $modelClassName = '\lib\Metadata\Model\Metadata';
 
     public static function gc()
     {

--- a/lib/class/Metadata/Repository/MetadataField.php
+++ b/lib/class/Metadata/Repository/MetadataField.php
@@ -21,16 +21,16 @@
  *
  */
 
-namespace Lib\Metadata\Repository;
+namespace lib\Metadata\Repository;
 
 /**
  * Description of Metadata_field
  *
  * @author raziel
  */
-class MetadataField extends \Lib\Repository
+class MetadataField extends \lib\Repository
 {
-    protected $modelClassName = '\Lib\Metadata\Model\MetadataField';
+    protected $modelClassName = '\lib\Metadata\Model\MetadataField';
 
     public static function gc()
     {

--- a/lib/class/Repository.php
+++ b/lib/class/Repository.php
@@ -21,9 +21,9 @@
  *
  */
 
-namespace Lib;
+namespace lib;
 
-use Lib\Interfaces\Model;
+use lib\Interfaces\Model;
 
 /**
  * Description of Repository

--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -1684,8 +1684,8 @@ abstract class Catalog extends database_object
         Tag::gc();
         
         // TODO: use InnoDB with foreign keys and on delete cascade to get rid of garbage collection
-        \Lib\Metadata\Repository\Metadata::gc();
-        \Lib\Metadata\Repository\MetadataField::gc();
+        \lib\Metadata\Repository\Metadata::gc();
+        \lib\Metadata\Repository\MetadataField::gc();
         debug_event('catalog', 'Database cleanup ended', 5);
     }
 

--- a/lib/class/search.class.php
+++ b/lib/class/search.class.php
@@ -395,7 +395,7 @@ class Search extends playlist_object
             );
 
             $metadataFields          = array();
-            $metadataFieldRepository = new \Lib\Metadata\Repository\MetadataField();
+            $metadataFieldRepository = new \lib\Metadata\Repository\MetadataField();
             foreach ($metadataFieldRepository->findAll() as $metadata) {
                 $metadataFields[$metadata->getId()] = $metadata->getName();
             }

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -22,7 +22,7 @@
 
 class Song extends database_object implements media, library_item
 {
-    use \Lib\Metadata\Metadata;
+    use \lib\Metadata\Metadata;
 
     /* Variables from DB */
 

--- a/modules/catalog/local/local.catalog.php
+++ b/modules/catalog/local/local.catalog.php
@@ -616,8 +616,8 @@ class Catalog_local extends Catalog
             }
         }
 
-        \Lib\Metadata\Repository\Metadata::gc();
-        \Lib\Metadata\Repository\MetadataField::gc();
+        \lib\Metadata\Repository\Metadata::gc();
+        \lib\Metadata\Repository\MetadataField::gc();
         return $dead_total;
     }
 


### PR DESCRIPTION
This was changed in commit `69a4a5f1f47a8e0caeb77c6835e0361549253937`, after which ampache stopped working with errors like this in my logs:

    2015/11/21 08:11:29 [error] 4311#0: *750664 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Trait 'Lib\Metadata\Metadata' not found in /home/ampache/html/lib/class/song.class.php on line 25" while reading response header from upstream, client: 1.2.3.4, server: domain.tld, request: "POST /server/ajax.server.php?page=index&action=reloadnp HTTP/1.1", upstream: "fastcgi://unix:/run/ampache-php-fpm.sock:", host: "domain.tld", referrer: "http://domain.tld/index.php"

This PR reverts that, so ampache works again. It seems the cause is [this](https://github.com/ampache/ampache/blob/develop/composer.json#L325) not mapping as expected.