### PR TITLE
fix: Test all images found to select the one with the good dimensions

### DIFF
--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -1218,21 +1218,22 @@ abstract class Catalog extends database_object
         }
 
         $art     = new Art($id, $type);
-        $results = $art->gather($options, 1);
+        $results = $art->gather($options);
 
-        if (count($results)) {
+        foreach ($results as $result) {
             // Pull the string representation from the source
-            $image = Art::get_from_source($results[0], $type);
+            $image = Art::get_from_source($result, $type);
             if (strlen($image) > '5') {
-                $art->insert($image, $results[0]['mime']);
+                $inserted = $art->insert($image, $result['mime']);
                 // If they've enabled resizing of images generate a thumbnail
                 if (AmpConfig::get('resize_images')) {
                     $size  = array('width' => 275, 'height' => 275);
-                    $thumb = $art->generate_thumb($image,$size ,$results[0]['mime']);
+                    $thumb = $art->generate_thumb($image,$size ,$result['mime']);
                     if (is_array($thumb)) {
                         $art->save_thumb($thumb['thumb'], $thumb['thumb_mime'], $size);
                     }
                 }
+                if ($inserted) break;
             } else {
                 debug_event('gather_art', 'Image less than 5 chars, not inserting', 3);
             }


### PR DESCRIPTION
Whereas the gathering art process returns several images url, then it only tries to insert the first image. 
If the image doesn't meet the dimensions configured, the next ones are not tested and no image is selected.

This case is very frequent with LastFm gathering and art minimal size configured, as LastFm returns several images from the the smallest (34x34) to the largest. Setting art minimal size over 34x34 leads to retrieving no images.

The provided fix tests all the images returned till it finds a valid one into the configured dimensions.

It can now select larger images from LastFm according to the following configuration:
```
; Art Gather Order
; Simply arrange the following in the order you would like
; ampache to search. If you want to disable one of the search
; methods simply leave it out. DB should be left as the first
; method unless you want it to overwrite what's already in the
; database
; POSSIBLE VALUES (builtins): db tags folder lastfm musicbrainz google
; POSSIBLE VALUES (plugins): Amazon,TheAudioDb,Tmdb,Omdb,Flickr
; DEFAULT: db,tags,folder,musicbrainz,lastfm,google
art_order = "db,tags,folder,lastfm,musicbrainz,google"

; Album Art Minimum Width
; Specify the minimum width for arts (in pixel).
; DEFAULT: none
album_art_min_width = 199

; Album Art Maximum Width
; Specify the maximum width for arts (in pixel).
; DEFAULT: none
album_art_max_width = 801

; Album Art Minimum Height
; Specify the minimum height for arts (in pixel).
; DEFAULT: none
album_art_min_height = 199

; Album Art Maximum Height
; Specify the maximum height for arts (in pixel).
; DEFAULT: none
album_art_max_height =801
```