### PR TITLE
Fix proposition for #1242

### DIFF
--- a/lib/class/xml_data.class.php
+++ b/lib/class/xml_data.class.php
@@ -106,7 +106,7 @@ class XML_Data
     public static function error($code,$string)
     {
         $string = "\t<error code=\"$code\"><![CDATA[$string]]></error>";
-        self::output_xml($string);
+        return self::output_xml($string);
     } // error
 
     /**


### PR DESCRIPTION
The Ampache-XML API was not returning a valid XML document in case of failed passphrase validation.

Closes #1242.