### PR TITLE
Allow disabling stat recording from the play url

### DIFF
--- a/templates/header.inc.php
+++ b/templates/header.inc.php
@@ -216,7 +216,11 @@ $_SESSION['login'] = false;
         </script>
         <script type="text/javascript">
             var lastaction = new Date().getTime();
-            var refresh_slideshow_interval=<?php echo AmpConfig::get('slideshow_time'); ?>;
+            var refresh_slideshow_interval=<?php if (Preference::exists('flickr_api_key')) {
+            echo AmpConfig::get('slideshow_time');
+        } else {
+            echo 0;
+        } ?>;
             var iSlideshow = null;
             var tSlideshow = null;
             function init_slideshow_check()

--- a/templates/rightbar.inc.php
+++ b/templates/rightbar.inc.php
@@ -93,10 +93,20 @@
     }
 ?>
     <script type="text/javascript">
-            $("#content").removeClass("content-right-wild", 500);
-            $("#footer").removeClass("footer-wild", 500);
-            $("#rightbar").removeClass("hidden");
-            $("#rightbar").show("slow");
+        <?php if (count($objects) > 0 || (AmpConfig::get('play_type') == 'localplay')) {
+    ?>
+             $("#content").removeClass("content-right-wild", 500);
+             $("#footer").removeClass("footer-wild", 500);
+             $("#rightbar").removeClass("hidden");
+             $("#rightbar").show("slow");
+        <?php
+} else {
+        ?>
+            $("#content").addClass("content-right-wild", 500);
+            $("#footer").addClass("footer-wild", 500);
+            $("#rightbar").hide("slow");
+        <?php
+    } ?>
     </script>
 <?php
     // Limit the number of objects we show here


### PR DESCRIPTION
Don't record the stats for a playback if you're requesting a download/play with cache=1

Example URL:
```
https://ampache/play/index.php?ssid=1234&type=song&oid=7873&uid=20&player=api&name=Stan%20the%20Man.mp3&cache=1
```

This is to allow API clients to use the record_play method instead:
```
https://ampache/server/xml.server.php?action=record_play&auth=1234&version=350001&type=song&id=7873&user=20
```