### PR TITLE
Fixed more occurences of play_next in wrong spot

### DIFF
--- a/templates/show_album_row.inc.php
+++ b/templates/show_album_row.inc.php
@@ -26,11 +26,11 @@
         <?php
             if ($show_direct_play) {
                 echo Ajax::button('?page=stream&action=directplay&object_type=album&' . $libitem->get_http_album_query_ids('object_id'), 'play', T_('Play'), 'play_album_' . $libitem->id);
+                if (Stream_Playlist::check_autoplay_next()) {
+                    echo Ajax::button('?page=stream&action=directplay&object_type=album&object_id=' . $libitem->id . '&playnext=true', 'play_next', T_('Play next'), 'nextplay_album_' . $libitem->id);
+                }
                 if (Stream_Playlist::check_autoplay_append()) {
                     echo Ajax::button('?page=stream&action=directplay&object_type=album&' . $libitem->get_http_album_query_ids('object_id') . '&append=true', 'play_add', T_('Play last'), 'addplay_album_' . $libitem->id);
-                    if (Stream_Playlist::check_autoplay_next()) {
-                        echo Ajax::button('?page=stream&action=directplay&object_type=album&object_id=' . $libitem->id . '&playnext=true', 'play_next', T_('Play next'), 'nextplay_album_' . $libitem->id);
-                    }
                 }
             }
         ?>

--- a/templates/show_artist_row.inc.php
+++ b/templates/show_artist_row.inc.php
@@ -26,11 +26,11 @@
     <?php
         if ($show_direct_play) {
             echo Ajax::button('?page=stream&action=directplay&object_type=artist&object_id=' . $libitem->id, 'play', T_('Play'), 'play_artist_' . $libitem->id);
+            if (Stream_Playlist::check_autoplay_next()) {
+                echo Ajax::button('?page=stream&action=directplay&object_type=artist&object_id=' . $libitem->id . '&playnext=true', 'play_next', T_('Play next'), 'nextplay_artist_' . $libitem->id);
+            }
             if (Stream_Playlist::check_autoplay_append()) {
                 echo Ajax::button('?page=stream&action=directplay&object_type=artist&object_id=' . $libitem->id . '&append=true', 'play_add', T_('Play last'), 'addplay_artist_' . $libitem->id);
-                if (Stream_Playlist::check_autoplay_next()) {
-                    echo Ajax::button('?page=stream&action=directplay&object_type=artist&object_id=' . $libitem->id . '&playnext=true', 'play_next', T_('Play next'), 'nextplay_artist_' . $libitem->id);
-                }
             }
         }
     ?>

--- a/templates/show_playlist_row.inc.php
+++ b/templates/show_playlist_row.inc.php
@@ -28,9 +28,9 @@
             echo Ajax::button('?page=stream&action=directplay&object_type=playlist&object_id=' . $libitem->id, 'play', T_('Play'), 'play_playlist_' . $libitem->id);
             if (Stream_Playlist::check_autoplay_next()) {
                 echo Ajax::button('?page=stream&action=directplay&object_type=playlist&object_id=' . $libitem->id . '&playnext=true', 'play_next', T_('Play next'), 'nextplay_playlist_' . $libitem->id);
-                if (Stream_Playlist::check_autoplay_append()) {
-                    echo Ajax::button('?page=stream&action=directplay&object_type=playlist&object_id=' . $libitem->id . '&append=true', 'play_add', T_('Play last'), 'addplay_playlist_' . $libitem->id);
-                }
+            }
+            if (Stream_Playlist::check_autoplay_append()) {
+                echo Ajax::button('?page=stream&action=directplay&object_type=playlist&object_id=' . $libitem->id . '&append=true', 'play_add', T_('Play last'), 'addplay_playlist_' . $libitem->id);
             }
         }
     ?>

