### PR TITLE
Proposition of fix for #1213

### DIFF
--- a/lib/class/subsonic_xml_data.class.php
+++ b/lib/class/subsonic_xml_data.class.php
@@ -465,8 +465,8 @@ class Subsonic_XML_Data
         }
         $xsong->addAttribute('suffix', $song->type);
         $xsong->addAttribute('contentType', $song->mime);
-        // Create a clean fake path instead of song real file path to have better offline mode storage on Subsonic clients
-        $path = $artist->name . '/' . $album->name . '/' . basename($song->file);
+        // Return a file path relative to the catalog root path
+        $path = $song->get_rel_path();
         $xsong->addAttribute('path', $path);
 
         // Set transcoding information if required

--- a/modules/catalog/local/local.catalog.php
+++ b/modules/catalog/local/local.catalog.php
@@ -847,8 +847,7 @@ class Catalog_local extends Catalog
 
     public function get_rel_path($file_path)
     {
-        $info         = $this->_get_info();
-        $catalog_path = rtrim($info->path, "/");
+        $catalog_path = rtrim($this->path, "/");
         return( str_replace( $catalog_path . "/", "", $file_path ) );
     }
 

--- a/modules/catalog/remote/remote.catalog.php
+++ b/modules/catalog/remote/remote.catalog.php
@@ -345,8 +345,7 @@ class Catalog_remote extends Catalog
 
     public function get_rel_path($file_path)
     {
-        $info         = $this->_get_info();
-        $catalog_path = rtrim($info->uri, "/");
+        $catalog_path = rtrim($this->uri, "/");
         return( str_replace( $catalog_path . "/", "", $file_path ) );
     }
 

--- a/modules/catalog/subsonic/subsonic.catalog.php
+++ b/modules/catalog/subsonic/subsonic.catalog.php
@@ -339,8 +339,7 @@ class Catalog_subsonic extends Catalog
 
     public function get_rel_path($file_path)
     {
-        $info         = $this->_get_info();
-        $catalog_path = rtrim($info->uri, "/");
+        $catalog_path = rtrim($this->uri, "/");
         return( str_replace( $catalog_path . "/", "", $file_path ) );
     }
 


### PR DESCRIPTION
Returns path relative to the catalog root path in Subsonic API.

<del>Note that for this I needed to implement the `Catalog::_get_info`
function, which was already called in the code, but was not declared
anywhere. This implementation may not be the best one…</del>

Closes issue #1213.