### PR TITLE
Fix #1717 performance issues with playlist display

### DIFF
--- a/lib/class/search.class.php
+++ b/lib/class/search.class.php
@@ -421,7 +421,7 @@ class Search extends playlist_object
             $playlists = array();
             foreach (Playlist::get_playlists() as $playlistid) {
                 $playlist = new Playlist($playlistid);
-                $playlist->format();
+                $playlist->format(false);
                 $playlists[$playlistid] = $playlist->f_name;
             }
             $this->types[] = array(

--- a/templates/rightbar.inc.php
+++ b/templates/rightbar.inc.php
@@ -37,7 +37,7 @@
     Playlist::build_cache($playlists);
     foreach ($playlists as $playlist_id) {
         $playlist = new Playlist($playlist_id);
-        $playlist->format(); ?>
+        $playlist->format(false); ?>
                 <li>
                     <?php echo Ajax::text('?page=playlist&action=append_item&playlist_id=' . $playlist->id, $playlist->f_name, 'rb_append_playlist_' . $playlist->id); ?>
                 </li>


### PR DESCRIPTION
This part call the playlist_object.abstract.php for each playlist from everywhere. It results on User::format calls with the heavy bandwitch usage sum MySQL query.
I'm a long time Ampache user so my bandwitch usage is pretty loaded. Before using playlists, I hadn't any performance issue. I never make the link between playlist and my performance issues until today.
I didn't spend a lot of time to test my fix but didn't encounter any trouble so far.