### PR TITLE
fixes to get_icon/image

### DIFF
--- a/lib/class/ui.class.php
+++ b/lib/class/ui.class.php
@@ -278,10 +278,10 @@ class UI
                 $svgicon->desc = $title;
             }
 
-            $id_attrib = ($id_attrib) ? $id_attrib : 'icon' ;
+            $id_attrib = ($id_attrib) ?? 'icon-' . $name ;
             $svgicon->addAttribute('id', $id_attrib);
 
-            $class_attrib = ($class_attrib) ? $class_attrib : 'icon' ;
+            $class_attrib = ($class_attrib) ?? 'icon' ;
             $svgicon->addAttribute('class', $class_attrib);
 
             $tag = explode("\n", $svgicon->asXML(), 2)[1];
@@ -374,10 +374,10 @@ class UI
                 $svgimage->desc = $title;
             }
 
-            $id_attrib = ($id_attrib) ? $id_attrib : 'icon' ;
+            $id_attrib = ($id_attrib) ?? 'image-' . $name ;
             $svgimage->addAttribute('id', $id_attrib);
 
-            $class_attrib = ($class_attrib) ? $class_attrib : 'icon' ;
+            $class_attrib = ($class_attrib) ?? 'image' ;
             $svgimage->addAttribute('class', $class_attrib);
 
             $tag = explode("\n", $svgimage->asXML(), 2)[1];

--- a/lib/class/ui.class.php
+++ b/lib/class/ui.class.php
@@ -278,10 +278,10 @@ class UI
                 $svgicon->desc = $title;
             }
 
-            $id_attrib = ($id_attrib) ?? 'icon-' . $name ;
+            $id_attrib = ($id_attrib) ?: 'icon-' . $name ;
             $svgicon->addAttribute('id', $id_attrib);
 
-            $class_attrib = ($class_attrib) ?? 'icon' ;
+            $class_attrib = ($class_attrib) ?: 'icon' ;
             $svgicon->addAttribute('class', $class_attrib);
 
             $tag = explode("\n", $svgicon->asXML(), 2)[1];
@@ -374,10 +374,10 @@ class UI
                 $svgimage->desc = $title;
             }
 
-            $id_attrib = ($id_attrib) ?? 'image-' . $name ;
+            $id_attrib = ($id_attrib) ?: 'image-' . $name ;
             $svgimage->addAttribute('id', $id_attrib);
 
-            $class_attrib = ($class_attrib) ?? 'image' ;
+            $class_attrib = ($class_attrib) ?: 'image' ;
             $svgimage->addAttribute('class', $class_attrib);
 
             $tag = explode("\n", $svgimage->asXML(), 2)[1];


### PR DESCRIPTION
Simplified the ternary operator, into a null coalescing operator. Also, changed the id attribute to default to "icon-$name" instead of "icon" as the class is already icon. Added the "icon-" prefix just in case there happens to be another element with the same id value. Then applied the same thing to get_image.