### PR TITLE
Fix issue #1211

### DIFF
--- a/lib/preferences.php
+++ b/lib/preferences.php
@@ -244,7 +244,7 @@ function create_preference_input($name,$value)
             if (AmpConfig::get('allow_localplay_playback')) {
                 echo "\t<option value=\"localplay\" $is_localplay>" . T_('Localplay') . "</option>\n";
             }
-            echo "\t<option value=\"web_player\" $is_web_player>" . _('Web Player') . "</option>\n";
+            echo "\t<option value=\"web_player\" $is_web_player>" . T_('Web Player') . "</option>\n";
             echo "</select>\n";
         break;
         case 'playlist_type':

--- a/templates/show_playlist.inc.php
+++ b/templates/show_playlist.inc.php
@@ -76,7 +76,7 @@ UI::show_box_top('<div id="playlist_row_' . $playlist->id . '">' . $title . '</d
         <li>
             <a href="<?php echo AmpConfig::get('web_path');
     ?>/playlist.php?action=sort_tracks&playlist_id=<?php echo $playlist->id;
-    ?>"><?php echo UI::get_icon('sort',_('Sort Tracks by Artist, Album, Song'));
+    ?>"><?php echo UI::get_icon('sort', T_('Sort Tracks by Artist, Album, Song'));
     ?>
             &nbsp;&nbsp;<?php echo T_('Sort Tracks by Artist, Album, Song');
     ?></a>
@@ -84,7 +84,7 @@ UI::show_box_top('<div id="playlist_row_' . $playlist->id . '">' . $title . '</d
         <li>
             <a href="<?php echo AmpConfig::get('web_path');
     ?>/playlist.php?action=remove_duplicates&playlist_id=<?php echo $playlist->id;
-    ?>"><?php echo UI::get_icon('wand',_('Remove duplicates'));
+    ?>"><?php echo UI::get_icon('wand', T_('Remove duplicates'));
     ?>
             &nbsp;&nbsp;<?php echo T_('Remove duplicates');
     ?></a>


### PR DESCRIPTION
Wrong gettext function calls

There were some issues when gettext is not installed on the system, due
to direct function calls to gettext and not to the encapsulated ones.

Closes #1211.