### PR TITLE
Fix proposition for issue #123.

### DIFF
--- a/admin/catalog.php
+++ b/admin/catalog.php
@@ -122,12 +122,12 @@ switch ($_REQUEST['action']) {
             foreach ($songs as $song_id) {
                 Song::update_enabled(true, $song_id);
             }
-            $body = count($songs) . ngettext(' Song Enabled', ' Songs Enabled', count($songs));
+            $body = count($songs) . nT_(' Song Enabled', ' Songs Enabled', count($songs));
         } else {
             $body = T_('No Disabled Songs selected');
         }
         $url      = AmpConfig::get('web_path') . '/admin/catalog.php';
-        $title    = count($songs) . ngettext(' Disabled Song Processed', ' Disabled Songs Processed', count($songs));
+        $title    = count($songs) . nT_(' Disabled Song Processed', ' Disabled Songs Processed', count($songs));
         show_confirmation($title,$body,$url);
     break;
     case 'clean_all_catalogs':

--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -596,9 +596,9 @@ abstract class Catalog extends database_object
         $hours = $hours % 24;
 
         $time_text = "$days ";
-        $time_text .= ngettext('day', 'days', $days);
+        $time_text .= nT_('day', 'days', $days);
         $time_text .= ", $hours ";
-        $time_text .= ngettext('hour', 'hours', $hours);
+        $time_text .= nT_('hour', 'hours', $hours);
 
         $results['time_text'] = $time_text;
 
@@ -1803,7 +1803,7 @@ abstract class Catalog extends database_object
         if (!defined('SSE_OUTPUT')) {
             UI::show_box_top();
         }
-        UI::update_text('', sprintf(ngettext('Catalog Clean Done. %d file removed.', 'Catalog Clean Done. %d files removed.', $dead_total), $dead_total));
+        UI::update_text('', sprintf(nT_('Catalog Clean Done. %d file removed.', 'Catalog Clean Done. %d files removed.', $dead_total), $dead_total));
         if (!defined('SSE_OUTPUT')) {
             UI::show_box_bottom();
         }

