### PR TITLE
generic_play_url should be passed a string

### DIFF
--- a/lib/class/podcast_episode.class.php
+++ b/lib/class/podcast_episode.class.php
@@ -357,7 +357,7 @@ class Podcast_Episode extends database_object implements media, library_item
      * @param boolean $local
      * @return string
      */
-    public static function play_url($oid, $additional_params = '', $player = null, $local = false)
+    public static function play_url($oid, $additional_params = '', $player = '', $local = false)
     {
         return Song::generic_play_url('podcast_episode', $oid, $additional_params, $player, $local);
     }

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -1818,7 +1818,7 @@ class Song extends database_object implements media, library_item
      * @param string $player
      * @return string
      */
-    public static function play_url($oid, $additional_params = '', $player = null, $local = false)
+    public static function play_url($oid, $additional_params = '', $player = '', $local = false)
     {
         return self::generic_play_url('song', $oid, $additional_params, $player, $local);
     }

--- a/lib/class/video.class.php
+++ b/lib/class/video.class.php
@@ -449,7 +449,7 @@ class Video extends database_object implements media, library_item
      * @param boolean $local
      * @return string
      */
-    public static function play_url($oid, $additional_params = '', $player = null, $local = false)
+    public static function play_url($oid, $additional_params = '', $player = '', $local = false)
     {
         return Song::generic_play_url('video', $oid, $additional_params, $player, $local);
     }


### PR DESCRIPTION
close #1959
play_url can be called with a null player and it should fall back to an empty string.