### PR TITLE
FIX for #1195 & New position for update notification

### DIFF
--- a/lib/class/autoupdate.class.php
+++ b/lib/class/autoupdate.class.php
@@ -226,7 +226,7 @@ class AutoUpdate
      */
     public static function show_new_version()
     {
-        echo '<div>';
+        echo '<div id="autoupdate">';
         echo '<font color="#ff0000">' . T_('Update available') . '</font>';
         echo ' (' . self::get_latest_version() . ').<br />';
 

--- a/templates/header.inc.php
+++ b/templates/header.inc.php
@@ -408,16 +408,7 @@ $_SESSION['login'] = false;
                         </span>
                     <?php 
 } ?>
-                    <span id="updateInfo">
-                    <?php
-                    if (AmpConfig::get('autoupdate') && Access::check('interface','100')) {
-                        if (AutoUpdate::is_update_available()) {
-                            AutoUpdate::show_new_version();
-                        }
-                    }
-                    $count_temp_playlist = count($GLOBALS['user']->playlist->get_items());
-                    ?>
-                    </span>
+
                     <?php UI::show_box_bottom(); ?>
                 </div> <!-- End headerbox -->
             </div><!-- End header -->
@@ -527,20 +518,35 @@ $_SESSION['login'] = false;
             <div id="ajax-loading">Loading . . .</div>
             <div id="util_div" style="display:none;"></div>
             <iframe name="util_iframe" id="util_iframe" style="display:none;" src="<?php echo $web_path; ?>/util.php"></iframe>
+            
             <div id="content" class="content-<?php echo AmpConfig::get('ui_fixed') ? (AmpConfig::get('topmenu') ? 'fixed-topmenu' : 'fixed') : 'float'; ?> <?php echo (($count_temp_playlist || AmpConfig::get('play_type') == 'localplay') ? '' : 'content-right-wild'); echo $isCollapsed ? ' content-left-wild' : ''; ?>">
 
-                <?php if (AmpConfig::get('int_config_version') != AmpConfig::get('config_version') and $GLOBALS['user']->has_access(100)) {
-    ?>
-                <div class="fatalerror">
-                    <?php echo T_('Error Config File Out of Date');
-    ?>
-                    <a rel="nohtml" href="<?php echo $web_path;
-    ?>/admin/system.php?action=generate_config"><?php echo T_('Generate New Config');
-    ?></a> |
-                    <a rel="nohtml" href="<?php echo $web_path;
-    ?>/admin/system.php?action=write_config"><?php echo T_('Write New Config');
-    ?></a>
-                </div>
-                <?php 
-} ?>
+                <?php
+                    if (Access::check('interface','100')) {
+                        echo '<div id=update_notify>';
+                        if (AmpConfig::get('autoupdate') && AutoUpdate::is_update_available()) {
+                            AutoUpdate::show_new_version();
+                            echo '<br />';
+                        }
+                        $count_temp_playlist = count($GLOBALS['user']->playlist->get_items());
+                        
+                        if (AmpConfig::get('int_config_version') != AmpConfig::get('config_version')) {
+                            ?>
+                            <div class="fatalerror">
+                                <?php echo T_('Error: Your config file is out of date!');
+                            ?>
+                                <br />
+                                <a rel="nohtml" href="<?php echo $web_path;
+                            ?>/admin/system.php?action=generate_config"><?php echo T_('Generate and download new config file');
+                            ?></a> |
+                                <a rel="nohtml" href="<?php echo $web_path;
+                            ?>/admin/system.php?action=write_config"><?php echo T_('Write new config file to disk');
+                            ?></a>
+                            </div>
+                <?php
+
+                        }
+                        echo '</div>';
+                    }
+                ?>
                 <div id="guts">

--- a/templates/header.inc.php
+++ b/templates/header.inc.php
@@ -434,7 +434,7 @@ $_SESSION['login'] = false;
                 </div>
                 <div id="topmenu_item">
                     <a href="<?php echo $web_path ?>/browse.php?action=artist">
-                        <img src="<?php echo $web_path ?>/images/topmenu-music.png" />
+                        <img src="<?php echo $web_path ?>/images/topmenu-artist.png" />
                         <span><?php echo T_('Artists') ?></span>
                     </a>
                 </div>

--- a/themes/reborn/templates/default.css
+++ b/themes/reborn/templates/default.css
@@ -248,10 +248,6 @@ input[type=button]:focus:active, input[type=submit]:focus:active {
     top: 20px;
 }
 
-#updateInfo {
-    float: left;
-}
-
 #sb_Subsearch input[type=submit] {
     min-width: 100px;
     font-size: 15px;


### PR DESCRIPTION
FIX for #1195: file path correction.

New position for update notification:
Since ever, I hated it that the Update notification is within the headerbox. Now it's on the top of the content div like the "updated config" notification.

I also kicked out one permission check so the "autoupdate" notification and/or the "new config" notification is only shown if the permission is 100... Like before but in another way. ^^

Before, there was a `<span>...</span>`, no matter what user was logged in. Now there is a div with `id="update_notify"` what is also only shown, if the admin is logged in.

And it looks much cleaner on the UI. :-)

I also cleaned the depending CSS rule in `/reborn/templates/default.css`