### PR TITLE
Return up to 99 999 starred artists/albums/tracks to subsonic

### DIFF
--- a/lib/class/subsonic_api.class.php
+++ b/lib/class/subsonic_api.class.php
@@ -1173,7 +1173,7 @@ class Subsonic_Api
         self::check_version($input, "1.7.0");
 
         $r = Subsonic_XML_Data::createSuccessResponse();
-        Subsonic_XML_Data::addStarred($r, Userflag::get_latest('artist'), Userflag::get_latest('album'), Userflag::get_latest('song'), $elementName);
+        Subsonic_XML_Data::addStarred($r, Userflag::get_latest('artist',null,99999), Userflag::get_latest('album',null,99999), Userflag::get_latest('song',null,99999), $elementName);
         self::apiOutput($input, $r);
     }
 


### PR DESCRIPTION
Subsonic clients (at least dsub) appears to expect all starred artists, albums and tracks to be returned when requesting a list of starred items. Ampache was returning only 10, which broke starred functionality in dsub. This changes the subsonic API class to return up to 99 999 items of each type instead, enabling starred functionality to work properly.

I have tested the change using dsub as a client to ampache.