### PR TITLE
Fix too big Album Art on index while Grid View is disabled

### DIFF
--- a/themes/reborn/templates/default.css
+++ b/themes/reborn/templates/default.css
@@ -1019,6 +1019,8 @@ table.disablegv td.cel_rating {
 }
 
 .random_selection .random_album .art_album img {
+    height: 100px;
+    width: 100px;
     vertical-align: middle;
     -webkit-border-radius: 2px;
     -moz-border-radius: 2px;


### PR DESCRIPTION
Without this, you'll get:

![tobigalbumartonindex](https://cloud.githubusercontent.com/assets/6222200/11955069/9b625b90-a8ae-11e5-9ddb-19e31be12c12.png)
