### PR TITLE
Minor correction to tab theming for reborn theme

### DIFF
--- a/themes/reborn/templates/dark.css
+++ b/themes/reborn/templates/dark.css
@@ -590,6 +590,14 @@ a.option-list:hover {
 	border-color: #1d1d1d;
 }
 
+#tabs li a {
+  color: #ff9d00;
+}
+
+#tabs li a:hover {
+  color: #ffc466;
+}
+
 #tabs li.tab_active a {
 	color: #fff;
 }

--- a/themes/reborn/templates/light.css
+++ b/themes/reborn/templates/light.css
@@ -576,6 +576,14 @@ a.option-list:hover {
     background-image: url("../../../images/background.light.png") !important;
 }
 
+#tabs li a {
+  color: #1990db;
+}
+
+#tabs li a:hover {
+  color: #52aae4;
+}
+
 #tabs li.tab_active a {
 	color: #000;
 }


### PR DESCRIPTION
There was a small issue with the light theme: in artist view (among others), the tabs were orange and not blue. This is a very small tweak to override the tab color in light.css and dark.css.