### PR TITLE
Fix issue #1259.

### DIFF
--- a/lib/ui.lib.php
+++ b/lib/ui.lib.php
@@ -713,7 +713,7 @@ function toggle_visible($element)
 function display_notification($message, $timeout = 5000)
 {
     echo "<script type='text/javascript'>";
-    echo "displayNotification('" . json_encode($message) . "', " . $timeout . ");";
+    echo "displayNotification('" . addslashes(json_encode($message)) . "', " . $timeout . ");";
     echo "</script>\n";
 }
 


### PR DESCRIPTION
Notification text was not correctly escaped.

Quotes were not escaped in notification text, which resulted in
JavaScript errors with some translations, such as French translation,
which make heavy use of quotes.

Closes #1259.