### PR TITLE
Transifex config update

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,8 +1,8 @@
 [main]
 host = https://www.transifex.com
 
-[project_slug.resource_slug]
-file_filter = locale/<lang>_<lang>/LC_MESSAGES/messages.po
+[ampache.messagespot]
+file_filter = locale/<lang>/LC_MESSAGES/messages.po
 source_file = locale/base/messages.pot
-source_lang = en_US
+source_lang = en
 type = PO


### PR DESCRIPTION
To make it work right with, for example, the CLI client, it's easier to change it to the real Transifex behaviour so that the source language is ignored if you pull/push the files.

The file_filter seems to use the `<lang>` expression as a wild card.
On my tests with the CLI Client, it worked perfectly with one `<lang>` expression to get the right language code from Transifex, if it is set up properly on Transifex. (`locale/languagecode_LANDCODE/messages.*`)

Now the .tx config should fit the Ampache project. Maybe here was one of the problems, why it wasn't working with the Amazon instance?
Well @Afterster, I don't know how it was tested, so it's only a shot into the blue. :-)

By the way, I also didn't get it really working, for my taste, too less examples or bad documented, idk.. -.-
But if I have the time, I'll further investigate it. :-D


:-)