### PR TITLE
Saving rating as popularimeter into ID3 of MP3 songs.

### DIFF
--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -1050,6 +1050,39 @@ class Song extends database_object implements media, library_item
                         $meta[$metadata->getField()->getName()] = $metadata->getData();
                     }
                 }
+                // Get user mail for rating
+                $ratingMail = trim($GLOBALS['user']->email);
+                // If user has no email in record, use user@example.net
+                if($ratingMail === '') {
+                    $ratingMail = 'user@example.net';
+                }
+                // Get Rating from user
+                $rating = new Rating($this->id, 'song');
+                switch ((int)$rating->get_user_rating()) {
+                    case (5):
+                        $ratingNumber = 255;
+                        break;
+                    case (4):
+                        $ratingNumber = 196;
+                        break;
+                    case (3):
+                        $ratingNumber = 128;
+                        break;
+                    case (2):
+                        $ratingNumber = 64;
+                        break;
+                    case (1):
+                        $ratingNumber = 1;
+                        break;
+                    default:
+                        $ratingNumber = 0;
+                        break;
+                }
+                $meta['popularimeter'] = [
+                    'email' => $ratingMail,
+                    'rating' => $ratingNumber,
+                    'data' => 0
+                ];
                 $id3 = new vainfo($this->file);
                 $id3->write_id3($meta);
                 Catalog::update_media_from_tags($this);

--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -253,7 +253,7 @@ class vainfo
 
             // Foreach what we've got
             foreach ($data as $key => $value) {
-                if ($key != 'APIC') {
+                if ($key != 'APIC' && $key != 'popularimeter') {
                     $TagData[$key][0] = $value;
                 }
             }
@@ -263,6 +263,11 @@ class vainfo
                 $TagData['attached_picture'][0]['picturetypeid'] = '3';
                 $TagData['attached_picture'][0]['description']   = 'Cover';
                 $TagData['attached_picture'][0]['mime']          = $data['APIC']['mime'];
+            }
+
+            // If popularimeter is available, pass them into ID3 writer
+            if (isset($data['popularimeter'])) {
+                $TagData['popularimeter'] = $data['popularimeter'];
             }
 
             $tagWriter->tag_data = $TagData;


### PR DESCRIPTION
In case of setting write_id3 is activated, the user rating will be written in popularimeter tag of a MP3 song.
For saving this rating the user mail address will be used. If no user mail address is available, the user@example.net mail address will be used.