### PR TITLE
Small changes to make translation easier

### DIFF
--- a/modules/catalog/dropbox/dropbox.catalog.php
+++ b/modules/catalog/dropbox/dropbox.catalog.php
@@ -185,7 +185,7 @@ class Catalog_dropbox extends Catalog
         try {
             $app = new DropboxApp($apikey, $secret, $authtoken);
         } catch (DropboxClientException $e) {
-            AmpError::add('general', T_('Invalid <api key, secret, or access token>: ' . $e->getMessage()));
+            AmpError::add('general', T_('Invalid "API key", "secret", or "access token": ' . $e->getMessage()));
 
             return false;
         }
@@ -194,7 +194,7 @@ class Catalog_dropbox extends Catalog
         try {
             $listFolderContents = $dropbox->listFolder($path);
         } catch (DropboxClientException $e) {
-            AmpError::add('general', T_('Invalid <dropbox-path>: ' . $e->getMessage()));
+            AmpError::add('general', T_('Invalid "dropbox-path": ' . $e->getMessage()));
             $listFolderContents = null;
 
             return false;
@@ -401,14 +401,14 @@ class Catalog_dropbox extends Catalog
             
             if ($res) {
                 $gtypes      = $this->get_gather_types('video');
-                $vainfo     = new vainfo($outfile, $gtypes, '', '', '', $this->sort_pattern, $this->rename_pattern, $islocal);
+                $vainfo      = new vainfo($outfile, $gtypes, '', '', '', $this->sort_pattern, $this->rename_pattern, $islocal);
                 $vainfo->get_info();
         
                 $tag_name           = vainfo::get_tag_type($vainfo->tags, 'metadata_order_video');
                 $results            = vainfo::clean_tag_info($vainfo->tags, $tag_name, $outfile);
                 $results['catalog'] = $this->id;
         
-                $results['file']      = $outfile;
+                $results['file']       = $outfile;
                 $video_id              = Video::insert($results, $gtypes, []);
                 if ($results['art']) {
                     $art = new Art($video_id, 'video');
@@ -499,7 +499,7 @@ class Catalog_dropbox extends Catalog
             
             $this->update_last_update();
         } catch (DropboxClientException $e) {
-            AmpError::add('general', T_('Invalid <api key, secret, or access token>: ' . $e->getMessage()));
+            AmpError::add('general', T_('Invalid Invalid "API key", "secret", or "access token": ' . $e->getMessage()));
         }
         
         return $updated;

--- a/modules/catalog/seafile/seafile.catalog.php
+++ b/modules/catalog/seafile/seafile.catalog.php
@@ -71,14 +71,13 @@ class Catalog_Seafile extends Catalog
      */
     public function get_create_help()
     {
-        return
-            "<ul><li>" . T_("Install a Seafile server per its documentation (https://www.seafile.com/)") . "</li>" .
-            "<li>" . T_("Enter url to server (e.g. &ldquo;https://seafile.example.com&rdquo;) and library name (e.g. &ldquo;Music&rdquo;).") . "</li>" .
-            "<li>" . T_("'API Call Delay' is a delay inserted between repeated requests to Seafile (such as during an Add or Clean action) to accomodate Seafile's Rate Limiting. ")
-                   . T_("<br/>The default is tuned towards Seafile's default rate limit settings; see ")
-                   . '<a href=\'https://forum.syncwerk.com/t/too-many-requests-when-using-web-api-status-code-429/2330\'>' . T_("this forum post") . '</a>'
-                   . T_(" for more information.") . "</li>" .
-            "<li>  " . T_("After creating the catalog, you must 'Make it ready' on the catalog table.") . "</li></ul>";
+        $help = "<ul><li>" . T_("Install a Seafile server as described in its documentation on %s") . "</li>" .
+                "<li>" . T_("Enter url to server (e.g. 'https://seafile.example.com') and library name (e.g. 'Music').") . "</li>" .
+                "<li>" . T_("'API Call Delay' is a delay inserted between repeated requests to Seafile (such as during an Add or Clean action) to accomodate Seafile's Rate Limiting. <br/>" .
+                "The default is tuned towards Seafile's default rate limit settings; see %sthis forum post%s for more information.") . "</li>" .
+                "<li>" . T_("After creating the catalog, you must 'Make it ready' on the catalog table.") . "</li></ul>";
+
+        return sprintf($help, "<a target='_blank' href='https://www.seafile.com/'>https://www.seafile.com/</a>", "<a href='https://forum.syncwerk.com/t/too-many-requests-when-using-web-api-status-code-429/2330'>", "</a>");
     } // get_create_help
 
     /**

--- a/themes/reborn/templates/dark.css
+++ b/themes/reborn/templates/dark.css
@@ -314,6 +314,10 @@ table.tabledata a {
     color: #eee;
 }
 
+#catalog_type_fields table.tabledata a{
+	color: #ff9d00
+}
+
 table.tabledata a:hover, table.tabledata a:focus {
     color: #ffc466;
 }

--- a/themes/reborn/templates/light.css
+++ b/themes/reborn/templates/light.css
@@ -300,6 +300,10 @@ table.tabledata a {
     color: #666;
 }
 
+#catalog_type_fields table.tabledata a {
+	color: #1990db;
+}
+
 table.tabledata a:hover, table.tabledata a:focus {
     color: #52aae4;
 }


### PR DESCRIPTION
Changed and combined some strings to make translation in Transifex
easier. It's always better to not split up translatable strings, so
translators can see how they're put together and don't have to search
for the parts.

Also, in the `dropbox.catalog.php`, I changed the strings to not behave
like html tags. Transifex doesn't like this / treats it as html tags.
;-)

If it's better, we also could change the `\'` to `"`. But I guess it doesn't really matter.

EDIT: Btw. I also put some new rules into the reborn themes CSS to highlight the links in the "add-catalog-help-section"

:-)