### PR TITLE
Show artist name as well as album name when hovering images

### DIFF
--- a/lib/class/art.class.php
+++ b/lib/class/art.class.php
@@ -1692,7 +1692,7 @@ class Art extends database_object
      */
     public static function display_item($item, $thumb, $link = null)
     {
-        return self::display($item->type ?: strtolower(get_class($item)), $item->id, $item->get_fullname(), $thumb, $link);
+        return self::display($item->type ?: strtolower(get_class($item)), $item->id, "[" . $item->f_artist . "] " . $item->get_fullname(), $thumb, $link);
     }
 
     /**


### PR DESCRIPTION
**Problem:**
When hovering images on "album of the moment" to see the tooltip, no artist name is shown.
This is annoying as the coverart is not always really readable (or contains any text at all), so you got an album name but don't have a clue which artist it is.

**Solution:**
This patch adds the same pattern to the tooltip text as applied when no images is found.
The pattern is "[artist] album".

**Known Issues:**
The downside of this patch is, that the artist name now also shown in image tooltips when listing albums of an specific artist. But I think this is an acceptable issue.

**Not included in this patch:**
Another improvement I would suggest is to make the tooltip text configurable. Either global (ampache config) or per user.
As I don't know how to solve this the right way, I left that feature ou