### PR TITLE
Apply trim on dropbox parameters

### DIFF
--- a/modules/catalog/dropbox/dropbox.catalog.php
+++ b/modules/catalog/dropbox/dropbox.catalog.php
@@ -167,8 +167,8 @@ class Catalog_dropbox extends Catalog
      */
     public static function create_type($catalog_id, $data)
     {
-        $apikey   = $data['apikey'];
-        $secret   = $data['secret'];
+        $apikey   = trim($data['apikey']);
+        $secret   = trim($data['secret']);
         $path     = $data['path'];
         $getchunk = $data['getchunk'];
 


### PR DESCRIPTION
Copying dropbox secret key from the Dropbox UI easily adds extra
whitespaces at the beginning of the string, which leads to invalid
secret key and stack trace. As they are invalid, apply a trim to them
before storing them in database.