--- a/templates/show_podcast_episode.inc.php
+++ b/templates/show_podcast_episode.inc.php
@@ -56,14 +56,14 @@
         <?php if (AmpConfig::get('directplay')) {
             ?>
             <?php echo Ajax::button('?page=stream&action=directplay&object_type=podcast_episode&object_id=' . $episode->id, 'play', T_('Play'), 'play_podcast_episode_' . $episode->id); ?>
-            <?php if (Stream_Playlist::check_autoplay_append()) {
-                ?>
-                <?php echo Ajax::button('?page=stream&action=directplay&object_type=podcast_episode&object_id=' . $episode->id . '&append=true', 'play_add', T_('Play last'), 'addplay_podcast_episode_' . $episode->id); ?>
-            <?php
-            } ?>
             <?php if (Stream_Playlist::check_autoplay_next()) {
                 ?>
                 <?php echo Ajax::button('?page=stream&action=directplay&object_type=podcast_episode&object_id=' . $episode->id . '&playnext=true', 'play_next', T_('Play next'), 'nextplay_podcast_episode_' . $episode->id); ?>
+            <?php
+            } ?>
+            <?php if (Stream_Playlist::check_autoplay_append()) {
+                ?>
+                <?php echo Ajax::button('?page=stream&action=directplay&object_type=podcast_episode&object_id=' . $episode->id . '&append=true', 'play_add', T_('Play last'), 'addplay_podcast_episode_' . $episode->id); ?>
             <?php
             } ?>
         <?php

--- a/templates/show_podcast_episode_row.inc.php
+++ b/templates/show_podcast_episode_row.inc.php
@@ -28,9 +28,9 @@
             echo Ajax::button('?page=stream&action=directplay&object_type=podcast_episode&object_id=' . $libitem->id, 'play', T_('Play'), 'play_podcast_episode_' . $libitem->id);
             if (Stream_Playlist::check_autoplay_next()) {
                 echo Ajax::button('?page=stream&action=directplay&object_type=podcast_episode&object_id=' . $libitem->id . '&playnext=true', 'play_next', T_('Play next'), 'nextplay_podcast_episode_' . $libitem->id);
-                if (Stream_Playlist::check_autoplay_append()) {
-                    echo Ajax::button('?page=stream&action=directplay&object_type=podcast_episode&object_id=' . $libitem->id . '&append=true', 'play_add', T_('Play last'), 'addplay_podcast_episode_' . $libitem->id);
-                }
+            }
+            if (Stream_Playlist::check_autoplay_append()) {
+                echo Ajax::button('?page=stream&action=directplay&object_type=podcast_episode&object_id=' . $libitem->id . '&append=true', 'play_add', T_('Play last'), 'addplay_podcast_episode_' . $libitem->id);
             }
         }
     ?>

--- a/templates/show_recently_played.inc.php
+++ b/templates/show_recently_played.inc.php
@@ -87,17 +87,21 @@ foreach ($data as $row) {
         <td class="cel_play">
             <span class="cel_play_content">&nbsp;</span>
             <div class="cel_play_hover">
-            <?php if (AmpConfig::get('directplay')) { ?>
+            <?php if (AmpConfig::get('directplay')) {
+        ?>
                 <?php echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $song->id, 'play', T_('Play'), 'play_song_' . $nb . '_' . $song->id); ?>
                 <?php if (Stream_Playlist::check_autoplay_next()) {
-                    ?>
+            ?>
                     <?php echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $song->id . '&playnext=true', 'play_next', T_('Play next'), 'nextplay_song_' . $nb . '_' . $song->id); ?>
-                <?php } ?>
+                <?php
+        } ?>
                 <?php if (Stream_Playlist::check_autoplay_append()) {
-                    ?>
+            ?>
                     <?php echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $song->id . '&append=true', 'play_add', T_('Play last'), 'addplay_song_' . $nb . '_' . $song->id); ?>
-                <?php } ?>
-            <?php } ?>
+                <?php
+        } ?>
+            <?php
+    } ?>
             </div>
         </td>
         <td class="cel_song"><?php echo $song->f_link; ?></td>

