### PR TITLE
A small change to make translation easier

### DIFF
--- a/lib/preferences.php
+++ b/lib/preferences.php
@@ -403,7 +403,7 @@ function create_preference_input($name,$value)
             $url         = $plugin->_plugin->url;
             $api_key     = rawurlencode(AmpConfig::get('lastfm_api_key'));
             $callback    = rawurlencode(AmpConfig::get('web_path') . '/preferences.php?tab=plugins&action=grant&plugin=' . $plugin_name);
-            echo "<a href='$url/api/auth/?api_key=$api_key&cb=$callback'>" . UI::get_icon('plugin', T_("Click for grant Ampache to ") . $plugin_name) . '</a>';
+            echo "<a href='$url/api/auth/?api_key=$api_key&cb=$callback'>" . UI::get_icon('plugin', sprintf(T_("Click to grant %s access to Ampache"), $plugin_name)) . '</a>';
         break;
         default:
             if (preg_match('/_pass$/', $name)) {
@@ -415,4 +415,3 @@ function create_preference_input($name,$value)
 
     }
 } // create_preference_input
-


### PR DESCRIPTION
It's always better to keep those variable user-, plugin-, etc-names as dynamic as possible. Otherwise it's sometimes extremely problematic to find the right sentence-formatting. In German I would translate it that way:

"Klicke um `$plugin_name` den Zugriff zu erlauben"

And does this English sentence in the source fit better? As I see from the context, the user is asked to give `$plugin_name`the right to access Ampache, is this right?

:-)