### PR TITLE
Use correct fields type in modules and localplay

### DIFF
--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -283,11 +283,8 @@ abstract class Catalog extends database_object
                         case 'checkbox':
                             echo "<input type='checkbox' name='" . $key . "' value='1' " . (($field['value']) ? 'checked' : '') . "/>";
                             break;
-                        case 'password':
-                            echo "<input type='password' name='" . $key . "' value='" . $field['value'] . "' />";
-                            break;
                         default:
-                            echo "<input type='text' name='" . $key . "' value='" . $field['value'] . "' />";
+                            echo "<input type='".$field['type']."' name='" . $key . "' value='" . $field['value'] . "' />";
                             break;
                     }
                     echo "</td></tr>";
@@ -332,13 +329,13 @@ abstract class Catalog extends database_object
                 debug_event('catalog', $file . ' is not a directory.', 3);
                 continue;
             }
-            
+
             // Make sure the plugin base file exists inside the plugin directory
             if (! file_exists($basedir . '/' . $file . '/' . $file . '.catalog.php')) {
                 debug_event('catalog', 'Missing class for ' . $file, 3);
                 continue;
             }
-            
+
             $results[] = $file;
         } // end while
 
@@ -723,12 +720,12 @@ abstract class Catalog extends database_object
         $db_results = Dba::read($sql, $params);
         $data       = Dba::fetch_row($db_results);
         $playlists  = $data[0];
-        
+
         $sql          = 'SELECT COUNT(`id`) FROM `live_stream`';
         $db_results   = Dba::read($sql, $params);
         $data         = Dba::fetch_row($db_results);
         $live_streams = $data[0];
-        
+
         $sql          = 'SELECT COUNT(`id`) FROM `podcast`';
         $db_results   = Dba::read($sql, $params);
         $data         = Dba::fetch_row($db_results);
@@ -1085,7 +1082,7 @@ abstract class Catalog extends database_object
 
         return $results;
     }
-    
+
     /**
      * get_podcast_ids
      *
@@ -1128,7 +1125,7 @@ abstract class Catalog extends database_object
 
         return $results;
     }
-    
+
     /**
      * get_newest_podcasts_ids
      *
@@ -1622,7 +1619,7 @@ abstract class Catalog extends database_object
 
         /* Since we're doing a full compare make sure we fill the extended information */
         $song->fill_ext_info();
-        
+
         if (Song::isCustomMetadataEnabled()) {
             $ctags = self::get_clean_metadata($song, $results);
             if (method_exists($song, 'updateOrInsertMetadata') && $song::isCustomMetadataEnabled()) {
@@ -1707,11 +1704,11 @@ abstract class Catalog extends database_object
             }
         }
         $new_video->tags        = $results['genre'];
-        
+
         $info = Video::compare_video_information($video, $new_video);
         if ($info['change']) {
             debug_event('update', $video->file . " : differences found, updating database", 5);
-            
+
             $video->update_video($video->id, $new_video);
 
             if ($video->tags != $new_video->tags) {
@@ -1720,10 +1717,10 @@ abstract class Catalog extends database_object
         } else {
             debug_event('update', $video->file . " : no differences found", 5);
         }
-        
+
         return $info;
     }
