### PR TITLE
.tag_actions to show on hover of .tag_container

### DIFF
--- a/themes/reborn/templates/default.css
+++ b/themes/reborn/templates/default.css
@@ -174,7 +174,7 @@ input[type=button]:focus:active, input[type=submit]:focus:active {
 
 #ajax-loading {
     background-repeat: no-repeat;
-    background-position: right; 
+    background-position: right;
     display: none;
     font-size: 12px;
     left: 52px;
@@ -322,7 +322,7 @@ input[type=button]:focus:active, input[type=submit]:focus:active {
     width: 128px;
     height: 128px;
     background-repeat: no-repeat;
-    background-position: center; 
+    background-position: center;
     background-size: contain;
     margin: auto;
 }
@@ -1210,6 +1210,11 @@ span.fatalerror {
 
 .box-content #tag_filter .tag_actions {
     margin: 15px 0 0 -8px;
+    visibility: hidden;
+}
+
+.box-content #tag_filter .tag_container:hover .tag_actions {
+    visibility: visible;
 }
 
 .box-content #tag_filter .tag_button span {


### PR DESCRIPTION
I'd like to propose a change to the Tag Cloud page, so that the tag actions only show when you hover over the button container. When you have a lot of tags, the actions are pretty distracting and make it more difficult to read the tags.

![image](https://user-images.githubusercontent.com/17068090/61250515-8348fe80-a71d-11e9-943a-25cf1b390e02.png)

But, if we set the buttons to be hidden by default, the result is a much cleaner-looking interface:

![image](https://user-images.githubusercontent.com/17068090/61250578-a7a4db00-a71d-11e9-8fdf-a5963967f847.png)

Then, when you hover over a button its actions will show, allowing you to click on it as you would normally:

![image](https://user-images.githubusercontent.com/17068090/61250806-47626900-a71e-11e9-8965-1989ece24e1f.png)