### PR TITLE
Fix issue that blocks webplayer when transcoding

### DIFF
--- a/lib/class/webplayer.class.php
+++ b/lib/class/webplayer.class.php
@@ -102,7 +102,7 @@ class WebPlayer
 
                     // Transcode is not forced, transcode only if required
                     if (!$transcode) {
-                        if (!in_array('native', $valid_types)) {
+                        if ($transcode_cfg == 'always' || !in_array('native', $valid_types)) {
                             $transcode_settings = $media->get_transcode_settings(null, 'webplayer');
                             if ($transcode_settings) {
                                 $types['real'] = $transcode_settings['format'];


### PR DESCRIPTION
IRC backlog:

         Niols │ Hey, the player time bar isn't working on my instance, is this due to a recent commit (I'm up-to-date with develop) or is it only me?
    @Afterster │ working on my side
    @Afterster │ maybe related to your transcoding config
         Niols │ Oh
         Niols │ That would explain a lot of things actually if transcoding weren't working ^^
         Niols │ How can I know if transcoding is working correctly?
    @Afterster │ I think it is working by default now, and it's why you don't have the time (it's generally the case when you transcode)
         Niols │ That's sad :(
         Niols │ Hm, about transcoding, it looks like I can't transcode FLAC files
         Niols │ I looked at the configuration, and I don't seem to have anything related to transcoding of FLACs specifically
         Niols │ Except 'transcode_flac = allowed'
    @Afterster │ ok, it means your browser cannot stream flac (mostly), then it try to transcode
         Niols │ Well, I have this issue with transcode=never, default and always
         Niols │ So I guess my browser can't read FLAC
         Niols │ and there is probably an other problem in transcoding
         Niols │ I tried the avconv command given in config, piped it to a file
         Niols │ I'm able to read this mp3 128kbps file
         Niols │ But when I take the same song
         Niols │ With transcode=always in user config
         Niols │ The player fails
         Niols │ I have nothing in server logs nor in firefox' console
    @Afterster │ the transcode command is working on your server ?
    @Afterster │ if you try throug shell
         Niols │ Yep, I tried
         Niols │ I guess I tried the right thing
         Niols │ transcode_cmd transcode_input encode_args_mp3 > test.mp3
         Niols │ This is working correctly
         Niols │ A have a waveform, but it's null
         Niols │ I mean, not moving at all
         Niols │ Just a straight line
         Niols │ I tried with an other FLAC. The file goes into the player, goes in Now Playing. I have an apparently correct waveform. But it's not playing
         Niols │ Hum, I enabled debug log, and I really don't understand
         Niols │ I copied/pasted the exact transcode command found in these logs and it's working
         Niols │ (when I download the file created with shell)
         Niols │ But not in the webplayer
         Niols │ Could that come from this?
         Niols │ 2016-03-06 19:43:46 [niols] (webplayer.class.php) -> Types {{"real":"flac","player":"flac"}}
         Niols │ I would've expected real=flac, player=mp3 since i'm transcoding
         Niols │ Otherwise, my debug log looks normal to me
         Niols │ Here it is, if you want to take a look: <link1>
    @Afterster │ what's your value for transcode setting?
         Niols │ Here is my transcode part in ampache.cfg.php
         Niols │ <link2>
    @Afterster │ yes but for your user?
    @Afterster │ the same setting that give issue for waveform as you reported
         Niols │ Oh, sorry
         Niols │ <link3> (french, sorry)
    @Afterster │ javascript disabled for player?
         Niols │ All four players enabled
    @Afterster │ ok I see the issue
         Niols │ great! :)
    @Afterster │ webplayer.class.php, L105, change to:
    @Afterster │ if ($transcode_cfg == 'always' || !in_array('native', $valid_types)) {
         Niols │ It's working!
         Niols │ Note: it also solved the "play bar not moving" issue
         Niols │ Well played and thank you so much :)
         Niols │ Do you want me to PR this?
    @Afterster │ welcome :)
    @Afterster │ yes you can PR, thks

Here is `<link1>`:
```
2016-03-06 19:43:46 [niols] (session) -> uihno40va6ep7t65er4bsrivv6 has been extended to Sun, 06 Mar 2016 20:43:46 +0100 extension length 3600 
2016-03-06 19:43:46 [niols] (ajax.server.php) -> Called for page: {stream} 
2016-03-06 19:43:46 [niols] (stream.ajax.php) -> Called for action {directplay} 
2016-03-06 19:43:46 [niols] (stream.ajax.php) -> Play type {} 
2016-03-06 19:43:46 [niols] (session) -> uihno40va6ep7t65er4bsrivv6 has been extended to Sun, 06 Mar 2016 20:43:46 +0100 extension length 3600 
2016-03-06 19:43:46 [niols] (session) -> uihno40va6ep7t65er4bsrivv6 has been extended to Sun, 06 Mar 2016 20:43:46 +0100 extension length 3600 
2016-03-06 19:43:46 [niols] (stream.php) -> Asked for {play_item}. 
2016-03-06 19:43:46 [niols] (stream.php) -> Stream Type: web_player Media IDs: [{"object_type":"song","object_id":"20105"}] 
2016-03-06 19:43:46 [niols] (session) -> Session created: bc7fbb8e3e6883a0c57e23af183648e6   
2016-03-06 19:43:46 [niols] (media) -> Using default target format 
2016-03-06 19:43:46 [niols] (media) -> Transcode settings: from flac to mp3 
2016-03-06 19:43:46 [niols] (media) -> Command: avconv Arguments: -i %FILE% -vn -b:a %BITRATE%K -c:a libmp3lame -f mp3 pipe:1 
2016-03-06 19:43:46 [niols] (media) -> Changing play url type from {flac} to {mp3} due to encoding settings... 
2016-03-06 19:43:46 [niols] (stream_playlist.class.php) -> Adding url {{"properties":["url","title","author","time","info_url","image_url","album","type","codec","track_num"]}}... 
2016-03-06 19:43:46 [niols] (stream_playlist) -> Generating a {web_player} object...   
2016-03-06 19:43:46 [niols] (webplayer.class.php) -> Types {{"real":"flac","player":"flac"}} 
2016-03-06 19:43:46 [niols] (webplayer.class.php) -> Return get_media_js_param {{"title":"Lone Digger","artist":"Caravan Palace","artist_id":"685","album_id":"1711","replaygain_track_gain":"0.000000","replaygain_track_peak":"0.000000","replaygain_album_gain":"0.000000","replaygain_album_peak":"0.000000","media_id":"20105","media_type":"song","filetype":"flac","url":"https:\/\/music.b-six.rocks:443\/play\/index.php?ssid=bc7fbb8e3e6883a0c57e23af183648e6&type=song&oid=20105&uid=6&name=Caravan%20Palace%20-%20Lone%20Digger.mp3","poster":"https:\/\/music.b-six.rocks\/image.php?object_id=1711&object_type=album&auth=bc7fbb8e3e6883a0c57e23af183648e6&thumb=3&name=art.jpg"}} 
2016-03-06 19:43:46 [niols] (webplayer.class.php) -> Types {{"real":"flac","player":"flac"}}   
2016-03-06 19:43:46 [niols] (webplayer.class.php) -> Return get_media_js_param {{"title":"Lone Digger","artist":"Caravan Palace","artist_id":"685","album_id":"1711","replaygain_track_gain":"0.000000","replaygain_track_peak":"0.000000","replaygain_album_gain":"0.000000","replaygain_album_peak":"0.000000","media_id":"20105","media_type":"song","filetype":"flac","url":"https:\/\/music.b-six.rocks:443\/play\/index.php?ssid=bc7fbb8e3e6883a0c57e23af183648e6&type=song&oid=20105&uid=6&name=Caravan%20Palace%20-%20Lone%20Digger.mp3","poster":"https:\/\/music.b-six.rocks\/image.php?object_id=1711&object_type=album&auth=bc7fbb8e3e6883a0c57e23af183648e6&thumb=3&name=art.jpg"}} 
2016-03-06 19:43:47 [niols] (session) -> uihno40va6ep7t65er4bsrivv6 has been extended to Sun, 06 Mar 2016 20:43:47 +0100 extension length 3600 
2016-03-06 19:43:47 [niols] (webplayer.class.php) -> Types {{"real":"flac","player":"flac"}} 
2016-03-06 19:43:47 [niols] (webplayer.class.php) -> Types {{"real":"flac","player":"flac"}} 
2016-03-06 19:43:47 [niols] (webplayer.class.php) -> Return get_media_js_param {{"title":"Lone Digger","artist":"Caravan Palace","artist_id":"685","album_id":"1711","replaygain_track_gain":"0.000000","replaygain_track_peak":"0.000000","replaygain_album_gain":"0.000000","replaygain_album_peak":"0.000000","media_id":"20105","media_type":"song","filetype":"flac","url":"https:\/\/music.b-six.rocks:443\/play\/index.php?ssid=bc7fbb8e3e6883a0c57e23af183648e6&type=song&oid=20105&uid=6&name=Caravan%20Palace%20-%20Lone%20Digger.mp3","poster":"https:\/\/music.b-six.rocks\/image.php?object_id=1711&object_type=album&auth=bc7fbb8e3e6883a0c57e23af183648e6&thumb=3&name=art.jpg"}} 
2016-03-06 19:43:48 [niols] (session) -> uihno40va6ep7t65er4bsrivv6 has been extended to Sun, 06 Mar 2016 20:43:48 +0100 extension length 3600 
2016-03-06 19:43:48 [niols] (session) -> bc7fbb8e3e6883a0c57e23af183648e6 has been extended to Sun, 06 Mar 2016 21:43:48 +0100 extension length 7200 
2016-03-06 19:43:48 [niols] (ajax.server.php) -> Called for page: {} 
2016-03-06 19:43:48 [niols] (play) -> Playing file (/home/b6/music/library/good/Caravan Palace/2015 - __°_°__/01 - Lone Digger.flac}... 
2016-03-06 19:43:48 [niols] (play) -> Media type {flac} 
2016-03-06 19:43:48 [niols] (play) -> Custom play action {} 
2016-03-06 19:43:48 [niols] (play) -> Transcode to {} 
2016-03-06 19:43:48 [niols] (play) -> Transcoding due to always 
2016-03-06 19:43:48 [niols] (stream.class.php) -> Starting transcode for {/home/b6/music/library/good/Caravan Palace/2015 - __°_°__/01 - Lone Digger.flac}. Type {}. Options: Array 
2016-03-06 19:43:48 [niols] (stream.class.php) -> ( 
2016-03-06 19:43:48 [niols] (stream.class.php) -> ) 
2016-03-06 19:43:48 [niols] (stream.class.php) -> }... 
2016-03-06 19:43:48 [niols] (media) -> Using default target format 
2016-03-06 19:43:48 [niols] (media) -> Transcode settings: from flac to mp3 
2016-03-06 19:43:48 [niols] (media) -> Command: avconv Arguments: -i %FILE% -vn -b:a %BITRATE%K -c:a libmp3lame -f mp3 pipe:1 
2016-03-06 19:43:48 [niols] (stream) -> Configured bitrate is 128 
2016-03-06 19:43:48 [niols] (stream) -> Final transcode bitrate is 128 
2016-03-06 19:43:48 [niols] (stream) -> %SAMPLE% not in transcode command 
2016-03-06 19:43:48 [niols] (stream) -> %MAXBITRATE% not in transcode command 
2016-03-06 19:43:48 [niols] (stream) -> %RESOLUTION% not in transcode command 
2016-03-06 19:43:48 [niols] (stream) -> %QUALITY% not in transcode command 
2016-03-06 19:43:48 [niols] (stream) -> Transcode command: avconv -i '/home/b6/music/library/good/Caravan Palace/2015 - __°_°__/01 - Lone Digger.flac' -vn -b:a 128K -c:a libmp3lame -f mp3 pipe:1 
2016-03-06 19:43:48 [niols] (stream) -> Transcode command prefix: exec  
2016-03-06 19:43:48 [niols] (play) -> Starting stream of /home/b6/music/library/good/Caravan Palace/2015 - __°_°__/01 - Lone Digger.flac with size 25719026 


^C
```

Here is `<link2>`:
```
;######################################################                                                          
; These are commands used to transcode non-streaming                                                             
; formats to the target file type for streaming.                                                                 
; This can be useful in re-encoding file types that don't stream                                                 
; very well, or if your player doesn't support some file types.                                                  
;                                                                                                                
; 'Downsampling' will also use these commands.                                                                   
;                                                                                                                
; To state the bleeding obvious, any programs referenced in the transcode                                        
; commands must be installed, in the web server's search path (or referenced                                     
; by their full path), and executable by the web server.                                                         

; Input type selection                                                                                           
; TYPE is the extension. 'allowed' certifies that transcoding works properly for                                 
; this input format. 'required' further forbids the direct streaming of a format                                 
; (e.g. if you store everything in FLAC, but don't want to ever stream that.)                                    
; transcode_TYPE         = {allowed|required|false}                                                              
; DEFAULT: false                                                                                                 
;;; Audio                                                                                                        
transcode_m4a = "allowed"
transcode_flac = "allowed"
transcode_mpc = "allowed"
transcode_ogg = "allowed"
transcode_oga = "allowed"
transcode_wav = "allowed"
transcode_wma = "allowed"
transcode_aif = "allowed"
transcode_aiff = "allowed"
transcode_ape = "allowed"
transcode_shn = "allowed"
transcode_mp3 = "allowed"
;;; Video                                                                                                        
transcode_avi = "allowed"
transcode_mkv = "allowed"
transcode_mpg = "allowed"
transcode_mpeg = "allowed"
transcode_m4v = "allowed"
transcode_mp4 = "allowed"
transcode_mov = "allowed"
transcode_wmv = "allowed"
transcode_ogv = "allowed"
transcode_divx = "allowed"
transcode_m2ts = "allowed"
transcode_webm = "allowed"

; Default audio output format                                                                                    
; DEFAULT: none                                                                                                  
encode_target = "mp3"

; Default video output format                                                                                    
; DEFAULT: none                                                                                                  
encode_video_target = "webm"

; Override the default output format on a per-type basis                                                         
; encode_target_TYPE = TYPE                                                                                      
; DEFAULT: none                                                                                                  
;encode_target_flac = ogg                                                                                        

; Override the default TYPE transcoding behavior on a per-player basis                                           
; transcode_player_PLAYER_TYPE = TYPE                                                                            
; Valid PLAYER is: webplayer, api                                                                                
; DEFAULT: none                                                                                                  
;transcode_player_webplayer_m4a = required                                                                       
;transcode_player_webplayer_flac = required                                                                      
;transcode_player_webplayer_mpc = required                                                                       

; Override the default output format on a per-player basis                                                       
; encode_player_PLAYER_target = TYPE                                                                             
; Valid PLAYER is: webplayer, api                                                                                
; DEFAULT: none                                                                                                  
;encode_player_webplayer_target = mp3                                                                            
;encode_player_api_target = mp3                                                                                  

; Allow clients to override transcode settings (output type, bitrate, codec ...)                                 
; DEFAULT: true                                                                                                  
transcode_player_customize = "true"

; Command configuration. Substitutions will be made as follows:                                                  
; %FILE% => filename                                                                                             
; %BITRATE% => target bit rate                                                                                   
; You can do fancy things like VBR, but consider whether the consequences are                                    
; acceptable in your environment.                                                                                

; Master transcode command                                                                                       
; transcode_cmd should be a single command that supports multiple file types,                                    
; such as ffmpeg or avconv. It's still possible to make a configuration that's                                   
; equivalent to the old default, but if you find that necessary you should be                                    
; clever enough to figure out how on your own.                                                                   
; DEFAULT: none                                                                                                  
transcode_cmd = "avconv"
;transcode_cmd = "avconv"                                                                                        
;transcode_cmd = "/usr/bin/neatokeen"                                                                            

; Transcode input file argument                                                                                  
transcode_input = "-i %FILE%"

; Specific transcode commands                                                                                    
; It shouldn't be necessary in most cases, but you can override the transcode                                    
; command for specific source formats.  It still needs to accept the                                             
; encoding arguments, so the easiest approach is to use your normal command as                                   
; a clearing-house.                                                                                              
; transcode_cmd_TYPE = TRANSCODE_CMD                                                                             
;transcode_cmd_mid = "timidity -Or -o – %FILE% | ffmpeg -f s16le -i pipe:0"                                      

; Encoding arguments                                                                                             
; For each output format, you should provide the necessary arguments for                                         
; your transcode_cmd.                                                                                            
; encode_args_TYPE = TRANSCODE_CMD_ARGS                                                                          
encode_args_mp3 = "-vn -b:a %BITRATE%K -c:a libmp3lame -f mp3 pipe:1"
encode_args_ogg = "-vn -b:a %BITRATE%K -c:a libvorbis -f ogg pipe:1"
encode_args_m4a = "-vn -b:a %BITRATE%K -c:a libfdk_aac -f adts pipe:1"
encode_args_wav = "-vn -b:a %BITRATE%K -c:a pcm_s16le -f wav pipe:1"
encode_args_flv = "-b:a %BITRATE%K -ar 44100 -ac 2 -v 0 -f flv -c:v libx264 -preset superfast -threads 0 pipe:1"
encode_args_webm = "-q %QUALITY% -f webm -c:v libvpx -maxrate %MAXBITRATE%k -preset superfast -threads 0 pipe:1"
encode_args_ts = "-q %QUALITY% -s %RESOLUTION% -f mpegts -c:v libx264 -c:a libmp3lame -maxrate %MAXBITRATE%k -pr\
eset superfast -threads 0 pipe:1"

; Encoding arguments to retrieve an image from a single frame                                                    
encode_get_image = "-ss %TIME% -f image2 -vframes 1 pipe:1"

; Encoding argument to encrust subtitle                                                                          
encode_srt = "-vf \"subtitles='%SRTFILE%'\""

; Encode segment frame argument                                                                                  
encode_ss_frame = "-ss %TIME%"

; Encode segment duration argument                                                                               
encode_ss_duration = "-t %DURATION%"
```

Here is `<link3>`:
```
Transcodage
Taux limite 	8192
Débit de transcodage    128 	
Transcodage   Toujours
```