-    
+
     /**
      * Get rid of all tags found in the libraryItem
      * @param library_item $libraryItem
@@ -1860,7 +1857,7 @@ abstract class Catalog extends database_object
         Tmp_Playlist::gc();
         Shoutbox::gc();
         Tag::gc();
-        
+
         // TODO: use InnoDB with foreign keys and on delete cascade to get rid of garbage collection
         \Lib\Metadata\Repository\Metadata::gc();
         \Lib\Metadata\Repository\MetadataField::gc();
@@ -1893,12 +1890,12 @@ abstract class Catalog extends database_object
         if (empty($year)) {
             return 0;
         }
-        
+
         $year = intval($year);
         if ($year < 0 || $year > 9999) {
             return 0;
         }
-        
+
         return $year;
     }
 
@@ -2298,13 +2295,13 @@ abstract class Catalog extends database_object
 
         return (Access::check('interface','75') || ($libitem->get_user_owner() == $user && AmpConfig::get('upload_allow_remove')));
     }
-    
+
     public static function process_action($action, $catalogs, $options = null)
     {
         if (!$options || !is_array($options)) {
             $options = array();
         }
-        
+
         switch ($action) {
             case 'add_to_all_catalogs':
                 $catalogs = Catalog::get_catalogs();
@@ -2316,7 +2313,7 @@ abstract class Catalog extends database_object
                             $catalog->add_to_catalog($options);
                         }
                     }
-                    
+
                     if (!defined('SSE_OUTPUT')) {
                         AmpError::display('catalog_add');
                     }
@@ -2405,7 +2402,7 @@ abstract class Catalog extends database_object
                 }
                 break;
         }
-        
+
         // Remove any orphaned artists/albums/etc.
         self::gc();
     }

--- a/modules/catalog/beets/beets.catalog.php
+++ b/modules/catalog/beets/beets.catalog.php
@@ -82,7 +82,7 @@ class Catalog_beets extends Beets\Catalog
 
     public function catalog_fields()
     {
-        $fields['beetsdb'] = array('description' => T_('Beets Database File'), 'type' => 'textbox');
+        $fields['beetsdb'] = array('description' => T_('Beets Database File'), 'type' => 'text');
 
         return $fields;
     }

--- a/modules/catalog/beetsremote/beetsremote.catalog.php
+++ b/modules/catalog/beetsremote/beetsremote.catalog.php
@@ -83,7 +83,7 @@ class Catalog_beetsremote extends Beets\Catalog
 
     public function catalog_fields()
     {
-        $fields['uri'] = array('description' => T_('Beets Server URI'), 'type' => 'textbox');
+        $fields['uri'] = array('description' => T_('Beets Server URI'), 'type' => 'url');
 
         return $fields;
     }

--- a/modules/catalog/dropbox/dropbox.catalog.php
+++ b/modules/catalog/dropbox/dropbox.catalog.php
@@ -111,9 +111,9 @@ class Catalog_dropbox extends Catalog
 
     public function catalog_fields()
     {
-        $fields['apikey']        = array('description' => T_('API Key'), 'type'=>'textbox');
+        $fields['apikey']        = array('description' => T_('API Key'), 'type'=>'text');
         $fields['secret']        = array('description' => T_('Secret'), 'type'=>'password');
-        $fields['path']          = array('description' => T_('Path'), 'type'=>'textbox', 'value' => '/');
+        $fields['path']          = array('description' => T_('Path'), 'type'=>'url', 'value' => '/');
         $fields['getchunk']      = array('description' => T_('Get chunked files on analyze'), 'type'=>'checkbox', 'value' => true);
 
         return $fields;

--- a/modules/catalog/local/local.catalog.php
+++ b/modules/catalog/local/local.catalog.php
@@ -101,7 +101,7 @@ class Catalog_local extends Catalog
 
     public function catalog_fields()
     {
-        $fields['path']      = array('description' => T_('Path'),'type'=>'textbox');
+        $fields['path']      = array('description' => T_('Path'),'type'=>'url');
 
         return $fields;
     }
@@ -703,7 +703,7 @@ class Catalog_local extends Catalog
                 $results['album'] = $album->name;
             }
         }
-        
+
         if (count($this->get_gather_types('music')) > 0) {
             if (AmpConfig::get('catalog_check_duplicate')) {
                 if (Song::find($results)) {

--- a/modules/catalog/remote/remote.catalog.php
+++ b/modules/catalog/remote/remote.catalog.php
@@ -99,8 +99,8 @@ class Catalog_remote extends Catalog
 
     public function catalog_fields()
     {
-        $fields['uri']           = array('description' => T_('Uri'),'type'=>'textbox');
-        $fields['username']      = array('description' => T_('Username'),'type'=>'textbox');
+        $fields['uri']           = array('description' => T_('Uri'),'type'=>'url');
+        $fields['username']      = array('description' => T_('Username'),'type'=>'text');
         $fields['password']      = array('description' => T_('Password'),'type'=>'password');
 
         return $fields;

--- a/modules/catalog/soundcloud/soundcloud.catalog.php
+++ b/modules/catalog/soundcloud/soundcloud.catalog.php
@@ -103,8 +103,8 @@ class Catalog_soundcloud extends Catalog
 
     public function catalog_fields()
     {
-        $fields['userid']      = array('description' => T_('User ID'),'type'=>'textbox');
-        $fields['secret']      = array('description' => T_('Secret'),'type'=>'textbox');
+        $fields['userid']      = array('description' => T_('User ID'),'type'=>'text');
+        $fields['secret']      = array('description' => T_('Secret'),'type'=>'password');
 
         return $fields;
     }

--- a/modules/catalog/subsonic/subsonic.catalog.php
+++ b/modules/catalog/subsonic/subsonic.catalog.php
@@ -99,8 +99,8 @@ class Catalog_subsonic extends Catalog
 
     public function catalog_fields()
     {
-        $fields['uri']           = array('description' => T_('URI'),'type'=>'textbox');
-        $fields['username']      = array('description' => T_('Username'),'type'=>'textbox');
+        $fields['uri']           = array('description' => T_('URI'),'type'=>'url');
+        $fields['username']      = array('description' => T_('Username'),'type'=>'text');
         $fields['password']      = array('description' => T_('Password'),'type'=>'password');
 
         return $fields;
@@ -202,7 +202,7 @@ class Catalog_subsonic extends Catalog
     public function update_remote_catalog()
     {
         debug_event('subsonic_catalog', 'Updating remote catalog...', 5);
-        
+
         $subsonic = $this->createClient();
 
         $songsadded = 0;
@@ -270,7 +270,7 @@ class Catalog_subsonic extends Catalog
         }
 
         debug_event('subsonic_catalog', 'Catalog updated.', 5);
-        
+
         return true;
     }
 

--- a/modules/localplay/httpq/httpq.controller.php
+++ b/modules/localplay/httpq/httpq.controller.php
@@ -193,10 +193,10 @@ class AmpacheHttpq extends localplay_controller
          */
         public function instance_fields()
         {
-            $fields['name']         = array('description' => T_('Instance Name'),'type'=>'textbox');
-            $fields['host']         = array('description' => T_('Hostname'),'type'=>'textbox');
-            $fields['port']         = array('description' => T_('Port'),'type'=>'textbox');
-            $fields['password']     = array('description' => T_('Password'),'type'=>'textbox');
+            $fields['name']         = array('description' => T_('Instance Name'),'type'=>'text');
+            $fields['host']         = array('description' => T_('Hostname'),'type'=>'text');
+            $fields['port']         = array('description' => T_('Port'),'type'=>'number');
+            $fields['password']     = array('description' => T_('Password'),'type'=>'password');
 
             return $fields;
         } // instance_fields

