### PR TITLE
Vainfo::clean_tag_info cleans year and disk

### DIFF
--- a/lib/class/album.class.php
+++ b/lib/class/album.class.php
@@ -400,10 +400,6 @@ class Album extends database_object implements library_item
         $mbid_group   = empty($mbid_group) ? null : $mbid_group;
         $release_type = empty($release_type) ? null : $release_type;
 
-        // Not even sure if these can be negative, but better safe than llama.
-        $year = Catalog::normalize_year($year);
-        $disk = abs(intval($disk));
-
         if (!$name) {
             $name         = T_('Unknown (Orphaned)');
             $year         = 0;

--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -362,9 +362,9 @@ class vainfo
             $info['original_name'] = $info['original_name'] ?: stripslashes(trim($tags['original_name']));
             $info['title']         = $info['title'] ?: stripslashes(trim($tags['title']));
 
-            $info['year'] = $info['year'] ?: intval($tags['year']);
-
-            $info['disk'] = $info['disk'] ?: intval($tags['disk']);
+            // Not even sure if these can be negative, but better safe than llama.
+            $info['year'] = Catalog::normalize_year($info['year'] ?: intval($tags['year']));
+            $info['disk'] = abs($info['disk'] ?: intval($tags['disk']));
 
             $info['totaldisks'] = $info['totaldisks'] ?: intval($tags['totaldisks']);
 


### PR DESCRIPTION
It may happen that Tag "Year" is not well formatted (e.g. containing -1), which would lead to DB-Error in updating the field when "Reading from Tags" is done. The cleaning routines of Album::Check were moved into this function to get this working.