### PR TITLE
Change default flac transcode target to opus

### DIFF
--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -911,7 +911,7 @@ registration_mandatory_fields = "fullname"
 ; Override the default output format on a per-type basis
 ; encode_target_TYPE = TYPE
 ; DEFAULT: none
-;encode_target_flac = ogg
+;encode_target_flac = opus
 
 ; Override the default TYPE transcoding behavior on a per-player basis
 ; transcode_player_PLAYER_TYPE = TYPE


### PR DESCRIPTION
I suggest changing the default transcode target for flac from ogg (vorbis) to opus, which is now a default codec in many systems (due to it being a requirement for WebRTC, implemented by all modern browsers and mobile OSes).
The reasoning is that opus is currently our best free and open codec for low latency, high quality sound, and at 128k or below, it offers better performance than vorbis. Low bandwith, low latency and high quality is exactly a use case for Ampache transcoding, so I suggest the ampache config suggests using opus, at the very least for flac.

We could even suggest it as the basic target for encode_target, encode_player_webplayer_target and encode_player_api_target in replacement of the (aging, proprietary) mp3.