### PR TITLE
Seafile Catalog Module

### DIFF
--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -1536,21 +1536,11 @@ abstract class Catalog extends database_object
      */
     public static function update_media_from_tags($media, $gather_types = array('music'), $sort_pattern='', $rename_pattern='')
     {
-        // Check for patterns
-        if (!$sort_pattern or !$rename_pattern) {
-            $catalog        = Catalog::create_from_id($media->catalog);
-            $sort_pattern   = $catalog->sort_pattern;
-            $rename_pattern = $catalog->rename_pattern;
-        }
-
         debug_event('tag-read', 'Reading tags from ' . $media->file, 5);
 
-        $vainfo = new vainfo($media->file, $gather_types, '', '', '', $sort_pattern, $rename_pattern);
-        $vainfo->get_info();
+        $catalog        = Catalog::create_from_id($media->catalog);
 
-        $key = vainfo::get_tag_type($vainfo->tags);
-
-        $results = vainfo::clean_tag_info($vainfo->tags, $key, $media->file);
+        $results = $catalog->get_media_tags($media, $gather_types, $sort_pattern, $rename_pattern);
 
         // Figure out what type of object this is and call the right
         // function, giving it the stuff we've figured out above
@@ -1764,6 +1754,25 @@ abstract class Catalog extends database_object
             $field = $libraryItem->getField($tag);
             $libraryItem->addMetadata($field, $value);
         }
