### PR TITLE
Fix issue #1356

### DIFF
--- a/modules/catalog/dropbox/dropbox.catalog.php
+++ b/modules/catalog/dropbox/dropbox.catalog.php
@@ -113,7 +113,7 @@ class Catalog_dropbox extends Catalog
     {
         $fields['apikey']        = array('description' => T_('API Key'), 'type'=>'text');
         $fields['secret']        = array('description' => T_('Secret'), 'type'=>'password');
-        $fields['path']          = array('description' => T_('Path'), 'type'=>'url', 'value' => '/');
+        $fields['path']          = array('description' => T_('Path'), 'type'=>'text', 'value' => '/');
         $fields['getchunk']      = array('description' => T_('Get chunked files on analyze'), 'type'=>'checkbox', 'value' => true);
 
         return $fields;

--- a/modules/catalog/local/local.catalog.php
+++ b/modules/catalog/local/local.catalog.php
@@ -101,7 +101,7 @@ class Catalog_local extends Catalog
 
     public function catalog_fields()
     {
-        $fields['path']      = array('description' => T_('Path'),'type'=>'url');
+        $fields['path']      = array('description' => T_('Path'),'type'=>'text');
 
         return $fields;
     }


### PR DESCRIPTION
Invalid URL type for input fields for paths

Some input fields were wrongly assigned a "url" type and browsers were
enforcing a valid URL to be put in these fields. Set them back to text.

Closes #1356.