### PR TITLE
Only show the "Video" header on the sidebar when there are videos

### DIFF
--- a/templates/show_search_form.inc.php
+++ b/templates/show_search_form.inc.php
@@ -40,7 +40,7 @@ UI::show_box_top(T_('Search Ampache') . "...", 'box box_advanced_search');
     } else {
         echo T_('Artists');
     } ?></td>
-    <?php if (AmpConfig::get('allow_video')) {
+    <?php if (AmpConfig::get('allow_video') && Video::get_item_count('Video')) {
         ?>
         <td><?php if ((string) filter_input(INPUT_GET, 'type', FILTER_SANITIZE_SPECIAL_CHARS) != 'video') {
             ?>

--- a/templates/show_stats.inc.php
+++ b/templates/show_stats.inc.php
@@ -33,7 +33,7 @@ $catalogs = Catalog::get_catalogs();
             <th><?php echo T_('Albums'); ?></th>
             <th><?php echo T_('Artists'); ?></th>
             <th><?php echo T_('Songs'); ?></th>
-            <?php if (AmpConfig::get('allow_video')) {
+            <?php if (AmpConfig::get('allow_video') && Video::get_item_count('Video')) {
     ?>
                 <th><?php echo T_('Videos'); ?></th>
             <?php
@@ -51,7 +51,7 @@ $catalogs = Catalog::get_catalogs();
             <td><?php echo $stats['albums']; ?></td>
             <td><?php echo $stats['artists']; ?></td>
             <td><?php echo $stats['songs']; ?></td>
-            <?php if (AmpConfig::get('allow_video')) {
+            <?php if (AmpConfig::get('allow_video') && Video::get_item_count('Video')) {
         ?>
                 <td><?php echo $stats['videos']; ?></td>
             <?php
@@ -83,7 +83,7 @@ $catalogs = Catalog::get_catalogs();
             <th class="cel_lastadd"><?php echo T_('Last Add'); ?></th>
             <th class="cel_lastclean"><?php echo T_('Last Clean'); ?></th>
             <th class="cel_songs"><?php echo T_('Songs'); ?></th>
-            <?php if (AmpConfig::get('allow_video')) {
+            <?php if (AmpConfig::get('allow_video') && Video::get_item_count('Video')) {
         ?>
             <th class="cel_video"><?php echo T_('Videos'); ?></th>
             <?php
@@ -104,7 +104,7 @@ $catalogs = Catalog::get_catalogs();
         <td class="cel_lastadd"><?php echo scrub_out($catalog->f_add); ?></td>
         <td class="cel_lastclean"><?php echo scrub_out($catalog->f_clean); ?></td>
         <td class="cel_songs"><?php echo scrub_out($stats['songs']); ?></td>
-            <?php if (AmpConfig::get('allow_video')) {
+            <?php if (AmpConfig::get('allow_video') && Video::get_item_count('Video')) {
             ?>
                 <td class="cel_video"><?php echo scrub_out($stats['videos']); ?></td>
             <?php

--- a/templates/show_stats_highest.inc.php
+++ b/templates/show_stats_highest.inc.php
@@ -41,7 +41,7 @@ $browse->set_simple_browse(true);
 $browse->show_objects();
 $browse->store();
 
-if (AmpConfig::get('allow_video')) {
+if (AmpConfig::get('allow_video') && Video::get_item_count('Video')) {
     $sql    = Rating::get_highest_sql('video');
     $browse = new Browse();
     $browse->set_type('video', $sql);

--- a/templates/show_stats_newest.inc.php
+++ b/templates/show_stats_newest.inc.php
@@ -34,7 +34,7 @@ $browse->set_simple_browse(true);
 $browse->show_objects();
 $browse->store();
 
-if (AmpConfig::get('allow_video')) {
+if (AmpConfig::get('allow_video') && Video::get_item_count('Video')) {
     $sql    = Stats::get_newest_sql('video');
     $browse = new Browse();
     $browse->set_type('video', $sql);

--- a/templates/show_stats_popular.inc.php
+++ b/templates/show_stats_popular.inc.php
@@ -49,7 +49,7 @@ $browse->set_simple_browse(true);
 $browse->show_objects();
 $browse->store();
 
-if (AmpConfig::get('allow_video')) {
+if (AmpConfig::get('allow_video') && Video::get_item_count('Video')) {
     $sql    = Stats::get_top_sql('video');
     $browse = new Browse();
     $browse->set_type('video', $sql);

--- a/templates/show_stats_recent.inc.php
+++ b/templates/show_stats_recent.inc.php
@@ -41,7 +41,7 @@ $browse->set_simple_browse(true);
 $browse->show_objects();
 $browse->store();
 
-if (AmpConfig::get('allow_video')) {
+if (AmpConfig::get('allow_video') && Video::get_item_count('Video')) {
     $sql    = Stats::get_recent_sql('video', $user_id);
     $browse = new Browse();
     $browse->set_type('video', $sql);

--- a/templates/show_stats_userflag.inc.php
+++ b/templates/show_stats_userflag.inc.php
@@ -41,7 +41,7 @@ $browse->set_simple_browse(true);
 $browse->show_objects();
 $browse->store();
 
-if (AmpConfig::get('allow_video')) {
+if (AmpConfig::get('allow_video') && Video::get_item_count('Video')) {
     $sql    = Userflag::get_latest_sql('video');
     $browse = new Browse();
     $browse->set_type('video', $sql);

--- a/templates/sidebar_home.inc.php
+++ b/templates/sidebar_home.inc.php
@@ -203,7 +203,7 @@
           <li id="sb_home_search_album"><a href="<?php echo $web_path; ?>/search.php?type=album"><?php echo T_('Albums'); ?></a></li>
           <li id="sb_home_search_artist"><a href="<?php echo $web_path; ?>/search.php?type=artist"><?php echo T_('Artists'); ?></a></li>
           <li id="sb_home_search_playlist"><a href="<?php echo $web_path; ?>/search.php?type=playlist"><?php echo T_('Playlists'); ?></a></li>
-          <?php if (AmpConfig::get('allow_video')) {
+          <?php if (AmpConfig::get('allow_video') && Video::get_item_count('Video')) {
         ?>
             <li id="sb_home_search_video"><a href="<?php echo $web_path ?>/search.php?type=video"><?php echo T_('Videos') ?></a></li>
           <?php

--- a/templates/sidebar_home.inc.php
+++ b/templates/sidebar_home.inc.php
@@ -91,11 +91,7 @@
                 <li id="sb_home_browse_video_video"><a href="<?php echo $web_path ?>/browse.php?action=personal_video"><?php echo T_('Personal Videos') ?></a></li>
           <?php
             } ?>
-          <?php if (Video::get_item_count('Video')) {
-                ?>
                 <li id="sb_home_browse_video_tagsVideo"><a href="<?php echo $web_path ?>/browse.php?action=tag&type=video"><?php echo T_('Tag Cloud') ?></a></li>
-          <?php
-            } ?>
             </ul>
         </li>
     <?php

--- a/templates/sidebar_home.inc.php
+++ b/templates/sidebar_home.inc.php
@@ -67,7 +67,7 @@
         } ?>
         </ul>
     </li>
-    <?php if (AmpConfig::get('allow_video')) {
+    <?php if (AmpConfig::get('allow_video') && Video::get_item_count('Video')) {
             ?>
         <li><h4 class="header"><span class="sidebar-header-title"><?php echo T_('Video') ?></span><img src="<?php echo AmpConfig::get('web_path') . AmpConfig::get('theme_path'); ?>/images/icons/icon_all.png" class="header-img <?php echo ($_COOKIE['sb_browse_video'] == 'collapsed') ? 'collapsed' : 'expanded'; ?>" id="browse_video" lt="<?php echo T_('Expand/Collapse'); ?>" title="<?php echo T_('Expand/Collapse'); ?>" /></h4>
             <ul class="sb3" id="sb_home_browse_video">


### PR DESCRIPTION
I think that the sidebar should only show the "Video" header on the sidebar when the user has a video catalog with videos in it.

If you have enabled video features in Ampache server settings, then you will get the "Video" section in the sidebar, even if you do not have any video catalogs. I don't think this makes any sense, as it distracts the user by cluttering the interface with something that appears relevant, but does nothing.

![image](https://user-images.githubusercontent.com/17068090/61315723-fb1e3400-a7c4-11e9-9030-621daf660c56.png)

This is a fairly simple fix, adding a check to see if there are any videos in the database before showing the heading.

Change with video:

![image](https://user-images.githubusercontent.com/17068090/61315892-636d1580-a7c5-11e9-8ab4-a70ac1e8834e.png)

Change without video:

![image](https://user-images.githubusercontent.com/17068090/61315949-7ed82080-a7c5-11e9-9d28-c9c9d76f3db6.png)