--- a/templates/show_recently_played.inc.php
+++ b/templates/show_recently_played.inc.php
@@ -87,21 +87,17 @@ foreach ($data as $row) {
         <td class="cel_play">
             <span class="cel_play_content">&nbsp;</span>
             <div class="cel_play_hover">
-            <?php if (AmpConfig::get('directplay')) {
-        ?>
+            <?php if (AmpConfig::get('directplay')) { ?>
                 <?php echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $song->id, 'play', T_('Play'), 'play_song_' . $nb . '_' . $song->id); ?>
-                <?php if (Stream_Playlist::check_autoplay_append()) {
-            ?>
-                    <?php echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $song->id . '&append=true', 'play_add', T_('Play last'), 'addplay_song_' . $nb . '_' . $song->id); ?>
-                <?php
-        } ?>
                 <?php if (Stream_Playlist::check_autoplay_next()) {
-            ?>
+                    ?>
                     <?php echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $song->id . '&playnext=true', 'play_next', T_('Play next'), 'nextplay_song_' . $nb . '_' . $song->id); ?>
-                <?php
-        } ?>
-        <?php
-    } ?>
+                <?php } ?>
+                <?php if (Stream_Playlist::check_autoplay_append()) {
+                    ?>
+                    <?php echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $song->id . '&append=true', 'play_add', T_('Play last'), 'addplay_song_' . $nb . '_' . $song->id); ?>
+                <?php } ?>
+            <?php } ?>
             </div>
         </td>
         <td class="cel_song"><?php echo $song->f_link; ?></td>

--- a/templates/show_song_row.inc.php
+++ b/templates/show_song_row.inc.php
@@ -36,9 +36,9 @@ if ($libitem->enabled || Access::check('interface', '50')) {
         echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $libitem->id, 'play', T_('Play'), 'play_song_' . $libitem->id);
         if (Stream_Playlist::check_autoplay_next()) {
             echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $libitem->id . '&playnext=true', 'play_next', T_('Play next'), 'nextplay_song_' . $libitem->id);
-            if (Stream_Playlist::check_autoplay_append()) {
-                echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $libitem->id . '&append=true', 'play_add', T_('Play last'), 'addplay_song_' . $libitem->id);
-            }
+        }
+        if (Stream_Playlist::check_autoplay_append()) {
+            echo Ajax::button('?page=stream&action=directplay&object_type=song&object_id=' . $libitem->id . '&append=true', 'play_add', T_('Play last'), 'addplay_song_' . $libitem->id);
         }
     } ?>
     </div>
@@ -80,7 +80,7 @@ if ($libitem->enabled || Access::check('interface', '50')) {
         if (AmpConfig::get('ratings')) {
             ?>
             <td class="cel_rating" id="rating_<?php echo $libitem->id; ?>_song">
-                <?php Rating::show($libitem->id, 'song') ?>  
+                <?php Rating::show($libitem->id, 'song') ?>
             </td>
     <?php
         }

--- a/templates/show_video_row.inc.php
+++ b/templates/show_video_row.inc.php
@@ -33,9 +33,9 @@ if (!isset($video_type)) {
             echo Ajax::button('?page=stream&action=directplay&object_type=video&object_id=' . $libitem->id, 'play', T_('Play'), 'play_video_' . $libitem->id);
             if (Stream_Playlist::check_autoplay_next()) {
                 echo Ajax::button('?page=stream&action=directplay&object_type=video&object_id=' . $libitem->id . '&playnext=true', 'play_next', T_('Play next'), 'nextplay_video_' . $libitem->id);
-                if (Stream_Playlist::check_autoplay_append()) {
-                    echo Ajax::button('?page=stream&action=directplay&object_type=video&object_id=' . $libitem->id . '&append=true', 'play_add', T_('Play last'), 'addplay_video_' . $libitem->id);
-                }
+            }
+            if (Stream_Playlist::check_autoplay_append()) {
+                echo Ajax::button('?page=stream&action=directplay&object_type=video&object_id=' . $libitem->id . '&append=true', 'play_add', T_('Play last'), 'addplay_video_' . $libitem->id);
             }
         }
     ?>


### PR DESCRIPTION
Looks like there were a couple more cases where play_next comes after play_last. Probably should have looked first time for #2000.

Also, for some reason and only in some cases was play_last nested within play_next (or visa-versa). So I took the liberty of just moving them out on their own, makes code look nicer and more consistent.