### PR TITLE
Rework LDAP Auth

### DIFF
--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -680,41 +680,58 @@ site_charset = UTF-8
 ; LDAP login info (optional)                             #
 ;#########################################################
 
-; LDAP filter string to use (required)
-; For OpenLDAP use "uid"
-; For Microsoft Active Directory (MAD) use "sAMAccountName"
+; LDAP server URL (required)
 ; DEFAULT: none
-;ldap_filter = "(sAMAccountName=%v)"
+;ldap_url = "ldap://localhost/"
+;ldap_url = "ldaps://localhost/"
 
-; LDAP objectclass (required)
-; OpanLDAP objectclass = "*"
-; MAD objectclass = "organizationalPerson"
-; DEFAULT null
-;ldap_objectclass = "organizationalPerson"
-
-; Initial credentials to bind with for searching (optional)
+; LDAP credentials (optional)
 ; DEFAULT: none
 ;ldap_username = ""
 ;ldap_password = ""
+
+; LDAP Base DN for the search (required)
+; DEFAULT: none
+;ldap_search_dn = "ou=People,dc=yoursubdomain,dc=yourdomain,dc=yourtld"
+
+; LDAP objectClass (required)
+; DEFAULT: none
+;ldap_objectclass = "posixAccount"          ; OpenLDAP
+;ldap_objectclass = "organizationalPerson"  ; Microsoft Active Directory
+
+; LDAP filter for search (required)
+; DEFAULT: none
+;ldap_filter = "(uid=%v)"                   ; OpenLDAP
+;ldap_filter = "(sAMAccountName=%v)"        ; Microsoft Active Directory
 
 ; Require that the user is in a specific group (optional)
 ; DEFAULT: none
 ;ldap_require_group = "cn=yourgroup,ou=yourorg,dc=yoursubdomain,dc=yourdomain,dc=yourtld"
 
-; This is the search dn used to find users (required)
-; DEFAULT: none
-;ldap_search_dn = "ou=People,dc=yoursubdomain,dc=yourdomain,dc=yourtld"
+; LDAP name field
+; DEFAULT = "cn"
+;ldap_name_field = "cn"
+;ldap_name_field = "givenName sn"
 
-; This is the address of your ldap server (required)
-; DEFAULT: none
-;ldap_url = ""
-
-; Attributes where additional user information is stored (optional)
-; OpenLDAP ldap_name_field = "cn"
-; MAD ldap_name_field = "displayname"
-; DEFAULT: none
+; LDAP email field
+; DEFAULT = "mail"
 ;ldap_email_field = "mail"
-;ldap_name_field  = "cn"
+
+; LDAP protocol version to use
+; DEFAULT: 3
+;ldap_protocol_version = 3
+
+; LDAP StartTLS
+; DEFAULT: false
+;ldap_start_tls = "false"
+
+; LDAP member attribute name.
+; That's the name of the attribute of the group that will contain
+; the usernames.
+; DEFAULT: member
+;ldap_member_attribute = "member"
+;ldap_member_attribute = "memberuid"
+
 
 
 ;#########################################################

--- a/lib/class/ampconfig.class.php
+++ b/lib/class/ampconfig.class.php
@@ -51,13 +51,13 @@ class AmpConfig
      * This returns a config value.
      * @param string $name
      */
