### PR TITLE
Use UTF-8 without BOM for all the files in Ampache

### DIFF
--- a/lib/class/query.class.php
+++ b/lib/class/query.class.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /* vim:set softtabstop=4 shiftwidth=4 expandtab: */
 /**
  *

--- a/templates/show_song_row.inc.php
+++ b/templates/show_song_row.inc.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /* vim:set softtabstop=4 shiftwidth=4 expandtab: */
 /**
  *


### PR DESCRIPTION
Remove leading character for BOM for some files that were using it. With this PR, all the files in Ampache should be encoded as UTF-8 without BOM.

This is to solve an issue discussed on IRC, which arised in https://github.com/ampache/ampache/issues/1249 resulting in invalid JSON output.