### PR TITLE
Change position of "Play next" button

### DIFF
--- a/templates/show_song.inc.php
+++ b/templates/show_song.inc.php
@@ -68,14 +68,14 @@ $button_flip_state_id = 'button_flip_state_' . $song->id;
         <?php if (AmpConfig::get('directplay')) {
         ?>
             <?php echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $song->id, 'play', T_('Play'), 'play_song_' . $song->id); ?>
-            <?php if (Stream_Playlist::check_autoplay_append()) {
-            ?>
-                <?php echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $song->id . '&append=true', 'play_add', T_('Play last'), 'addplay_song_' . $song->id); ?>
-            <?php
-        } ?>
             <?php if (Stream_Playlist::check_autoplay_next()) {
             ?>
                 <?php echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $song->id . '&playnext=true', 'play_next', T_('Play next'), 'nextplay_song_' . $song->id); ?>
+            <?php
+        } ?>
+            <?php if (Stream_Playlist::check_autoplay_append()) {
+            ?>
+                <?php echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $song->id . '&append=true', 'play_add', T_('Play last'), 'addplay_song_' . $song->id); ?>
             <?php
         } ?>
             <?php echo $song->show_custom_play_actions(); ?>


### PR DESCRIPTION
In response to #2000. It makes sense to keep the order of the play buttons consistent across the interface.