### PR TITLE
Allow cells in Debug page to wrap long lines

### DIFF
--- a/themes/reborn/templates/default.css
+++ b/themes/reborn/templates/default.css
@@ -860,6 +860,10 @@ table.tabledata {
     margin-bottom: 20px;
 }
 
+.box_debug_tools table {
+    table-layout: fixed;
+}
+
 table.tabledata thead .th-top, table.tabledata tfoot .th-bottom {
     font-size: 12px;
 }
@@ -875,10 +879,9 @@ table.tabledata tfoot .th-bottom {
 
 table.tabledata td {
     vertical-align: middle;
-    white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis;
     padding: 3px 10px 3px 0;
+    word-wrap: break-word;
 }
 
 table.tabledata tr:hover, table.tabledata tr:focus {
@@ -1047,6 +1050,11 @@ table.disablegv td.cel_play, table.disablegv td.cel_add, table.disablegv td.cel_
 
 table.disablegv td.cel_rating {
     display: inline-block !important;
+}
+
+#col_php_setting,
+#col_configuration {
+    width: 20%;
 }
 
 /***********************************************

--- a/themes/reborn/templates/default.css
+++ b/themes/reborn/templates/default.css
@@ -219,7 +219,6 @@ input[type=button]:focus:active, input[type=submit]:focus:active {
 #header #headerlogo, #header #headerbox , #header .box_headerbox, #header .box-inside, #header .box-content {
     height: 100%;
     overflow: hidden;
-    display: inline-block;
 }
 
 #header #headerlogo {


### PR DESCRIPTION
Noticed on the Debug page, that if there is a really long line that it creates a scroll bar and pushes the width of the table larger than the page.

I think it should be okay to wrap very long lines so that it removes the scroll bar and keeps the page looking nice.