### PR TITLE
JS autofocus on login and lost password pages replaced by au HTML5 attribute

### DIFF
--- a/templates/show_login_form.inc.php
+++ b/templates/show_login_form.inc.php
@@ -43,12 +43,9 @@ define('TABLE_RENDERED', 1);
         <meta http-equiv="Content-Type" content="text/html; charset=<?php echo AmpConfig::get('site_charset'); ?>" />
         <?php require_once AmpConfig::get('prefix') . UI::find_template('stylesheets.inc.php'); ?>
         <title> <?php echo AmpConfig::get('site_title'); ?> </title>
-        <script type="text/javascript" language="javascript">
-            function focus(){ document.login.username.focus(); }
-        </script>
     </head>
 
-    <body id="loginPage" onload="focus();">
+    <body id="loginPage">
         <div id="maincontainer">
             <div id="header"><!-- This is the header -->
                 <a href="<?php echo $web_path; ?>"><h1 id="headerlogo"></h1></a>
@@ -58,7 +55,7 @@ define('TABLE_RENDERED', 1);
                 <form name="login" method="post" enctype="multipart/form-data" action="<?php echo $web_path; ?>/login.php">
                     <div class="loginfield" id="usernamefield">
                         <label for="username"><?php echo  T_('Username'); ?>:</label>
-                        <input class="text_input" type="text" id="username" name="username" value="<?php echo scrub_out($_REQUEST['username']); ?>" />
+                        <input class="text_input" type="text" id="username" name="username" value="<?php echo scrub_out($_REQUEST['username']); ?>" autofocus />
                     </div>
                     <div class="loginfield" id="passwordfield">
                         <label for="password"><?php echo  T_('Password'); ?>:</label>

--- a/templates/show_lostpassword_form.inc.php
+++ b/templates/show_lostpassword_form.inc.php
@@ -39,14 +39,8 @@ $web_path = AmpConfig::get('web_path');
         <meta http-equiv="Content-Type" content="text/html; charset=<?php echo AmpConfig::get('site_charset'); ?>" />
         <?php require_once AmpConfig::get('prefix') . UI::find_template('stylesheets.inc.php'); ?>
         <title><?php echo scrub_out(AmpConfig::get('site_title')); ?></title>
-        <script type="text/javascript" language="javascript">
-            function focus()
-            {
-                document.login.email.focus();
-            }
-        </script>
     </head>
-    <body id="loginPage" onload="focus();">
+    <body id="loginPage">
         <div id="maincontainer">
             <div id="header"><!-- This is the header -->
                 <h1 id="headerlogo">
@@ -61,7 +55,7 @@ $web_path = AmpConfig::get('web_path');
                     <div class="loginfield" id="emailfield">
                         <label for="email"><?php echo  T_('Email'); ?>:</label>
                         <input type="hidden" id="action" name="action" value="send" />
-                        <input class="text_input" type="text" id="email" name="email" />
+                        <input class="text_input" type="text" id="email" name="email" autofocus />
                     </div>
                     <input class="button" id="lostpasswordbutton" type="submit" value="<?php echo T_('Submit'); ?>" />
                 </form>


### PR DESCRIPTION
Hi there,
I propose to replace the autofocus JS handling by a standard one. When the page take some time to load and we already filled the login and typing the password, the focus get back to the login. With this trick, it didn't.
Thanks for this amazing piece of software, have a nice day.