-    public static function get($name)
+    public static function get($name, $default=null)
     {
         if (isset(self::$_global[$name])) {
             return self::$_global[$name];
         }
 
-        return null;
+        return $default;
     }
 
     /**

--- a/lib/class/ldap.class.php
+++ b/lib/class/ldap.class.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPLv3)
+ * Copyright 2001 - 2015 Ampache.org
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+
+/**
+ * This class defines custom LDAP exceptions that will be used in the
+ * main LDAP class.
+ */
+class LDAPException extends Exception
+{
+    /**
+     * A LDAPException may be constructed thanks to a message, or an error
+     * code. If the given argument is an integer, the exception will be
+     * produced with message:
+     *
+     *     LDAP error: [errno] errmsg
+     *
+     * Otherwise, the provided message will be used.
+     *
+     * @param mixed $message
+     */
+    public function __construct ($message)
+    {
+        if (is_int (message)) {
+            $message = 'LDAP error: [' . $message . '] ' . ldap_err2str($message);
+        }
+
+        debug_event('LDAP', 'Exception: ' . $message, 6);
+        parent::__construct ($message);
+    }
+}
+
+
+
+/**
+ * This class handles all the contacts with a LDAP server
+ */
+class LDAP
+{
+    /**
+     * Constructor
+     *
+     * This should never be called
+     */
+    public function __construct()
+    {
+        debug_event('LDAP', '__construct has been called. This should not happen', 2);
+    }
+
+
+    /**
+     * ldap_auth
+     *
+     * This handles authentication against a LDAP server.
+     *
+     * @param string $username
+     * @param string $password
+     * @return array
+     */
+    public static function auth ($username, $password)
+    {
+        try {
+            /* Connect to the LDAP
+               Note: This does not open a connection. It checks whether
+               the given parameters are plausibe and can be used to open a
+               connection as soon as one is needed. */
+
+            if (! $url = AmpConfig::get('ldap_url')) {
+                throw new LDAPException('Required configuration value missing: ldap_url');
+            }
+
+            if (! $link = ldap_connect ($url)) {
+                throw new LDAPException('Could not connect to ' . $url);
+            }
+
+            /* Set the LDAP protocol version (default: 3) */
+
+            $protocol_version = AmpConfig::get('ldap_protocol_version', 3);
+            if (! ldap_set_option ($link, LDAP_OPT_PROTOCOL_VERSION, $protocol_version)) {
+                throw new LDAPException('Could not set option PROTOCOL_VERSION to ' . $protocol_version);
+            }
+
+            /* Use StartTLS if asked */
+
+            if (AmpConfig::get('ldap_start_tls', "false") != "false") {
+                if (! ldap_start_tls ($link)) {
+                    throw new LDAPException('Could not use StartTLS');
+                }
+            }
+
+            /* Connect to the LDAP using the given username and password.
+               If these parameters do not exist, an anonymous connection
+               will be used */
+
+            $ampache_username = AmpConfig::get('ldap_username');
+            $ampache_password = AmpConfig::get('ldap_password');
+
+            if (! ldap_bind ($link, $ampache_username, $ampache_password)) {
+                throw new LDAPException('Could not bind to server using username `'
+                                    . $ampache_username . '` and password `'
+                                    . $ampache_password . '`');
+            }
+
+            /* Search for the user with given base_dn, filter, objectclass and username */
+
+            if (! $filter = AmpConfig::get('ldap_filter')) {
+                throw new LDAPException('Required configuration value missing: ldap_filter');
+            }
+
+            if (strpos ($filter, '%v') !== false) {
+                $filter = str_replace('%v', $username, $filter);
+            } else {
+                $filter = "($filter=$username)"; // Backward compatibility
+            }
+
+            if (! $objectclass = AmpConfig::get('ldap_objectclass')) {
+                throw new LDAPException('Required configuration value missing: ldap_objectclass');
+            }
+
+            $search = "(&(objectclass=$objectclass)$filter)";
+            debug_event ('LDAP', 'search: ' . $search, 5);
+
+            if (! $base_dn = AmpConfig::get('ldap_search_dn')) {
+                throw new LDAPException('Required configuration value missing: ldap_search_dn');
+            }
+
+            if (! $result = ldap_search ($link, $base_dn, $search)) {
+                throw new LDAPException(ldap_errno($link));
+            }
+
+            /* Bind with the user's DN and the password */
+
+            if (! $user_entry = ldap_first_entry ($link, $result)) {
+                throw new LDAPException('Empty search result');
+            }
+
+            if (! $user_dn = ldap_get_dn ($link, $user_entry)) {
+                throw new LDAPException(ldap_errno($link));
+            }
+
+            $user_entry = ldap_get_entries ($link, $result) [0];
+
+            if (! ldap_bind ($link, $user_dn, $password)) {
+                throw new LDAPException('Wrong password');
+            }
+
+            /* Test if the user is in the required group (optional) */
+
+            if ($group_dn = AmpConfig::get('ldap_require_group')) {
+                $member_attribute = AmpConfig::get('ldap_member_attribute', 'member');
+
+                if (! $group_result = ldap_read ($link, $group_dn, 'objectClass=*', [$member_attribute])) {
+                    throw new LDAPException("Could not read member attribute `$member_attribute`"
+                                            . " for group `$group_dn`");
+                }
+
+                if (! $group_infos = ldap_get_entries ($link, $group_result) [0]) {
+                    throw new LDAPException('Empty group search result');
+                }
+
+                if (! in_array ($username, $group_infos[$member_attribute])) {
+                    throw new LDAPException("`$username` is not member of the group `$group_dn`");
+                }
+            }
+
+            /* Obtain name and email field. Reconstruct name field to allow
+               custom things like "givenName sn" */
+
+            $name_field  = AmpConfig::get('ldap_name_field', 'cn');
+            $name_fields = explode(' ', $name_field);
+            $names       = array_map (function ($name_field) use ($user_entry) {
+                    return $user_entry[$name_field][0]; }, $name_fields);
+            $name = trim(implode(' ', $names));
+
+            $email_field = AmpConfig::get('ldap_email_field', 'mail');
+            $email       = $user_entry[$email_field][0];
+
+            $return_value = [
+                'success'  => true,
+                'type'     => 'ldap',
+                'username' => $username,
+                'name'     => $name,
+                'email'    => $email
+            ];
+        } catch (LDAPException $e) {
+            $message = $e->getMessage();
+
+            debug_event('LDAP', 'Error during authentication: ' . $message, 3);
+
+            $return_value = [
+                'success' => false,
+                'error'   => $message
+            ];
+        }
+
+        ldap_unbind ($link);
+
+        debug_event('LDAP', 'Return value of authentication: ' . json_encode($return_value), 6);
+
+        return $return_value;
+    }
+}


