### PR TITLE
Specify utf-8 charset for event-stream content to make Chrome happy

### DIFF
--- a/server/sse.server.php
+++ b/server/sse.server.php
@@ -36,7 +36,7 @@ set_time_limit(0);
 
 if (!$_REQUEST['html']) {
     define('SSE_OUTPUT', true);
-    header('Content-Type: text/event-stream');
+    header('Content-Type: text/event-stream; charset=utf-8');
     header('Cache-Control: no-cache');
 }
 


### PR DESCRIPTION
Otherwise chrome complains with:
EventSource's response has a charset ("iso-8859-1") that is not UTF-8. Aborting the connection.

Solves issue [#1162](https://github.com/ampache/ampache/issues/1162)