### PR TITLE
Solution for issue 1600 (rework 1)

### DIFF
--- a/arts.php
+++ b/arts.php
@@ -150,7 +150,7 @@ switch ($_REQUEST['action']) {
         // Prevent the script from timing out
         set_time_limit(0);
 
-        $image = Art::get_from_source($_SESSION['form']['images'][$image_id], 'album');
+        $image = Art::get_from_source($_SESSION['form']['images'][$image_id], 'song');
         $mime  = $_SESSION['form']['images'][$image_id]['mime'];
 
         // Special case for albums, I'm not sure if we should keep it, remove it or find a generic way

--- a/image.php
+++ b/image.php
@@ -47,7 +47,7 @@ if (!AmpConfig::get('resize_images')) {
 
 // FIXME: Legacy stuff - should be removed after a version or so
 if (!isset($_GET['object_type'])) {
-    $_GET['object_type'] = 'album';
+    $_GET['object_type'] = 'song';
 }
 
 $type = $_GET['object_type'];

--- a/lib/class/art.class.php
+++ b/lib/class/art.class.php
@@ -784,7 +784,7 @@ class Art extends database_object
      * @param string $type
      * @return string|null
      */
-    public static function get_from_source($data, $type = 'album')
+    public static function get_from_source($data, $type = 'song')
     {
         // Already have the data, this often comes from id3tags
         if (isset($data['raw'])) {
@@ -1397,6 +1397,8 @@ class Art extends database_object
             $data = $this->gather_video_tags();
         } elseif ($this->type == 'album') {
             $data = $this->gather_song_tags($limit);
+        } elseif ($this->type == 'song') {
+            $data = $this->gather_song_tags_single($limit);
         } else {
             $data = array();
         }
@@ -1437,6 +1439,28 @@ class Art extends database_object
             if ($limit && count($data) >= $limit) {
                 return array_slice($data, 0, $limit);
             }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Gather tags from single song instead of full album
+     * (taken from function gather_song_tags with some changes)
+     * @param int $limit
+     * @return array
+     */
+    public function gather_song_tags_single($limit = 5)
+    {
+        // get song object directly from id, not by loop through album
+        $song = new Song($this->uid);
+
+        $data = array();
+
+        $data = array_merge($data, $this->gather_media_tags($song));
+
+        if ($limit && count($data) >= $limit) {
+            return array_slice($data, 0, $limit);
         }
 
         return $data;

--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -1288,9 +1288,11 @@ abstract class Catalog extends database_object
         if ($songs == null) {
             $searches['album']  = $this->get_album_ids();
             $searches['artist'] = $this->get_artist_ids();
+            $searches['song'] = $this->get_songs();
         } else {
             $searches['album']  = array();
             $searches['artist'] = array();
+            $searches['song']  = array();
             foreach ($songs as $song_id) {
                 $song = new Song($song_id);
                 if ($song->id) {
@@ -1299,6 +1301,9 @@ abstract class Catalog extends database_object
                     }
                     if (!in_array($song->artist, $searches['artist'])) {
                         $searches['artist'][] = $song->artist;
+                    }
+                    if (!in_array($song->id, $searches['song'])) {
+                        $searches['song'][] = $song->id;
                     }
                 }
             }

--- a/lib/class/stream_playlist.class.php
+++ b/lib/class/stream_playlist.class.php
@@ -183,7 +183,7 @@ class Stream_Playlist
                     $url['title']     = $object->title;
                     $url['author']    = $object->f_artist_full;
                     $url['info_url']  = $object->f_link;
-                    $url['image_url'] = Art::url($object->album, 'album', $api_session, (AmpConfig::get('ajax_load') ? 3 : 4));
+                    $url['image_url'] = Art::url($object->id, 'song', $api_session, (AmpConfig::get('ajax_load') ? 3 : 4));
                     $url['album']     = $object->f_album_full;
                     $url['track_num'] = $object->f_track;
                 break;

--- a/lib/class/subsonic_api.class.php
+++ b/lib/class/subsonic_api.class.php
@@ -1129,7 +1129,7 @@ class Subsonic_Api
                 // in most cases the song doesn't have a picture, but the album where it belongs to has
                 // if this is the case, we take the album art
                 $song = new Song(Subsonic_XML_Data::getAmpacheId(Subsonic_XML_Data::getAmpacheId($id)));
-                $art  = new Art(Subsonic_XML_Data::getAmpacheId($song->album), "album");
+                $art  = new Art(Subsonic_XML_Data::getAmpacheId($song->id), "song");
             }
         } elseif (Subsonic_XML_Data::isPodcast($id)) {
             $art = new Art(Subsonic_XML_Data::getAmpacheId($id), "podcast");

--- a/lib/class/subsonic_xml_data.class.php
+++ b/lib/class/subsonic_xml_data.class.php
@@ -533,7 +533,7 @@ class Subsonic_XML_Data
 //        $artist->format();
         $xsong->addAttribute('artistId', self::getArtistId($songData['artist']));
         $xsong->addAttribute('artist', self::checkName($artistData['f_full_name']));
-        $xsong->addAttribute('coverArt', self::getAlbumId($albumData['id']));
+        $xsong->addAttribute('coverArt', self::getSongId($songData['id']));
         $xsong->addAttribute('duration', $songData['time']);
         $xsong->addAttribute('bitRate', intval($songData['bitrate'] / 1000));
         if ($addAmpacheInfo) {

--- a/lib/class/xml_data.class.php
+++ b/lib/class/xml_data.class.php
@@ -498,7 +498,7 @@ class XML_Data
             $playlist_track_string = self::playlist_song_tracks_string($song, $playlist_data);
             $tag_string            = self::tags_string(Tag::get_top_tags('song', $song_id));
             $rating                = new Rating($song_id, 'song');
-            $art_url               = Art::url($song->album, 'album', $_REQUEST['auth']);
+            $art_url               = Art::url($song->id, 'song', $_REQUEST['auth']);
 
             $string .= "<song id=\"" . $song->id . "\">\n" .
                 // Title is an alias for name

--- a/server/search.ajax.php
+++ b/server/search.ajax.php
@@ -121,7 +121,7 @@ switch ($_REQUEST['action']) {
                     'label' => $song->f_title_full,
                     'value' => $song->f_title_full,
                     'rels' => $song->f_artist_full,
-                    'image' => Art::url($song->album, 'album', null, 10),
+                    'image' => Art::url($song->id, 'song', null, 10),
                 );
             }
         }

--- a/templates/show_now_playing_row.inc.php
+++ b/templates/show_now_playing_row.inc.php
@@ -64,10 +64,10 @@
 <div class="np_group" id="np_group_3">
   <div id="album_<?php echo $media->album ?>" class="np_cell cel_albumart libitem_menu">
       <?php
-      $album = new Album($media->album);
-        if ($album->id) {
-            $album->format();
-            $album->display_art(1);
+      $song = new Song($media->id);
+      if ($song->id) {
+          $song->format();
+          $song->display_art(1);
         } ?>
   </div>
 </div>

--- a/templates/show_now_playing_row.inc.php
+++ b/templates/show_now_playing_row.inc.php
@@ -65,9 +65,9 @@
   <div id="album_<?php echo $media->album ?>" class="np_cell cel_albumart libitem_menu">
       <?php
       $song = new Song($media->id);
-      if ($song->id) {
-          $song->format();
-          $song->display_art(1);
+        if ($song->id) {
+            $song->format();
+            $song->display_art(1);
         } ?>
   </div>
 </div>


### PR DESCRIPTION
Original discussion: [https://github.com/ampache/ampache/issues/1600](url)

I changed the gather_art routines so that images of id tags are stored per song in image table. Furthermore I changed (hopefully) all places where the album image is shown into the song image.
It works for the webplayer and subsonic API. I was not able to check XML API because it does not work in my environment. All other APIs are disabled, so I did not touch them.