### PR TITLE
activate jplayer "preload" option

### DIFF
--- a/templates/show_html5_player.inc.php
+++ b/templates/show_html5_player.inc.php
@@ -40,7 +40,7 @@ var currentAudioElement = undefined;
                 shuffleTime: 'slow'
             },
             swfPath: "<?php echo AmpConfig::get('web_path'); ?>/lib/vendor/happyworm/jplayer/dist/jplayer",
-            preload: 'none',
+            preload: 'auto',
             audioFullScreen: true,
             smoothPlayBar: true,
             keyEnabled: true,


### PR DESCRIPTION
I hope there wasn't good reason to not enable it: woks well with Chrome