### PR TITLE
Add sort by Disk number to all non-default sorts

### DIFF
--- a/lib/class/artist.class.php
+++ b/lib/class/artist.class.php
@@ -274,13 +274,13 @@ class Artist extends database_object implements library_item
         $sort_type = AmpConfig::get('album_sort');
         $sql_sort  = '`album`.`name`,`album`.`disk`,`album`.`year`';
         if ($sort_type == 'year_asc') {
-            $sql_sort = '`album`.`year` ASC';
+            $sql_sort = '`album`.`year` ASC,`album`.`disk`';
         } elseif ($sort_type == 'year_desc') {
-            $sql_sort = '`album`.`year` DESC';
+            $sql_sort = '`album`.`year` DESC,`album`.`disk`';
         } elseif ($sort_type == 'name_asc') {
-            $sql_sort = '`album`.`name` ASC';
+            $sql_sort = '`album`.`name` ASC,`album`.`disk`';
         } elseif ($sort_type == 'name_desc') {
-            $sql_sort = '`album`.`name` DESC';
+            $sql_sort = '`album`.`name` DESC,`album`.`disk`';
         }
 
         if (!$ignoreAlbumGroups) {


### PR DESCRIPTION
When using a non-default sort of an artists albums disk order is undefined. I was getting albums listed like this

Album A [Disk 2]
Album A [Disk 1]
Album B [Disk 1]
Album B [Disk 2]

Disk will now always sort ASC