### PR DESCRIPTION
What have been done:

- Ignore `composer.lock` files

- Add a default value to `AmpConfig::get`.
  The default behaviour is still the same: `AmpConfig::get($key)` returns the value associated to the given key, and `null` if the key doesn't exist.
  But you can now provide a default return value: `AmpConfig::get($key, $default)` returns the value associated to the given key, and `$default` if the key doesn't exist.

- Rework LDAP section in config file
  This section should be a little cleaner, but might need more documentation.

- Rework LDAP auth
  - Move it from `lib/class/auth.class.php` (`Auth::ldap_auth`) to `lib/class/ldap.class.php` (`LDAP::auth`). The parameters are the same, but the function has been fully rewriten:
  - Code cleanup (in particular, no nested ifs anymore...)
  - Parameter for LDAP protocol version (default to 3)
  - Parameter for LDAP group's member attribute name (default to "member")
  - Parameter for StartTLS (default to false)
  - Support for custom name fields. For instance, on some LDAP servers, cn=uid, so that's not giving you the name. But you can take the first name from `givenName` and the familiy name from `sn`. Now you can provide the parameter `ldap_name_field = "givenName sn"` that will cover this case

In particular, the default behaviour of Ampache (with no extra config) should be exactly the same (backward compatibility...), but this allows better future reworks (because LDAP is now in a specific file, and because the code is much cleaner imo), a wider compatibility with LDAP servers, … and that's already something ^^

This code is working great against my personnal LDAP server. But there are so many ways of configuring a LDAP server that I could not cover all cases in tests… I might need some help from people using the LDAP auth on this one.

If this PR is accepted, I'll also rework the LDAP wiki page.