### PR TITLE
Fix for #1250

### DIFF
--- a/templates/show_html5_player.inc.php
+++ b/templates/show_html5_player.inc.php
@@ -295,7 +295,7 @@ if (AmpConfig::get('song_page_title') && !$is_share) {
 if (AmpConfig::get('webplayer_aurora')) {
     $atypes = array();
     foreach ($supplied as $stype) {
-        if ($stype == 'ogg') {
+        if ($stype == 'ogg' || $stype == 'oga') {
             // Ogg could requires vorbis/opus codecs
             if (!in_array('ogg', $atypes)) {
                 $atypes[] = 'ogg';


### PR DESCRIPTION
Aurora.JS was included, but we were not including the codecs JS files.
Including them fix the impossibility to play OGG vorbis audio files when
HTML5 player is disabled and only Flash player and Aurora.JS are
enabled.

**Important note**: Progression bar was not working even if the file was playing nicely. There might still be an underlying issue, that I did not find yet. I think we should open a new issue to track it and remember to fix it, if you think this change can be merged.

Closes #1250.