### PR TITLE
Moving Song to new Album would not work when writing of Metadata is enabled

### DIFF
--- a/bin/fix_filenames.inc
+++ b/bin/fix_filenames.inc
@@ -68,7 +68,7 @@ $db_results = Dba::read($sql);
 
 while ($row = Dba::fetch_assoc($db_results)) {
 
-    $catalog = Catalog::create_from_id($row['0']);
+    $catalog = Catalog::create_from_id($row['id']);
     printf(T_('Checking %s (%s)'), $catalog->name, $catalog->path);
     echo "\n";
     charset_directory_correct($catalog->path);

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -1057,7 +1057,7 @@ class Song extends database_object implements media, library_item
                 //default fields back again, making it impossible to change e.g albumartist
                 //(albumartist will be overridden by custom metadatafield band which is the id3 field for albumartist, look at relations in get_metadata)
                 $meta = $this->get_metadata();
-                $id3 = new vainfo($this->file);
+                $id3  = new vainfo($this->file);
                 $id3->write_id3($meta);
                 Catalog::update_media_from_tags($this);
             }

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -1048,16 +1048,13 @@ class Song extends database_object implements media, library_item
             $catalog = Catalog::create_from_id($this->catalog);
             if ($catalog->get_type() == 'local') {
                 debug_event('song', 'Writing id3 metadata to file ' . $this->file, 5);
+                $meta = $this->get_metadata();
                 if (self::isCustomMetadataEnabled()) {
                     foreach ($this->getMetadata() as $metadata) {
                         $meta[$metadata->getField()->getName()] = $metadata->getData();
                     }
                 }
-                //17.11.2018 obel1x moved beneath customfields as they may overwrite
-                //default fields back again, making it impossible to change e.g albumartist
-                //(albumartist will be overridden by custom metadatafield band which is the id3 field for albumartist, look at relations in get_metadata)
-                $meta = $this->get_metadata();
-                $id3  = new vainfo($this->file);
+                $id3 = new vainfo($this->file);
                 $id3->write_id3($meta);
                 Catalog::update_media_from_tags($this);
             }

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -1048,12 +1048,15 @@ class Song extends database_object implements media, library_item
             $catalog = Catalog::create_from_id($this->catalog);
             if ($catalog->get_type() == 'local') {
                 debug_event('song', 'Writing id3 metadata to file ' . $this->file, 5);
-                $meta = $this->get_metadata();
                 if (self::isCustomMetadataEnabled()) {
                     foreach ($this->getMetadata() as $metadata) {
                         $meta[$metadata->getField()->getName()] = $metadata->getData();
                     }
                 }
+                //17.11.2018 obel1x moved beneath customfields as they may overwrite
+                //default fields back again, making it impossible to change e.g albumartist
+                //(albumartist will be overridden by custom metadatafield band which is the id3 field for albumartist, look at relations in get_metadata)
+                $meta = $this->get_metadata();
                 $id3 = new vainfo($this->file);
                 $id3->write_id3($meta);
                 Catalog::update_media_from_tags($this);

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -1029,6 +1029,10 @@ class Song extends database_object implements media, library_item
             } // end whitelist
         } // end foreach
 
+        //16.11.2018 without format, metafields like f_album_full wont be updated - contaning old names.
+        //When writing and re-reading tags is enabled, e.g. old albumid will be restored while name equals old name
+        $this->format();
+
         $this->write_id3();
 
         return $this->id;


### PR DESCRIPTION
As update-functions will only set db-ids to new value and will not change real names, the id3 tags will still be written with old names. When reading Tags afterwards, the changes are discarded. Added format() in between update of db.ids and writing prevents this.