--- a/modules/localplay/mpd/mpd.controller.php
+++ b/modules/localplay/mpd/mpd.controller.php
@@ -222,10 +222,10 @@ class AmpacheMpd extends localplay_controller
      */
     public function instance_fields()
     {
-        $fields['name']        = array('description' => T_('Instance Name'),'type'=>'textbox');
-        $fields['host']        = array('description' => T_('Hostname'),'type'=>'textbox');
-        $fields['port']        = array('description' => T_('Port'),'type'=>'textbox');
-        $fields['password']    = array('description' => T_('Password'),'type'=>'textbox');
+        $fields['name']        = array('description' => T_('Instance Name'),'type'=>'text');
+        $fields['host']        = array('description' => T_('Hostname'),'type'=>'text');
+        $fields['port']        = array('description' => T_('Port'),'type'=>'number');
+        $fields['password']    = array('description' => T_('Password'),'type'=>'password');
 
         return $fields;
     } // instance_fields

--- a/modules/localplay/upnp/upnp.controller.php
+++ b/modules/localplay/upnp/upnp.controller.php
@@ -176,8 +176,8 @@ class AmpacheUPnP extends localplay_controller
      */
     public function instance_fields()
     {
-        $fields['name'] = array('description' => T_('Instance Name'), 'type'=>'textbox');
-        $fields['url']  = array('description' => T_('URL'), 'type'=>'textbox');
+        $fields['name'] = array('description' => T_('Instance Name'), 'type'=>'text');
+        $fields['url']  = array('description' => T_('URL'), 'type'=>'url');
 
         return $fields;
     }

