### PR TITLE
Composer info on Composer column in Itunes

### DIFF
--- a/lib/class/daap_api.class.php
+++ b/lib/class/daap_api.class.php
@@ -464,6 +464,9 @@ class Daap_Api
                     case 'daap.songartist':
                         $o .= self::tlv($m, $song->f_artist);
                         break;
+                    case 'daap.songcomposer':
+                        $o .= self::tlv($m, $song->f_composer);
+                        break;
                     case 'daap.songbitrate':
                         $o .= self::tlv($m, intval($song->bitrate / 1000));
                         break;
@@ -684,6 +687,7 @@ class Daap_Api
         self::add_dict('adbs', 'list', 'daap.databasesongs'); // response to a /databases/id/items
         self::add_dict('asal', 'string', 'daap.songalbum');
         self::add_dict('asar', 'string', 'daap.songartist');
+        self::add_dict('ascp', 'string', 'daap.songcomposer');
         self::add_dict('asbt', 'short', 'daap.songsbeatsperminute');
         self::add_dict('asbr', 'short', 'daap.songbitrate');
         self::add_dict('ascm', 'string', 'daap.songcomment');


### PR DESCRIPTION
i've noticed that the column composer isnt filled so i modify the daap_api.class.php and now is showing the info of composer on its respective column. 