### PR TITLE
Fix for issue #1248

### DIFF
--- a/install.php
+++ b/install.php
@@ -164,6 +164,7 @@ switch ($_REQUEST['action']) {
                 $created_config = $created_config && install_create_config($download);
             }
         }
+        // No break on purpose
     case 'show_create_account':
         $results = parse_ini_file($configfile);
         if (!isset($created_config)) {

--- a/lib/class/core.class.php
+++ b/lib/class/core.class.php
@@ -201,6 +201,32 @@ class Core
     } // form_verify
 
     /**
+     * gen_secure_token
+     *
+     * This generates a cryptographically secure token.
+     * Returns a token of the required bytes length, as a string. Returns false
+     * if it could not generate a cryptographically secure token.
+     */
+    public static function gen_secure_token($length)
+    {
+        $buffer = '';
+        if (function_exists('random_bytes')) {
+            $buffer = random_bytes($length);
+        } elseif (function_exists('mcrypt_create_iv')) {
+            $buffer = mcrypt_create_iv($length, MCRYPT_DEV_RANDOM);
+        } elseif (phpversion() > "5.6.12" && function_exists('openssl_random_pseudo_bytes')) {
+            // PHP version check for https://bugs.php.net/bug.php?id=70014
+            $buffer = openssl_random_pseudo_bytes($length);
+        } elseif (file_exists('/dev/random') && is_readable('/dev/random')) {
+            $buffer = file_get_contents('/dev/random', false, null, -1, $length);
+        } else {
+            return false;
+        }
+
+        return bin2hex($buffer);
+    }
+
+    /**
      * image_dimensions
     * This returns the dimensions of the passed song of the passed type
     * returns an empty array if PHP-GD is not currently installed, returns

--- a/lib/general.lib.php
+++ b/lib/general.lib.php
@@ -286,6 +286,12 @@ function generate_config($current)
             // Put in the current value
             if ($key == 'config_version') {
                 $line = $key . ' = ' . escape_ini($value);
+            } elseif ($key == 'secret_key' && !isset($current[$key])) {
+                $secret_key = Core::gen_secure_token(31);
+                if ($secret_key !== false) {
+                    $line = $key . ' = "' . escape_ini($secret_key) . '"';
+                }
+                // Else, unable to generate a cryptographically secure token, use the default one
             } elseif (isset($current[$key])) {
                 $line = $key . ' = "' . escape_ini($current[$key]) . '"';
                 unset($current[$key]);

--- a/templates/show_install_config.inc.php
+++ b/templates/show_install_config.inc.php
@@ -61,15 +61,16 @@ require $prefix . '/templates/install_header.inc.php';
             <?php AmpError::display('general'); ?>
 
             <h2><?php echo T_('Generate Config File'); ?></h2>
-            <h3><?php echo T_('Database connection'); ?></h3>
-            <?php AmpError::display('config'); ?>
-<form method="post" action="<?php echo $web_path . "/install.php?action=create_config"; ?>" enctype="multipart/form-data" autocomplete="off">
+            <h3><?php echo T_('Various'); ?></h3>
 <div class="form-group">
     <label for="web_path" class="col-sm-4 control-label"><?php echo T_('Web Path'); ?></label>
     <div class="col-sm-8">
         <input type="text" class="form-control" id="web_path" name="web_path" value="<?php echo scrub_out($web_path_guess); ?>">
     </div>
 </div>
+            <h3><?php echo T_('Database connection'); ?></h3>
+            <?php AmpError::display('config'); ?>
+<form method="post" action="<?php echo $web_path . "/install.php?action=create_config"; ?>" enctype="multipart/form-data" autocomplete="off">
 <div class="form-group">
     <label for="local_db" class="col-sm-4 control-label"><?php echo T_('Database Name'); ?></label>
     <div class="col-sm-8">


### PR DESCRIPTION
Generate `sceret_key` on Ampache installation

Generate a `secret_key` on Ampache installation and put it in the
generated config. This removes the need to do it manually, and the
secret key is ensured to be crypto safe.

Also move the `web_path` configuration setting under a "Various"
fieldset, as it had nothing to do with database settings.

Also added a comment about a missing `break` statement, which was on
purpose, but one could think it was a mistake at first sight.

Closes #1248.