### PR TITLE
Fixed an issue that artist name became empty in SubsonicAPI.

### DIFF
--- a/lib/class/subsonic_xml_data.class.php
+++ b/lib/class/subsonic_xml_data.class.php
@@ -483,6 +483,9 @@ class Subsonic_XML_Data
         
         $row = Dba::fetch_assoc($db_results);
 
+        $row['f_name'] = trim($row['prefix'] . ' ' . $row['name']);
+        $row['f_full_name'] = trim(trim($row['prefix']) . ' ' . trim($row['name']));
+
         return $row;
     }
     
@@ -521,7 +524,7 @@ class Subsonic_XML_Data
 //        $artist = new Artist($song->artist);
 //        $artist->format();
         $xsong->addAttribute('artistId', self::getArtistId($songData['artist']));
-        $xsong->addAttribute('artist', self::checkName($artistData['name']));
+        $xsong->addAttribute('artist', self::checkName($artistData['f_full_name']));
         $xsong->addAttribute('coverArt', self::getAlbumId($albumData['id']));
         $xsong->addAttribute('duration', $songData['time']);
         $xsong->addAttribute('bitRate', intval($songData['bitrate'] / 1000));

--- a/lib/class/subsonic_xml_data.class.php
+++ b/lib/class/subsonic_xml_data.class.php
@@ -483,7 +483,7 @@ class Subsonic_XML_Data
         
         $row = Dba::fetch_assoc($db_results);
 
-        $row['f_name'] = trim($row['prefix'] . ' ' . $row['name']);
+        $row['f_name']      = trim($row['prefix'] . ' ' . $row['name']);
         $row['f_full_name'] = trim(trim($row['prefix']) . ' ' . trim($row['name']));
 
         return $row;

--- a/lib/class/subsonic_xml_data.class.php
+++ b/lib/class/subsonic_xml_data.class.php
@@ -521,7 +521,7 @@ class Subsonic_XML_Data
 //        $artist = new Artist($song->artist);
 //        $artist->format();
         $xsong->addAttribute('artistId', self::getArtistId($songData['artist']));
-        $xsong->addAttribute('artist', self::checkName($artistData['f_full_name']));
+        $xsong->addAttribute('artist', self::checkName($artistData['name']));
         $xsong->addAttribute('coverArt', self::getAlbumId($albumData['id']));
         $xsong->addAttribute('duration', $songData['time']);
         $xsong->addAttribute('bitRate', intval($songData['bitrate'] / 1000));


### PR DESCRIPTION
I'm using latest Ampache (248d09e88c7e6cf0dbbe2f8872155ca212dc389b) with UltraSonic. But artist name of songs have been not displayed since the version. Because `$artistData['f_full_name']` doesn't exist.  
So I replaced `f_full_name` to `name` to fix the issue.