### PR TITLE
ipv6 addresses couldn't be  added to user's ip history.

### DIFF
--- a/lib/class/user.class.php
+++ b/lib/class/user.class.php
@@ -897,11 +897,15 @@ class User extends database_object
         // Remove port information if any
         if (!empty($sip)) {
             // Use parse_url to support easily ipv6
-            $sipar = parse_url("http://" . $sip);
+        	if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === true) {
+        		$sipar = parse_url("http://" . $sip);
+        	} else {
+        		$sipar = parse_url("http://[" . $sip."]");
+        	}
             $sip   = $sipar['host'];
         }
 
-        $ip    = (!empty($sip)) ? Dba::escape(inet_pton($sip)) : '';
+        $ip    = (!empty($sip)) ? Dba::escape(inet_pton(trim($sip, "[]"))) : '';
         $date  = time();
         $user  = $this->id;
         $agent = Dba::escape($_SERVER['HTTP_USER_AGENT']);


### PR DESCRIPTION
Added test for ipv4/ipv6 addresses. Added insertion of brackets to the `parse_url` function for IPV6 addresses and removal of brackets for the `inet_pton` function.