### PR TITLE
add global options to customize waveform size

### DIFF
--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -326,6 +326,16 @@ catalog_prefix_pattern = "The|An|A|Die|Das|Ein|Eine|Les|Le|La"
 ; DEFAULT: #FF0000
 ;waveform_color = "#FF0000"
 
+; Waveform height
+; The waveform height.
+; DEFAULT: 32
+;waveform_height = 32
+
+; Waveform width
+; The waveform width.
+; DEFAULT: 400
+;waveform_width = 400
+
 ; Temporary Directory Path
 ; If Waveform is enabled this must be set to tell
 ; Ampache which directory to save the temporary file to. Do not put a

--- a/lib/class/waveform.class.php
+++ b/lib/class/waveform.class.php
@@ -186,8 +186,8 @@ class Waveform
         }
 
         $detail     = 5;
-        $width      = 400;
-        $height     = 32;
+        $width      = AmpConfig::get('waveform_width') ?: 400;
+        $height     = AmpConfig::get('waveform_height') ?: 32;
         $foreground = AmpConfig::get('waveform_color') ?: '#FF0000';
         $background = '';
         $draw_flat  = true;


### PR DESCRIPTION
I found the waveform default size a bit small to really see the audio file wave form.

So I added two new options: "waveform_height" and "waveform_width" to permit the admin choose which size he wants.

The only problem I see is the memory consumption: on my conf, I first set waveform_height to 96 but it exceeded the php allocated memory. 
So I use 64 as a compromise.