### PR TITLE
Fix issue #1247

### DIFF
--- a/lib/class/api.class.php
+++ b/lib/class/api.class.php
@@ -135,7 +135,13 @@ class Api
         }
         $username = trim($input['user']);
         $ip       = $_SERVER['REMOTE_ADDR'];
-        $version  = $input['version'];
+        if (isset($input['version'])) {
+            // If version is provided, use it
+            $version = $input['version'];
+        } else {
+            // Else, just use the latest version available
+            $version = self::$version;
+        }
 
         // Log the attempt
         debug_event('API', "Handshake Attempt, IP:$ip User:$username Version:$version", 5);


### PR DESCRIPTION
XML API version is now assumed to be the latest available if not
specified as a parameter. Also fix the issue that an empty XML document
was issued when the version was not specified.

Closes issue #1247.