### PR TITLE
Fix_Filenames: Error Opening Catalog

### DIFF
--- a/bin/fix_filenames.inc
+++ b/bin/fix_filenames.inc
@@ -68,7 +68,7 @@ $db_results = Dba::read($sql);
 
 while ($row = Dba::fetch_assoc($db_results)) {
 
-    $catalog = Catalog::create_from_id($row['0']);
+    $catalog = Catalog::create_from_id($row['id']);
     printf(T_('Checking %s (%s)'), $catalog->name, $catalog->path);
     echo "\n";
     charset_directory_correct($catalog->path);


### PR DESCRIPTION
When i ran bin/fix_filenames.inc by executing:
sudo -u wwwrun php fix_filenames.inc
i get:
Quellzeichensatz (UTF-8):                                                                                                    
Verwende UTF-8 als Quellzeichensatz                                                                                          
Prüfe  ()
Fehler: Fehler beim öffnen von 
Überprüfung der Dateinamen, auf passende Zeichen, fertig gestellt

Thats it. I guessed that fetch $row['0'] will look for column named '0' instead of column Number 0 which is named 'id'.
I changed it and it works.
So here is my Version for you to check.