--- a/modules/localplay/vlc/vlc.controller.php
+++ b/modules/localplay/vlc/vlc.controller.php
@@ -177,10 +177,10 @@ class AmpacheVlc extends localplay_controller
          */
         public function instance_fields()
         {
-            $fields['name']         = array('description' => T_('Instance Name'),'type'=>'textbox');
-            $fields['host']         = array('description' => T_('Hostname'),'type'=>'textbox');
-            $fields['port']         = array('description' => T_('Port'),'type'=>'textbox');
-            $fields['password']     = array('description' => T_('Password'),'type'=>'textbox');
+            $fields['name']         = array('description' => T_('Instance Name'),'type'=>'text');
+            $fields['host']         = array('description' => T_('Hostname'),'type'=>'text');
+            $fields['port']         = array('description' => T_('Port'),'type'=>'number');
+            $fields['password']     = array('description' => T_('Password'),'type'=>'password');
 
             return $fields;
         } // instance_fields

--- a/modules/localplay/xbmc/xbmc.controller.php
+++ b/modules/localplay/xbmc/xbmc.controller.php
@@ -184,11 +184,11 @@ class AmpacheXbmc extends localplay_controller
      */
     public function instance_fields()
     {
-        $fields['name']         = array('description' => T_('Instance Name'),'type'=>'textbox');
-        $fields['host']         = array('description' => T_('Hostname'),'type'=>'textbox');
-        $fields['port']         = array('description' => T_('Port'),'type'=>'textbox');
-        $fields['user']         = array('description' => T_('Username'),'type'=>'textbox');
-        $fields['pass']         = array('description' => T_('Password'),'type'=>'textbox');
+        $fields['name']         = array('description' => T_('Instance Name'),'type'=>'text');
+        $fields['host']         = array('description' => T_('Hostname'),'type'=>'text');
+        $fields['port']         = array('description' => T_('Port'),'type'=>'number');
+        $fields['user']         = array('description' => T_('Username'),'type'=>'text');
+        $fields['pass']         = array('description' => T_('Password'),'type'=>'password');
 
         return $fields;
     } // instance_fields

--- a/templates/show_localplay_add_instance.inc.php
+++ b/templates/show_localplay_add_instance.inc.php
@@ -28,10 +28,10 @@
 <tr>
     <td><?php echo $field['description'];
     ?></td>
-    <td><input type="text" name="<?php echo $key;
+    <td><input type="<?php echo $field["type"]; ?>" name="<?php echo $key;
     ?>" /></td>
 </tr>
-<?php 
+<?php
 } ?>
 </table>
     <div class="formValidation">

--- a/templates/show_localplay_edit_instance.inc.php
+++ b/templates/show_localplay_edit_instance.inc.php
@@ -28,11 +28,11 @@
 <tr>
     <td><?php echo $field['description'];
     ?></td>
-    <td><input type="text" name="<?php echo $key;
+    <td><input type="<?php echo $field['type'];?>" name="<?php echo $key;
     ?>" value="<?php echo scrub_out($instance[$key]);
     ?>" /></td>
 </tr>
-<?php 
+<?php
 } ?>
 </table>
     <div class="formValidation">

--- a/templates/show_localplay_instances.inc.php
+++ b/templates/show_localplay_instances.inc.php
@@ -27,7 +27,7 @@
     ?>
         <th><?php echo $field['description'];
     ?></th>
-    <?php 
+    <?php
 } ?>
     <th><?php echo T_('Action'); ?></th>
 </tr>
@@ -39,9 +39,16 @@
     ?>">
     <?php foreach ($fields as $key=>$field) {
     ?>
-    <td><?php echo $instance[$key];
-    ?></td>
-    <?php 
+    <td>
+        <?php
+            if ($field["type"] != "password") {
+                echo $instance[$key];
+            } else {
+                echo "*****";
+            }
+        ?>
+    </td>
+    <?php
 }
     ?>
     <td>
@@ -53,7 +60,7 @@
     ?>
     </td>
 </tr>
-<?php 
+<?php
 } ?>
 </table>
 <?php UI::show_box_bottom(); ?>


### PR DESCRIPTION
I fixed the `types` associated to modules in localplay and catalog and used them to display the correct input, with the correct type, preventing passwords from appearing in cleartext.

I also took profit of the new HTML5 types (int and url) to have a better experience on browsers which support them.

This fixes #1339.