### PR TITLE
Fix negative Year dba-error

### DIFF
--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -1574,6 +1574,9 @@ abstract class Catalog extends database_object
         $new_song->file        = $results['file'];
         $new_song->title       = $results['title'];
         $new_song->year        = $results['year'];
+        if ($new_song->year < 0) { //no year = -1 in most programs, but this leads to error in db-update statement
+            $new_song->year = 0;
+        }
         $new_song->comment     = $results['comment'];
         $new_song->language    = $results['language'];
         $new_song->lyrics      = str_replace(


### PR DESCRIPTION
Most mp3-tag- programs set Year = -1 for none given. This will lead to an error when reading tags and updating db after reading tags. This fix sets Year to 0 in this case.