--- a/lib/i18n.php
+++ b/lib/i18n.php
@@ -32,7 +32,7 @@ function load_gettext()
 {
     $lang    = AmpConfig::get('lang');
     $popath  = AmpConfig::get('prefix') . '/locale/' . $lang . '/LC_MESSAGES/messages.po';
-    
+
     $t = new Translator();
     if (file_exists($popath)) {
         $translations = Gettext\Translations::fromPoFile($popath);
@@ -46,8 +46,17 @@ function T_($msgid)
     if (function_exists('__')) {
         return __($msgid);
     }
-    
+
     return $msgid;
+}
+
+function nT_($original, $plural, $value)
+{
+    if (function_exists('n__')) {
+        return n__($original, $plural, $value);
+    }
+
+    return $plural;
 }
 
 /**

--- a/locale/base/gather-messages.sh
+++ b/locale/base/gather-messages.sh
@@ -65,7 +65,7 @@ generate_pot() {
                 --add-comment=HINT: \
                 --msgid-bugs-address="https://www.transifex.com/projects/p/ampache/" \
                 -L php \
-                --keyword=gettext_noop --keyword=T_ --keyword=T_gettext --keyword=T_ngettext --keyword=ngettext \
+                --keyword=gettext_noop --keyword=T_ --keyword=nT_ \
                 -o $potfile \
                 $(find ../../ -type f -name \*.php -o -name \*.inc | sort)
     if [[ $? -eq 0 ]]; then
@@ -86,7 +86,7 @@ generate_pot_utds() {
                 --add-comment=HINT: \
                 --msgid-bugs-address="https://www.transifex.com/projects/p/ampache/" \
                 -L php \
-                --keyword=gettext_noop --keyword=T_ --keyword=T_gettext --keyword=T_ngettext --keyword=ngettext \
+                --keyword=gettext_noop --keyword=T_ --keyword=nT_ \
                 -o $potfile \
                 $(find ../../ -type f -name \*.php -o -name \*.inc | sort)
     if [[ $? -eq 0 ]]; then

--- a/playlist.php
+++ b/playlist.php
@@ -80,7 +80,7 @@ switch ($_REQUEST['action']) {
             $title = T_('Playlist Imported');
             $body  = basename($_FILES['filename']['name']);
             $body .= '<br />' .
-                sprintf(ngettext('Successfully imported playlist with %d song.', 'Successfully imported playlist with %d songs.', $result['count']), $result['count']);
+                sprintf(nT_('Successfully imported playlist with %d song.', 'Successfully imported playlist with %d songs.', $result['count']), $result['count']);
         } else {
             $url   = 'show_import_playlist';
             $title = T_('Playlist Not Imported');

--- a/templates/show_random.inc.php
+++ b/templates/show_random.inc.php
@@ -83,9 +83,9 @@
                 ($_POST['length'] == $i
                     ? 'selected="selected"' : '') . '>';
             if ($i < 60) {
-                printf(ngettext('%d minute', '%d minutes', $i), $i);
+                printf(nT_('%d minute', '%d minutes', $i), $i);
             } else {
-                printf(ngettext('%d hour', '%d hours', $i / 60), $i / 60);
+                printf(nT_('%d hour', '%d hours', $i / 60), $i / 60);
             }
             echo "</option>\n";
         }

--- a/templates/show_recently_played.inc.php
+++ b/templates/show_recently_played.inc.php
@@ -70,28 +70,28 @@ foreach ($data as $row) {
         $interval = intval(time() - $row['date']);
 
         if ($interval < 60) {
-            $time_string = sprintf(ngettext('%d second ago', '%d seconds ago', $interval), $interval);
+            $time_string = sprintf(nT_('%d second ago', '%d seconds ago', $interval), $interval);
         } elseif ($interval < 3600) {
             $interval    = floor($interval / 60);
-            $time_string = sprintf(ngettext('%d minute ago', '%d minutes ago', $interval), $interval);
+            $time_string = sprintf(nT_('%d minute ago', '%d minutes ago', $interval), $interval);
         } elseif ($interval < 86400) {
             $interval    = floor($interval / 3600);
-            $time_string = sprintf(ngettext('%d hour ago', '%d hours ago', $interval), $interval);
+            $time_string = sprintf(nT_('%d hour ago', '%d hours ago', $interval), $interval);
         } elseif ($interval < 604800) {
             $interval    = floor($interval / 86400);
-            $time_string = sprintf(ngettext('%d day ago', '%d days ago', $interval), $interval);
+            $time_string = sprintf(nT_('%d day ago', '%d days ago', $interval), $interval);
         } elseif ($interval < 2592000) {
             $interval    = floor($interval / 604800);
-            $time_string = sprintf(ngettext('%d week ago', '%d weeks ago', $interval), $interval);
+            $time_string = sprintf(nT_('%d week ago', '%d weeks ago', $interval), $interval);
         } elseif ($interval < 31556926) {
             $interval    = floor($interval / 2592000);
-            $time_string = sprintf(ngettext('%d month ago', '%d months ago', $interval), $interval);
+            $time_string = sprintf(nT_('%d month ago', '%d months ago', $interval), $interval);
         } elseif ($interval < 631138519) {
             $interval    = floor($interval / 31556926);
-            $time_string = sprintf(ngettext('%d year ago', '%d years ago', $interval), $interval);
+            $time_string = sprintf(nT_('%d year ago', '%d years ago', $interval), $interval);
         } else {
             $interval    = floor($interval / 315569260);
-            $time_string = sprintf(ngettext('%d decade ago', '%d decades ago', $interval), $interval);
+            $time_string = sprintf(nT_('%d decade ago', '%d decades ago', $interval), $interval);
         }
     }
     $song->format();


### PR DESCRIPTION
This commit introduces a `nT_` function to handle pluralization in
localizations, and avoid the need to call ngettext, which was resulting
in errors if PHP Gettext module was not available (and this was not
enforced by Ampache).

Any occurrence of `ngettext` has been replaced by this `nT_` call.

Also removed the useless keywords in the `gather-messages.sh` script,
and added the newly introduced `nT_` keyword.

Closes issue #123.