### PR TITLE
Add opus transcoding arguments to ampache.cfg

### DIFF
--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -965,6 +965,7 @@ transcode_input = "-i %FILE%"
 ; encode_args_TYPE = TRANSCODE_CMD_ARGS
 encode_args_mp3 = "-vn -b:a %BITRATE%K -c:a libmp3lame -f mp3 pipe:1"
 encode_args_ogg = "-vn -b:a %BITRATE%K -c:a libvorbis -f ogg pipe:1"
+encode_args_opus = "-vn -b:a %BITRATE%K -c:a libopus -compression_level 10 -vsync 2 -f ogg pipe:1"
 encode_args_m4a = "-vn -b:a %BITRATE%K -c:a libfdk_aac -f adts pipe:1"
 encode_args_wav = "-vn -b:a %BITRATE%K -c:a pcm_s16le -f wav pipe:1"
 encode_args_flv = "-b:a %BITRATE%K -ar 44100 -ac 2 -v 0 -f flv -c:v libx264 -preset superfast -threads 0 pipe:1"


### PR DESCRIPTION
Added a line for ffmpeg opus encoding (transcoding) using libopus (which obviously needs to be installed) to transcode on the fly to the very fast and efficient opus codec. (Very personal) bitrate recommendation: 128k (To be set in the the admin interface or user personal preferences).
I'm suggesting ogg as a transport (ogg opus) which in turns requires the vsync 2 option.