### PR TITLE
Add untranslated strings from HTML5 Player

### DIFF
--- a/modules/plugins/Flattr/Flattr.plugin.php
+++ b/modules/plugins/Flattr/Flattr.plugin.php
@@ -91,7 +91,7 @@ class AmpacheFlattr
         $name = ($libitem != null) ? $libitem->get_fullname() : (T_('User') . " `" . $this->user->fullname . "` " . T_('on') . " " . AmpConfig::get('site_title'));
         $link = ($libitem != null && $libitem->link) ? $libitem->link : $this->user->link;
 
-        echo "<a rel='nohtml' href='https://flattr.com/submit/auto?user_id=" . scrub_out($this->user_id) . "&url=" . rawurlencode($link) . "&category=audio&title=" . rawurlencode($name) . "' target='_blank'><img src='//button.flattr.com/flattr-badge-large.png' alt='Flattr this' title='Flattr this' border='0'></a>";
+        echo "<a rel='nohtml' href='https://flattr.com/submit/auto?user_id=" . scrub_out($this->user_id) . "&url=" . rawurlencode($link) . "&category=audio&title=" . rawurlencode($name) . "' target='_blank'><img src='//button.flattr.com/flattr-badge-large.png' alt='" . T_('Flattr this') . "' title='" . T_('Flattr this') . "' border='0'></a>";
     }
 
     /**

--- a/modules/plugins/Paypal/Paypal.plugin.php
+++ b/modules/plugins/Paypal/Paypal.plugin.php
@@ -105,7 +105,7 @@ class AmpachePaypal
         echo "<input type='hidden' name='no_note' value='0'>\n";
         echo "<input type='hidden' name='currency_code' value='" . scrub_out($this->currency_code) . "'>\n";
         echo "<input type='hidden' name='bn' value='PP-DonationsBF:btn_donate_SM.gif:NonHostedGuest'>\n";
-        echo "<input type='image' src='https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif' border='0' name='submit' alt='PayPal - The safer, easier way to pay online!'>\n";
+        echo "<input type='image' src='https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif' border='0' name='submit' alt='" . T_('PayPal - The safer, easier way to pay online!') . "'>\n";
         echo "<img alt= '' border='0' src='https://www.paypalobjects.com/fr_XC/i/scr/pixel.gif' width='1' height='1'>\n";
         echo "</form>\n";
     }

--- a/templates/error_page.inc.php
+++ b/templates/error_page.inc.php
@@ -40,7 +40,7 @@
     <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
         <div class="container">
             <a class="navbar-brand" href="#">
-                <img src="./images/ampache-dark.png" title="Ampache" alt="Ampache">
+                <img src="./images/ampache-dark.png" title="<?php echo T_('Ampache'); ?>" alt="<?php echo T_('Ampache'); ?>">
                 <?php echo T_('Ampache') . ' :: ' . T_('For the Love of Music'); ?>
             </a>
         </div>

--- a/templates/footer.inc.php
+++ b/templates/footer.inc.php
@@ -37,7 +37,7 @@
         <div id="footer" class="<?php echo(($count_temp_playlist || AmpConfig::get('play_type') == 'localplay') ? '' : 'footer-wild'); ?>">
         <?php if (AmpConfig::get('show_donate')) {
             ?>
-            <a id="donate" href="//ampache.github.io/donate.html" title="Donate" target="_blank"><?php echo T_('Donate'); ?></a> |
+            <a id="donate" href="//ampache.github.io/donate.html" title="<?php echo T_('Donate'); ?>" target="_blank"><?php echo T_('Donate'); ?></a> |
         <?php
         } ?>
         <?php
@@ -45,7 +45,7 @@
             echo AmpConfig::get('custom_text_footer');
         } else {
             ?>
-            <a id="ampache_link" href="https://github.com/ampache/ampache#readme" target="_blank" title="Copyright © 2001 - 2019 Ampache.org">Ampache <?php echo AmpConfig::get('version'); ?></a>
+            <a id="ampache_link" href="https://github.com/ampache/ampache#readme" target="_blank" title="<?php echo T_('Copyright'); ?> © 2001 - 2019 Ampache.org"><?php echo T_('Ampache') . ' ' . AmpConfig::get('version'); ?></a>
         <?php
         } ?>
         <?php if (AmpConfig::get('show_footer_statistics')) {

--- a/templates/install_header.inc.php
+++ b/templates/install_header.inc.php
@@ -49,7 +49,7 @@
     <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
         <div class="container">
             <a class="navbar-brand" href="#">
-                <img src="./images/ampache-dark.png" title="Ampache" alt="Ampache">
+                <img src="./images/ampache-dark.png" title="<?php echo T_('Ampache'); ?>" alt="<?php echo T_('Ampache'); ?>">
                 <?php echo T_('Ampache') . ' :: ' . T_('For the Love of Music') . ' - ' . T_('Installation'); ?>
             </a>
         </div>

--- a/templates/show_denied.inc.php
+++ b/templates/show_denied.inc.php
@@ -43,7 +43,7 @@ $web_path = AmpConfig::get('web_path');
         <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
             <div class="container">
                 <a class="navbar-brand" href="#">
-                    <img src="<?php echo $logo_url; ?>" title="Ampache" alt="Ampache">
+                    <img src="<?php echo $logo_url; ?>" title="<?php echo T_('Ampache'); ?>" alt="<?php echo T_('Ampache'); ?>">
                     <?php echo AmpConfig::get('site_title'); ?>
                 </a>
             </div>

--- a/templates/show_html5_player.inc.php
+++ b/templates/show_html5_player.inc.php
@@ -374,7 +374,7 @@ if (!$isVideo) {
 if ($isVideo) {
         ?>
         <div class="jp-video-play">
-            <a href="javascript:;" class="jp-video-play-icon" tabindex="1"><?php echo T_('Play'); ?></a>
+            <a href="javascript:;" class="jp-video-play-icon" tabindex="1" title="<?php echo T_('Play'); ?>"><?php echo T_('Play'); ?></a>
         </div>
 <?php
     } ?>
@@ -392,40 +392,40 @@ if ($isVideo) {
             <div class="jp-title"></div>
             <div class="jp-controls-holder">
                 <ul class="jp-controls">
-                    <li><a href="javascript:;" class="jp-previous" tabindex="1"><?php echo T_('Previous'); ?></a></li>
-                    <li><a href="javascript:;" class="jp-play" tabindex="1"><?php echo T_('Play'); ?></a></li>
-                    <li><a href="javascript:;" class="jp-pause" tabindex="1"><?php echo T_('Pause'); ?></a></li>
-                    <li><a href="javascript:;" class="jp-next" tabindex="1"><?php echo T_('Next'); ?></a></li>
-                    <li><a href="javascript:;" class="jp-stop" tabindex="1"><?php echo T_('Stop'); ?></a></li>
-                    <li><a href="javascript:;" class="jp-mute" tabindex="1" title="mute"><?php echo T_('Mute'); ?></a></li>
-                    <li><a href="javascript:;" class="jp-unmute" tabindex="1" title="unmute"><?php echo T_('Unmute'); ?></a></li>
-                    <li><a href="javascript:;" class="jp-volume-max" tabindex="1" title="max volume"><?php echo T_('Max Volume'); ?></a></li>
+                    <li><a href="javascript:;" class="jp-previous" tabindex="1" title="<?php echo T_('Previous'); ?>"><?php echo T_('Previous'); ?></a></li>
+                    <li><a href="javascript:;" class="jp-play" tabindex="1" title="<?php echo T_('Play'); ?>"><?php echo T_('Play'); ?></a></li>
+                    <li><a href="javascript:;" class="jp-pause" tabindex="1" title="<?php echo T_('Pause'); ?>"><?php echo T_('Pause'); ?></a></li>
+                    <li><a href="javascript:;" class="jp-next" tabindex="1" title="<?php echo T_('Next'); ?>"><?php echo T_('Next'); ?></a></li>
+                    <li><a href="javascript:;" class="jp-stop" tabindex="1" title="<?php echo T_('Stop'); ?>"><?php echo T_('Stop'); ?></a></li>
+                    <li><a href="javascript:;" class="jp-mute" tabindex="1" title="<?php echo T_('Mute'); ?>"><?php echo T_('Mute'); ?></a></li>
+                    <li><a href="javascript:;" class="jp-unmute" tabindex="1" title="<?php echo T_('Unmute'); ?>"><?php echo T_('Unmute'); ?></a></li>
+                    <li><a href="javascript:;" class="jp-volume-max" tabindex="1" title="<?php echo T_('Max Volume'); ?>"><?php echo T_('Max Volume'); ?></a></li>
                 </ul>
                 <div class="jp-volume-bar">
                     <div class="jp-volume-bar-value"></div>
                 </div>
 
                 <ul class="jp-toggles">
-                    <li><a href="javascript:;" class="jp-full-screen" tabindex="1" title="full screen"><?php echo T_('Full Screen'); ?></a></li>
-                    <li><a href="javascript:;" class="jp-restore-screen" tabindex="1" title="restore screen"><?php echo T_('Restore Screen'); ?></a></li>
-                    <li><a href="javascript:;" class="jp-shuffle" tabindex="1" title="shuffle"><?php echo T_('Shuffle'); ?></a></li>
-                    <li><a href="javascript:;" class="jp-shuffle-off" tabindex="1" title="shuffle off"><?php echo T_('Shuffle Off'); ?></a></li>
-                    <li><a href="javascript:;" class="jp-repeat" tabindex="1" title="repeat"><?php echo T_('Repeat'); ?></a></li>
-                    <li><a href="javascript:;" class="jp-repeat-off" tabindex="1" title="repeat off"><?php echo T_('Repeat Off'); ?></a></li>
+                    <li><a href="javascript:;" class="jp-full-screen" tabindex="1" title="<?php echo T_('Full Screen'); ?>"><?php echo T_('Full Screen'); ?></a></li>
+                    <li><a href="javascript:;" class="jp-restore-screen" tabindex="1" title="<?php echo T_('Restore Screen'); ?>"><?php echo T_('Restore Screen'); ?></a></li>
+                    <li><a href="javascript:;" class="jp-shuffle" tabindex="1" title="<?php echo T_('Shuffle'); ?>"><?php echo T_('Shuffle'); ?></a></li>
+                    <li><a href="javascript:;" class="jp-shuffle-off" tabindex="1" title="<?php echo T_('Shuffle Off'); ?>"><?php echo T_('Shuffle Off'); ?></a></li>
+                    <li><a href="javascript:;" class="jp-repeat" tabindex="1" title="<?php echo T_('Repeat'); ?>"><?php echo T_('Repeat'); ?></a></li>
+                    <li><a href="javascript:;" class="jp-repeat-off" tabindex="1" title="<?php echo T_('Repeat Off'); ?>"><?php echo T_('Repeat Off'); ?></a></li>
                 </ul>
             </div>
 <?php
     } else {
         ?>
             <ul class="jp-controls">
-              <li><a href="javascript:;" class="jp-previous" tabindex="1"><?php echo T_('Previous'); ?></a></li>
-              <li><a href="javascript:;" class="jp-play" tabindex="1"><?php echo T_('Play'); ?></a></li>
-              <li><a href="javascript:;" class="jp-pause" tabindex="1"><?php echo T_('Pause'); ?></a></li>
-              <li><a href="javascript:;" class="jp-next" tabindex="1"><?php echo T_('Next'); ?></a></li>
-              <li><a href="javascript:;" class="jp-stop" tabindex="1"><?php echo T_('Stop'); ?></a></li>
-              <li><a href="javascript:;" class="jp-mute" tabindex="1" title="mute"><?php echo T_('Mute'); ?></a></li>
-              <li><a href="javascript:;" class="jp-unmute" tabindex="1" title="unmute"><?php echo T_('Unmute'); ?></a></li>
-              <li><a href="javascript:;" class="jp-volume-max" tabindex="1" title="max volume"><?php echo T_('Max Volume'); ?></a></li>
+              <li><a href="javascript:;" class="jp-previous" tabindex="1" title="<?php echo T_('Previous'); ?>"><?php echo T_('Previous'); ?></a></li>
+              <li><a href="javascript:;" class="jp-play" tabindex="1" title="<?php echo T_('Play'); ?>"><?php echo T_('Play'); ?></a></li>
+              <li><a href="javascript:;" class="jp-pause" tabindex="1" title="<?php echo T_('Pause'); ?>"><?php echo T_('Pause'); ?></a></li>
+              <li><a href="javascript:;" class="jp-next" tabindex="1" title="<?php echo T_('Next'); ?>"><?php echo T_('Next'); ?></a></li>
+              <li><a href="javascript:;" class="jp-stop" tabindex="1" title="<?php echo T_('Stop'); ?>"><?php echo T_('Stop'); ?></a></li>
+              <li><a href="javascript:;" class="jp-mute" tabindex="1" title="<?php echo T_('Mute'); ?>"><?php echo T_('Mute'); ?></a></li>
+              <li><a href="javascript:;" class="jp-unmute" tabindex="1" title="<?php echo T_('Unmute'); ?>"><?php echo T_('Unmute'); ?></a></li>
+              <li><a href="javascript:;" class="jp-volume-max" tabindex="1" title="<?php echo T_('Max Volume'); ?>"><?php echo T_('Max Volume'); ?></a></li>
             </ul>
             <div class="jp-progress">
               <div class="jp-seek-bar">
@@ -438,10 +438,10 @@ if ($isVideo) {
             <div class="jp-current-time"></div>
             <div class="jp-duration"></div>
             <ul class="jp-toggles">
-                <li><a href="javascript:;" class="jp-shuffle" tabindex="1" title="shuffle"><?php echo T_('Shuffle'); ?></a></li>
-                <li><a href="javascript:;" class="jp-shuffle-off" tabindex="1" title="shuffle off"><?php echo T_('Shuffle Off'); ?></a></li>
-                <li><a href="javascript:;" class="jp-repeat" tabindex="1" title="repeat"><?php echo T_('Repeat'); ?></a></li>
-                <li><a href="javascript:;" class="jp-repeat-off" tabindex="1" title="repeat off"><?php echo T_('Repeat Off'); ?></a></li>
+                <li><a href="javascript:;" class="jp-shuffle" tabindex="1" title="<?php echo T_('Shuffle'); ?>"><?php echo T_('Shuffle'); ?></a></li>
+                <li><a href="javascript:;" class="jp-shuffle-off" tabindex="1" title="<?php echo T_('Shuffle Off'); ?>"><?php echo T_('Shuffle Off'); ?></a></li>
+                <li><a href="javascript:;" class="jp-repeat" tabindex="1" title="<?php echo T_('Repeat'); ?>"><?php echo T_('Repeat'); ?></a></li>
+                <li><a href="javascript:;" class="jp-repeat-off" tabindex="1" title="<?php echo T_('Repeat Off'); ?>"><?php echo T_('Repeat Off'); ?></a></li>
             </ul>
 <?php if (AmpConfig::get('waveform') && !$is_share) {
             ?>

--- a/templates/show_install_lang.inc.php
+++ b/templates/show_install_lang.inc.php
@@ -24,7 +24,7 @@ require $prefix . '/templates/install_header.inc.php';
 ?>
         <!-- Main jumbotron for a primary marketing message or call to action -->
         <div class="jumbotron">
-            <h1 id="headerlogo"><img src="./images/ampache.png" title="Ampache" alt="Ampache"></h1>
+            <h1 id="headerlogo"><img src="./images/ampache.png" title="<?php echo T_('Ampache'); ?>" alt="<?php echo T_('Ampache'); ?>"></h1>
         </div>
         <div class="page-header">
             <h1><?php echo T_('Choose Installation Language'); ?></h1>

--- a/templates/show_mail_users.inc.php
+++ b/templates/show_mail_users.inc.php
@@ -28,10 +28,10 @@
             <td><?php echo T_('Mail to'); ?>:</td>
             <td>
                 <select name="to">
-                    <option value="all" title="Mail Everyone"><?php echo T_('All'); ?></option>
-                    <option value="users" title="Mail Users"><?php echo T_('User'); ?></option>
-                    <option value="admins" title="Mail Admins"><?php echo T_('Admin'); ?></option>
-                    <option value="inactive" title="Mail Inactive Users"><?php echo T_('Inactive Users'); ?>&nbsp;</option>
+                    <option value="all" title="<?php echo T_('Mail Everyone'); ?>"><?php echo T_('All'); ?></option>
+                    <option value="users" title="<?php echo T_('Mail Users'); ?>"><?php echo T_('User'); ?></option>
+                    <option value="admins" title="<?php echo T_('Mail Admins'); ?>"><?php echo T_('Admin'); ?></option>
+                    <option value="inactive" title="<?php echo T_('Mail Inactive Users'); ?>"><?php echo T_('Inactive Users'); ?>&nbsp;</option>
                 </select>
             </td>
         </tr>
@@ -39,8 +39,8 @@
             <td><?php echo T_('From'); ?>:</td>
             <td>
                 <select name="from">
-                    <option value="self" title="Self"><?php echo T_('Yourself'); ?></option>
-                    <option value="system" title="System"><?php echo T_('Ampache'); ?></option>
+                    <option value="self" title="<?php echo T_('Self'); ?>"><?php echo T_('Yourself'); ?></option>
+                    <option value="system" title="<?php echo T_('System'); ?>"><?php echo T_('Ampache'); ?></option>
                 </select>
             </td>
         </tr>

--- a/templates/show_test.inc.php
+++ b/templates/show_test.inc.php
@@ -35,7 +35,7 @@
         <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
             <div class="container">
                 <a class="navbar-brand" href="#">
-                    <img src="<?php echo UI::get_logo_url('dark'); ?>" title="Ampache" alt="Ampache">
+                    <img src="<?php echo UI::get_logo_url('dark'); ?>" title="<?php echo T_('Ampache'); ?>" alt="<?php echo T_('Ampache'); ?>">
                     <?php echo T_('Ampache') . ' :: ' . T_('For the Love of Music'); ?>
                 </a>
             </div>

--- a/templates/show_test_config.inc.php
+++ b/templates/show_test_config.inc.php
@@ -35,7 +35,7 @@
         <div class="navbar navbar-inverse" role="navigation">
             <div class="container">
                 <a class="navbar-brand" href="#">
-                    <img src="./images/ampache-dark.png" title="Ampache" alt="Ampache">
+                    <img src="./images/ampache-dark.png" title="<?php echo T_('Ampache'); ?>" alt="<?php echo T_('Ampache'); ?>">
                     <?php echo T_('Ampache') . ' :: ' . T_('For the Love of Music'); ?>
                 </a>
             </div>

--- a/templates/test_error_page.inc.php
+++ b/templates/test_error_page.inc.php
@@ -39,7 +39,7 @@
     <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
         <div class="container">
             <a class="navbar-brand" href="#">
-                <img src="<?php echo UI::get_logo_url('dark'); ?>" title="Ampache" alt="Ampache">
+                <img src="<?php echo UI::get_logo_url('dark'); ?>" title="<?php echo T_('Ampache'); ?>" alt="<?php echo T_('Ampache'); ?>">
                 <?php echo T_('Ampache') . ' :: ' . T_('For the Love of Music') . ' - ' . T_('Installation'); ?>
             </a>
         </div>

--- a/update.php
+++ b/update.php
@@ -71,7 +71,7 @@ $htmllang = str_replace("_", "-", AmpConfig::get('lang'));
     <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
         <div class="container">
             <a class="navbar-brand" href="#">
-                <img src="<?php echo UI::get_logo_url('dark'); ?>" title="Ampache" alt="Ampache">
+                <img src="<?php echo UI::get_logo_url('dark'); ?>" title="<?php echo T_('Ampache'); ?>" alt="<?php echo T_('Ampache'); ?>">
                 <?php echo T_('Ampache') . ' :: ' . T_('For the Love of Music') . ' - ' . T_('Installation'); ?>
             </a>
         </div>


### PR DESCRIPTION
Noticed a bunch of untranslated strings from the player. Technically, with Reborn they are not shown in the interface, but for accessibility reasons (using a screen reader in another language) and for custom themes that might show the text I think it's important to have these translated.