+    }
+
+
+    public function get_media_tags($media, $gather_types, $sort_pattern, $rename_pattern)
+    {
+        // Check for patterns
+        if (!$sort_pattern or !$rename_pattern) {
+            $sort_pattern   = $this->sort_pattern;
+            $rename_pattern = $this->rename_pattern;
+        }
+
+        $vainfo = new vainfo($media->file, $gather_types, '', '', '', $sort_pattern, $rename_pattern);
+        $vainfo->get_info();
+
+        $key = vainfo::get_tag_type($vainfo->tags);
+
+        $results = vainfo::clean_tag_info($vainfo->tags, $key, $media->file);
+
+        return $results;
     }
 
     /**

--- a/modules/catalog/seafile/SeafileAdapter.php
+++ b/modules/catalog/seafile/SeafileAdapter.php
@@ -1,0 +1,277 @@
+<?php
+/* vim:set softtabstop=4 shiftwidth=4 expandtab: */
+/**
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPLv3)
+ * Copyright 2001 - 2016 Ampache.org
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+use Seafile\Client\Http\Client;
+use Seafile\Client\Resource\Library;
+use Seafile\Client\Resource\Directory;
+use Seafile\Client\Resource\File;
+use GuzzleHttp\Exception\ClientException;
+
+class SeafileAdapter
+{
+    // request API key from Seafile Server based on username and password
+    public static function request_api_key($server_uri, $username, $password)
+    {
+        $options = array(
+            'http' => array(
+                'header' => "Content-type: application/x-www-form-urlencoded\r\n",
+                'method' => 'POST',
+                'content' => http_build_query(array('username' => $username, 'password' => $password))
+            )
+        );
+
+        $result  = file_get_contents($server_uri . '/api2/auth-token/', false, stream_context_create($options));
+
+        if (!$result) {
+            throw new Exception(T_("Could not authenticate with Seafile"));
+        }
+
+        $token = json_decode($result);
+
+        return $token->token;
+    }
+
+    /////////////////////////
+    // instance
+    /////////////////////////
+
+    private $server;
+    private $api_key;
+    private $library_name;
+    private $call_delay;
+
+    private $client;
+    private $library;
+
+    private $directory_cache;
+
+    public function __construct($server_uri, $library_name, $call_delay, $api_key)
+    {
+        $this->server          = $server_uri;
+        $this->library_name    = $library_name;
+        $this->api_key         = $api_key;
+        $this->call_delay      = $call_delay;
+        $this->directory_cache = array();
+    }
+
+    // do we have all the info we need?
+    public function ready()
+    {
+        return $this->server != null &&
+            $this->api_key != null &&
+            $this->library_name != null &&
+            $this->call_delay != null;
+    }
+
+    // create API client object & find library
+    public function prepare()
+    {
+        if ($this->client !== null) {
+            return true;
+        }
+
+        if (!$this->ready()) {
+            $this->client = null;
+
+            return false;
+        }
+
+        $client = new Client([
+            'base_uri' => $this->server,
+            'debug' => false,
+            'delay' => $this->call_delay,
+            'headers' => [
+                'Authorization' => 'Token ' . $this->api_key
+            ]
+        ]);
+
+        $this->client = array(
+            'Libraries' => new Library($client),
+            'Directories' => new Directory($client),
+            'Files' => new File($client),
+            'Client' => $client
+        );
+
+        // Get Library
+        $libraries = $this->throttle_check(function () {
+            return $this->client['Libraries']->getAll();
+        });
+
+        $matches = array_values(array_filter($libraries, function ($library) {
+            return $library->name == $this->library_name;
+        }));
+
+        if (count($matches) == 0) {
+            AmpError::add('general', sprintf(T_('No media updated: could not find Seafile library called "%s"'), $this->library_name));
+
+            return false;
+        }
+
+        $this->library = $matches[0];
+
+        return true;
+    }
+
+    // run a function that hits the Seafile API, but catch throttling errors and retry
+    private function throttle_check($func)
+    {
+        while (true) {
+            try {
+                return $func();
+            } catch (ClientException $e) {
+                if ($e->getResponse()->getStatusCode() !== 429) {
+                    throw $e;
+                }
+
+                $resp = $e->getResponse()->getBody();
+
+                $error = json_decode($resp)->detail;
+
+                preg_match('(\d+) sec', $error, $matches);
+
+                $secs = intval($matches[1][0]);
+
+                debug_event('seafile', sprintf('Throttled by Seafile, waiting %d seconds.', $secs), 5);
+                sleep($secs + 1);
+            }
+        }
+    }
+
+    // given a given path & filename, return the "virtual" path string which will be stored in the database
+    public function to_virtual_path($file)
+    {
+        return $this->library->name . '|' . $file->dir . '|' . $file->name;
+    }
+
+    // given a database-stored "virtual" path, return the path & filename
+    public function from_virtual_path($file_path)
+    {
+        $split = explode('|', $file_path);
+
+        return array('path' => $split[1], 'filename' => $split[2]);
+    }
+
+    private function get_cached_directory($path)
+    {
+        if (array_key_exists($path, $this->directory_cache)) {
+            $directory = $this->directory_cache[$path];
+
+            if ($directory) {
+                return $directory;
+            } else {
+                return null;
+            }
+        } else {
+            try {
+                $directory = $this->throttle_check(function () use ($path) {
+                    return $this->client['Directories']->getAll($this->library, $path);
+                });
+                $this->directory_cache[$path] = $directory;
+
+                return $directory;
+            } catch (ClientException $e) {
+                if ($e->getResponse()->getStatusCode() == 404) {
+                    $this->directory_cache[$path] = false;
+
+                    return null;
+                } else {
+                    throw $e;
+                }
+            }
+        }
+    }
+
+    // run a function for all files in the seafile library.
+    // the function receives a DirectoryItem and should return 1 if the file was added, 0 otherwise
+    // (https://github.com/rene-s/Seafile-PHP-SDK/blob/master/src/Type/DirectoryItem.php)
+    // Returns number added, or -1 on failure
+    public function for_all_files($func, $path = '/')
+    {
+        if ($this->client != null) {
+            $directoryItems = $this->get_cached_directory($path);
+
+            $count = 0;
+
+            if ($directoryItems !== null && count($directoryItems) > 0) {
+                foreach ($directoryItems as $item) {
+                    if ($item->type == 'dir') {
+                        $count += $this->for_all_files($func, $path . $item->name . '/');
+                    } elseif ($item->type == 'file') {
+                        $count += $func($item);
+                    }
+                }
+            }
+
+            return $count;
+        }
+
+        return -1;
+    }
+
+    public function get_file($path, $name)
+    {
+        $directory = $this->get_cached_directory($path);
+
+        if ($directory) {
+            foreach ($directory as $file) {
+                if ($file->name === $name) {
+                    return $file;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    // download a file, optionally limited to just enough to be able to read its metadata tags(currently 2MB)
+    public function download($file, $partial = false)
+    {
+        $url = $this->throttle_check(function () use ($file) {
+            return $this->client['Files']->getDownloadUrl($this->library, $file, $file->dir);
+        });
+
+        if ($partial) {
+            $opts = ['curl' => [ CURLOPT_RANGE => '0-2097152' ]];
+        } else {
+            $opts = [ 'delay' => 0 ];
+        }
+        // grab a full 2 meg in case meta has image in it or something
+        $response = $this->throttle_check(function () use ($url, $opts) {
+            return $this->client['Client']->request('GET', $url, $opts);
+        });
+
+        $tempfilename = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $file->name;
+
+        $tempfile = fopen($tempfilename, 'wb');
+
+        fwrite($tempfile, $response->getBody());
+
+        fclose($tempfile);
+
+        return $tempfilename;
+    }
+
+    public function get_format_string()
+    {
+        return 'Seafile server "' . $this->server . '", library "' . $this->library_name . '"';
+    }
+}

--- a/modules/catalog/seafile/composer.module.json
+++ b/modules/catalog/seafile/composer.module.json
@@ -1,0 +1,11 @@
+{
+	"name": "ampache/ampache-seafile",
+	"description": "Seafile catalog for Ampache.",
+	"homepage": "http://ampache.org",
+	"keywords": ["ampache", "seafile", "catalog"],
+	"type": "ampache-catalog",
+	"license": "GPL-2.0",
+    "require": {
+		"rsd/seafile-php-sdk": "1.*"
+    }
+}

--- a/modules/catalog/seafile/seafile.catalog.php
+++ b/modules/catalog/seafile/seafile.catalog.php
@@ -1,0 +1,510 @@
+<?php
+/* vim:set softtabstop=4 shiftwidth=4 expandtab: */
+/**
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPLv3)
+ * Copyright 2001 - 2016 Ampache.org
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Seafile Catalog Class
+ *
+ * This class handles all actual work in regards to remote Seafile catalogs.
+ *
+ */
+
+require_once('SeafileAdapter.php');
+
+class Catalog_Seafile extends Catalog
+{
+    private static $version     = '000001';
+    private static $type        = 'seafile';
+    private static $description = 'Seafile Remote Catalog';
+    private static $table_name  = 'catalog_seafile';
+
+    private $seafile;
+
+    /**
+     * get_description
+     * This returns the description of this catalog
+     */
+    public function get_description()
+    {
+        return self::$description;
+    } // get_description
+
+    /**
+     * get_version
+     * This returns the current version
+     */
+    public function get_version()
+    {
+        return self::$version;
+    } // get_version
+
+    /**
+     * get_type
+     * This returns the current catalog type
+     */
+    public function get_type()
+    {
+        return self::$type;
+    } // get_type
+
+    /**
+     * get_create_help
+     * This returns hints on catalog creation
+     */
+    public function get_create_help()
+    {
+        return
+            "<ul><li>" . T_("Install a Seafile server per its documentation (https://www.seafile.com/)") . "</li>" .
+            "<li>" . T_("Enter url to server (e.g. &ldquo;https://seafile.example.com&rdquo;) and library name (e.g. &ldquo;Music&rdquo;).") . "</li>" .
+            "<li>" . T_("'API Call Delay' is a delay inserted between repeated requests to Seafile (such as during an Add or Clean action) to accomodate Seafile's Rate Limiting. ")
+                   . T_("<br/>The default is tuned towards Seafile's default rate limit settings; see ")
+                   . '<a href=\'https://forum.syncwerk.com/t/too-many-requests-when-using-web-api-status-code-429/2330\'>' . T_("this forum post") . '</a>'
+                   . T_(" for more information.") . "</li>" .
+            "<li>  " . T_("After creating the catalog, you must 'Make it ready' on the catalog table.") . "</li></ul>";
+    } // get_create_help
+
+    /**
+     * is_installed
+     * This returns true or false if remote catalog is installed
+     */
+    public function is_installed()
+    {
+        $sql        = "SHOW TABLES LIKE '" . self::$table_name . "'";
+        $db_results = Dba::query($sql);
+
+        return (Dba::num_rows($db_results) > 0);
+    } // is_installed
+
+    /**
+     * install
+     * This function installs the remote catalog
+     */
+    public function install()
+    {
+        $sql = "CREATE TABLE `" . self::$table_name . "` (" .
+            "`id` INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY , " .
+            "`server_uri` VARCHAR( 255 ) COLLATE utf8_unicode_ci NOT NULL , " .
+            "`api_key` VARCHAR( 100 ) COLLATE utf8_unicode_ci NOT NULL , " .
+            "`library_name` VARCHAR( 255 ) COLLATE utf8_unicode_ci NOT NULL , " .
+            "`api_call_delay` INT NOT NULL , " .
+            "`catalog_id` INT( 11 ) NOT NULL" .
+            ") ENGINE = MYISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci";
+
+        Dba::query($sql);
+
+        return true;
+    }
+
+    /**
+     * catalog_fields
+     *
+     * Return the necessary settings fields for creating a new Seafile catalog
+     */
+    public function catalog_fields()
+    {
+        $fields['server_uri']     = array('description' => T_('Server URI'), 'type' => 'text', 'value' => 'https://seafile.example.org/');
+        $fields['library_name']   = array('description' => T_('Library Name'), 'type' => 'text', 'value' => 'Music');
+        $fields['api_call_delay'] = array('description' => T_('API Call Delay'), 'type' => 'number', 'value' => '250');
+        $fields['username']       = array('description' => T_('Seafile Username/Email'), 'type' => 'text', 'value' => '' );
+        $fields['password']       = array('description' => T_('Seafile Password'), 'type' => 'password', 'value' => '' );
+
+        return $fields;
+    }
+
+    /**
+     * isReady
+     *
+     * Returns whether the catalog is ready for use.
+     */
+    public function isReady()
+    {
+        return $this->seafile->ready();
+    }
+
+    /**
+     * create_type
+     *
+     * This creates a new catalog type entry for a catalog
+     */
+    public static function create_type($catalog_id, $data)
+    {
+        $server_uri     = rtrim(trim($data['server_uri']), '/');
+        $library_name   = trim($data['library_name']);
+        $api_call_delay = trim($data['api_call_delay']);
+        $username       = trim($data['username']);
+        $password       = trim($data['password']);
+
+        if (!strlen($server_uri)) {
+            AmpError::add('general', T_('Error: Seafile Server URL is required.'));
+
+            return false;
+        }
+
+        if (!strlen($library_name)) {
+            AmpError::add('general', T_('Error: Seafile Server Library Name is required.'));
+
+            return false;
+        }
+
+        if (!strlen($username)) {
+            AmpError::add('general', T_('Error: Seafile Username is required.'));
+
+            return false;
+        }
+
+        if (!strlen($password)) {
+            AmpError::add('general', T_('Error: Seafile Password is required.'));
+
+            return false;
+        }
+
+        if (!is_numeric($api_call_delay)) {
+            AmpError::add('general', T_('Error: API Call Delay must have a numeric value.'));
+
+            return false;
+        }
+
+        try {
+            $api_key = SeafileAdapter::request_api_key($server_uri, $username, $password);
+
+            debug_event('seafile_catalog', 'Retrieved API token for user ' . $username . '.', 1);
+        } catch (Exception $e) {
+            AmpError::add('general', sprintf(T_('Error while authenticating against Seafile API: %s', $e->getMessage())));
+            debug_event('seafile_catalog', 'Exception while Authenticating: ' . $e->getMessage(), 2);
+        }
+
+        if ($api_key == null) {
+            return false;
+        }
+
+        $sql = "INSERT INTO `catalog_seafile` (`server_uri`, `api_key`, `library_name`, `api_call_delay`, `catalog_id`) VALUES (?, ?, ?, ?, ?)";
+        Dba::write($sql, array($server_uri, $api_key, $library_name, intval($api_call_delay), $catalog_id));
+
+        return true;
+    }
+
+    /**
+     * Constructor
+     *
+     * Catalog class constructor, pulls catalog information
+     */
+    public function __construct($catalog_id = null)
+    {
+        if ($catalog_id) {
+            $this->id = intval($catalog_id);
+            $info     = $this->get_info($catalog_id);
+
+            $this->seafile = new SeafileAdapter($info['server_uri'], $info['library_name'], $info['api_call_delay'], $info['api_key']);
+        }
+    }
+
+    public function get_rel_path($file_path)
+    {
+        $arr = $this->seafile->from_virtual_path($file_path);
+
+        return $arr['path'] . "/" . $arr['filename'];
+    }
+
+    /**
+     * add_to_catalog
+     * this function adds new files to an
+     * existing catalog
+     */
+    public function add_to_catalog($options = null)
+    {
+        // Prevent the script from timing out
+        set_time_limit(0);
+
+        if (!defined('SSE_OUTPUT')) {
+            UI::show_box_top(T_('Running Seafile Remote Update') . '. . .');
+        }
+
+        $success = false;
+
+        if ($this->seafile->prepare()) {
+            $count = $this->seafile->for_all_files(function ($file) {
+                if ($file->size == 0) {
+                    debug_event('read', $file->name . " ignored, 0 bytes", 5);
+
+                    return 0;
+                }
+
+                $is_audio_file = Catalog::is_audio_file($file->name);
+                $is_video_file = Catalog::is_video_file($file->name);
+
+                if ($is_audio_file && count($this->get_gather_types('music')) > 0) {
+                    if ($this->insert_song($file)) {
+                        return 1;
+                    }
+                } elseif ($is_video_file && count($this->get_gather_types('video')) > 0) {
+                    // TODO $this->insert_video()
+                } elseif (!$is_audio_file && !$is_video_file) {
+                    debug_event('read', $file->name . " ignored, unknown media file type", 5);
+                } else {
+                    debug_event('read', $file->name . " ignored, bad media type for this catalog.", 5);
+                }
+
+                return 0;
+            });
+
+            UI::update_text('', sprintf(T_('Catalog Update Finished.  Total Media: [%s]'), $count));
+
+            if ($count <= 0) {
+                AmpError::add('general', T_('No media updated, do you respect the patterns?'));
+            } else {
+                $success = true;
+            }
+        }
+
+        if (!defined('SSE_OUTPUT')) {
+            UI::show_box_bottom();
+        }
+
+        $this->update_last_add();
+
+        return $success;
+    }
+
+    /**
+     * _insert_local_song
+     *
+     * Insert a song that isn't already in the database.
+     */
+    private function insert_song($file)
+    {
+        if ($this->check_remote_song($this->seafile->to_virtual_path($file))) {
+            debug_event('seafile_catalog', 'Skipping existing song ' . $file->name, 5);
+            UI::update_text('', sprintf(T_('Skipping existing song "%s"'), $file->name));
+        } else {
+            debug_event('seafile_catalog', 'Adding song ' . $file->name, 5);
+            try {
+                $results = $this->download_metadata($file);
+                UI::update_text('', sprintf(T_('Adding song "%s"'), $file->name));
+                $added =  Song::insert($results);
+
+                if ($added) {
+                    $this->count++;
+                }
+
+                return $added;
+            } catch (Exception $e) {
+                debug_event('seafile_add', sprintf('Could not add song "%s": %s', $file->name, $e->getMessage()), 1);
+                UI::update_text('', sprintf(T_('Could not add song "%s"'), $file->name));
+            }
+        }
+
+        return false;
+    }
+
+    private function download_metadata($file, $sort_pattern = '', $rename_pattern = '', $gather_types = null)
+    {
+        // Check for patterns
+        if (!$sort_pattern or !$rename_pattern) {
+            $sort_pattern   = $this->sort_pattern;
+            $rename_pattern = $this->rename_pattern;
+        }
+
+        debug_event('seafile_catalog', 'Downloading partial song ' . $file->name, 5);
+
+        $tempfilename = $this->seafile->download($file, true);
+
+        if ($gather_types === null) {
+            $gather_types = $this->get_gather_types('music');
+        }
+
+        $vainfo = new vainfo($tempfilename, $gather_types, '', '', '', $sort_pattern, $rename_pattern, true);
+        $vainfo->forceSize($file->size);
+        $vainfo->get_info();
+
+        $key = vainfo::get_tag_type($vainfo->tags);
+
+        // maybe fix stat-ing-nonexistent-file bug?
+        $vainfo->tags['general']['size'] = intval($file->size);
+
+        $results = vainfo::clean_tag_info($vainfo->tags, $key, $file->name);
+
+        // Set the remote path
+        $results['catalog'] = $this->id;
+
+        $results['file'] = $this->seafile->to_virtual_path($file);
+
+        return $results;
+    }
+
+    public function verify_catalog_proc()
+    {
+        $results = array('total' => 0, 'updated' => 0);
+
+        set_time_limit(0);
+
+        if ($this->seafile->prepare()) {
+            $sql        = 'SELECT `id`, `file`, `title` FROM `song` WHERE `catalog` = ?';
+            $db_results = Dba::read($sql, array($this->id));
+            while ($row = Dba::fetch_assoc($db_results)) {
+                $results['total']++;
+                debug_event('seafile-verify', 'Starting work on ' . $row['file'] . '(' . $row['id'] . ')', 5, 'ampache-catalog');
+                $fileinfo = $this->seafile->from_virtual_path($row['file']);
+
+                $file = $this->seafile->get_file($fileinfo['path'], $fileinfo['filename']);
+
+                $metadata = null;
+
+                if ($file !== null) {
+                    $metadata = $this->download_metadata($file);
+                }
+
+                if ($metadata !== null) {
+                    debug_event('seafile-verify', 'updating song', 5, 'ampache-catalog');
+                    $song = new Song($row['id']);
+                    $info = self::update_song_from_tags($metadata, $song);
+                    if ($info['change']) {
+                        UI::update_text('', sprintf(T_('Updated song "%s"'), $row['title']));
+                        $results['updated']++;
+                    } else {
+                        UI::update_text('', sprintf(T_('Song up to date: "%s"'), $row['title']));
+                    }
+                } else {
+                    debug_event('seafile-verify', 'removing song', 5, 'ampache-catalog');
+                    UI::update_text('', sprintf(T_('Removing song "%s"'), $row['title']));
+                    //$dead++;
+                    Dba::write('DELETE FROM `song` WHERE `id` = ?', array($row['id']));
+                }
+            }
+
+            $this->update_last_update();
+        }
+
+        return $results;
+    }
+
+    public function get_media_tags($media, $gather_types, $sort_pattern, $rename_pattern)
+    {
+        if ($this->seafile->prepare()) {
+            $fileinfo = $this->seafile->from_virtual_path($media->file);
+
+            $file = $this->seafile->get_file($fileinfo['path'], $fileinfo['filename']);
+
+            if ($file !== null) {
+                return $this->download_metadata($file, $sort_pattern, $rename_pattern, $gather_types);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * clean_catalog_proc
+     *
+     * Removes songs that no longer exist.
+     */
+    public function clean_catalog_proc()
+    {
+        $dead = 0;
+
+        set_time_limit(0);
+
+        if ($this->seafile->prepare()) {
+            $sql        = 'SELECT `id`, `file` FROM `song` WHERE `catalog` = ?';
+            $db_results = Dba::read($sql, array($this->id));
+            while ($row = Dba::fetch_assoc($db_results)) {
+                debug_event('seafile-clean', 'Starting work on ' . $row['file'] . '(' . $row['id'] . ')', 5);
+                $file     = $this->seafile->from_virtual_path($row['file']);
+
+                try {
+                    $exists = $this->seafile->get_file($file['path'], $file['filename']) !== null;
+                } catch (Exception $e) {
+                    UI::update_text('', sprintf(T_('Error checking song "%s": %s'), $file['filename'], $e->getMessage()));
+                    debug_event('seafile-clean', 'Exception: ' . $e->getMessage(), 2);
+
+                    continue;
+                }
+
+                if ($exists) {
+                    debug_event('seafile-clean', 'keeping song', 5);
+                    UI::update_text('', sprintf(T_('Keeping song "%s"'), $file['filename']));
+                } else {
+                    UI::update_text('', sprintf(T_('Removing song "%s"'), $file['filename']));
+                    debug_event('seafile-clean', 'removing song', 5);
+                    $dead++;
+                    Dba::write('DELETE FROM `song` WHERE `id` = ?', array($row['id']));
+                }
+            }
+
+            $this->update_last_clean();
+        }
+
+        return $dead;
+    }
+
+    /**
+     * check_remote_song
+     *
+     * checks to see if a remote song exists in the database or not
+     * if it find a song it returns the UID
+     */
+    public function check_remote_song($file)
+    {
+        $sql        = 'SELECT `id` FROM `song` WHERE `file` = ?';
+        $db_results = Dba::read($sql, array($file));
+
+        if ($results = Dba::fetch_assoc($db_results)) {
+            return $results['id'];
+        }
+
+        return false;
+    }
+
+
+    /**
+     * format
+     *
+     * This makes the object human-readable.
+     */
+    public function format()
+    {
+        parent::format();
+        $this->f_info      = $this->seafile->get_format_string();
+        $this->f_full_info = $this->seafile->get_format_string();
+    }
+
+    public function prepare_media($media)
+    {
+        if ($this->seafile->prepare()) {
+            set_time_limit(0);
+
+            $fileinfo = $this->seafile->from_virtual_path($media->file);
+
+            $file = $this->seafile->get_file($fileinfo['path'], $fileinfo['filename']);
+
+            $tempfile = $this->seafile->download($file);
+
+            $media->file   = $tempfile;
+            $media->f_file = $fileinfo['filename'];
+
+            // in case this didn't get set for some reason
+            if ($media->size == 0) {
+                $media->size = Core::get_filesize($tempfile);
+            }
+        }
+
+        return $media;
+    }
+}


### PR DESCRIPTION
Hi, I needed a way to connect Ampache to my [Seafile](https://www.seafile.com/) file server, so despite not really being a PHP developer I decided to write my own.  I based it initially off the existing Dropbox module and used [this Seafile API client](https://github.com/rene-s/Seafile-PHP-SDK). I've Added, Verified, and Cleaned multiple times and everything seems to work. Well, the "gather art" process tries to treat my fake file paths as  local paths and displays failures, however it still can gather from searches, etc.

I did make one change to the `Catalog` class itself: I wanted to be able to use the "Update from tags" feature as I was organizing my library and fixing bad tags. The Catalog class's `update_media_from_tags` function was assuming the files were local (and it being static there was no way to override), so I pulled much of that function into a member function so I could override it in my catalog module.

Suggestions, requests, etc. are of course welcome.