### PR TITLE
Add now_playing.php for embedded now playing info

### DIFF
--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -590,6 +590,15 @@ live_stream = "true"
 ; Possible Values: Int > 5
 refresh_limit = "60"
 
+; Embedded Now Playing Page
+; Set this to true to enable the embedded now playing page (now_playing.php).
+; This page allows for embedding a now playing badge into a stream
+; or status page. Use with the parameter 'user_id' to filter by a
+; specific user. This page is like rss in that it doesn't require a
+; login to view.
+; DEFAULT: false
+;use_now_playing_embedded = "false"
+
 ; Now Playing Refresh Limit
 ; This defines the refresh limit in seconds for the
 ; now playing embedded page. This (now_playing.php) is not

--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -590,6 +590,26 @@ live_stream = "true"
 ; Possible Values: Int > 5
 refresh_limit = "60"
 
+; Now Playing Refresh Limit
+; This defines the refresh limit in seconds for the
+; now playing embedded page. This (now_playing.php) is not
+; part of the normal application and is designed to be
+; embedded in another app, like a stream or status page.
+; If this value is not valid, automatic refresh will be disabled.
+; DEFAULT: -1
+; Possible Values; Int > 1
+;now_playing_refresh_limit = "-1"
+
+; Now Playing Custom CSS
+; This defines the custom css file for the now playing embedded
+; page. This (now_playing.php) is not part of the normal
+; application and is designed to be embedded in another app, like
+; a stream or status page.
+; If this value is not set, no CSS will be used. Custom CSS can
+; still be applied in the other application, like OBS.
+; DEFAULT: Not enabled
+;now_playing_css_file = "templates/now-playing.css"
+
 ; Footer Statistics
 ; This defines whether statistics (Queries, Cache Hits, Load Time)
 ; are shown in the page footer.

--- a/now_playing.php
+++ b/now_playing.php
@@ -1,0 +1,64 @@
+<?php
+/* vim:set softtabstop=4 shiftwidth=4 expandtab: */
+/**
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPLv3)
+ * Copyright 2001 - 2017 Ampache.org
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+define('NO_SESSION', '1');
+require_once 'lib/init.php';
+
+?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $htmllang; ?>" lang="<?php echo $htmllang; ?>" dir="<?php echo is_rtl(AmpConfig::get('lang')) ? 'rtl' : 'ltr';?>">
+<head>
+    <!-- Propulsed by Ampache | ampache.org -->
+    <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=<?php echo AmpConfig::get('site_charset'); ?>" />
+    <title><?php echo AmpConfig::get('site_title'); ?> - Now Playing</title>
+<?php
+if (AmpConfig::get('now_playing_css_file')) {
+    ?>
+    <link rel="stylesheet" href="<?php echo $web_path;
+    echo AmpConfig::get('now_playing_css_file'); ?>" type="text/css" media="screen" />
+<?php
+}
+if (AmpConfig::get('now_playing_refresh_limit') > 1) {
+    $refresh_limit = AmpConfig::get('now_playing_refresh_limit'); ?>
+    <script type="text/javascript" language="javascript">
+        reload = window.setInterval(function(){ window.location.reload(); }, <?php echo $refresh_limit ?> * 1000);
+    </script>
+<?php
+} ?>
+</head>
+<body>
+<?php
+
+Stream::gc_now_playing();
+$results = Stream::get_now_playing();
+
+if ($_REQUEST['user_id']) {
+    // If the URL specifies a specific user, filter the results on that user
+    $results = array_filter($results, function ($item) {
+        return ($item['client']->id == $_REQUEST['user_id']);
+    });
+}
+
+require AmpConfig::get('prefix') . UI::find_template('show_now_playing.inc.php');
+?>
+</body>
+</html>

--- a/now_playing.php
+++ b/now_playing.php
@@ -23,6 +23,12 @@
 define('NO_SESSION', '1');
 require_once 'lib/init.php';
 
+/* Check Perms */
+if (!AmpConfig::get('use_now_playing_embedded') || AmpConfig::get('demo_mode')) {
+    UI::access_denied();
+    exit;
+}
+
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $htmllang; ?>" lang="<?php echo $htmllang; ?>" dir="<?php echo is_rtl(AmpConfig::get('lang')) ? 'rtl' : 'ltr';?>">

--- a/templates/now-playing.css
+++ b/templates/now-playing.css
@@ -1,0 +1,64 @@
+/* vim:set softtabstop=4 shiftwidth=4 expandtab: */
+/**
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPLv3)
+ * Copyright 2001 - 2017 Ampache.org
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+body {
+    background-color: rgba(0, 0, 0, 0);
+    margin: 0px;
+    font-family: Arial,sans-serif;
+    font-weight: normal;
+    font-size: 16px;
+    line-height: 1.5em;
+    overflow: hidden;
+}
+a {
+    color: #ff9d00;
+    text-decoration: none;
+}
+label {
+    color: #fff;
+}
+.np_row {
+    background-color: rgba(50, 50, 50, 0.7);
+    padding: 8px;
+    display: flex;
+    flex-direction: row;
+}
+.box-top, .box-title, .box-bottom, .cel_username, .cel_tags, .similars, .cel_rating, .cel_userflag {
+    display: none;
+}
+#np_group_2 {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    padding-left: 10px;
+}
+#np_group_3, .cel_song {
+    order: 1;
+}
+#np_group_2, .cel_artist {
+    order: 2;
+}
+.cel_album {
+    order: 3;
+}
+.item_art {
+    box-shadow: 0 0 10px rgba(0,0,0,0.75);
+}


### PR DESCRIPTION
Add a embedded "Now Playing" page for use in streams, status pages, and the like.

New page designed to be used like rss.php; not used through index.php
and no session. Designed to be customized by CSS.

Features:
'user_id' parameter for filtering the now playing info. Not setting the 'user_id' parameter will show all users.
Respects the user's 'Privacy: Now Playing' setting, since this is a no
session (public) interface.
Separate refresh config parameter from the index.
Config option for custom css to apply, with a distributed css (hides username by default).
URL: `/now_playing.php?user_id=1`

Without CSS:
![Naked](https://i.imgur.com/Mc6y7ZN.png)

With distributed CSS:
![CSS](https://i.imgur.com/r6BjicX.png)

With CSS and multiple users playing:
![Multi-user](https://i.imgur.com/M7nNbJd.png)