### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,11 @@
-# Issue Template
+---
+name: Bug report
+about: Help Ampache improve by submitting an issue.
+title: ''
+labels: ''
+assignees: ''
+
+---
 
 <!--
 1. Delete any section that is not relevant in this template.
@@ -26,7 +33,7 @@ Steps to reproduce the behavior:
 
 ## Environment
 
-* Ampache version:
+* Ampache version: 
 * Web server + version:
 * Server operating system:
 * Client operating system:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest a new feature for Ampache
+title: "[Feature Request]"
+labels: ''
+assignees: ''
+
+---
+
+<!-- Before submitting a feature request, make sure to search to see if it's already been suggested.
+
+Please be as descriptive as you can be about your feature. No request is too big or too small and if it make sense, there is a good chance it will be approved and make it into Ampache. However, there is no guarantee on the time-frame.
+
+The quickest way for a feature to make it into Ampache, is for you to submit a pull request yourself! -->
+
+**Describe what you don't like about Ampache, or what it is missing**
+
+
+**Describe how you would like the feature to work**


### PR DESCRIPTION
Github has a new method of storing issue templates, so I changed the existing one, and added one for feature requests. These show up in the GUI as options to choose from, so it makes it look a bit nicer and its easier to use. Also, I re-ordered the sections, as I thought it would be nicer if the issue was at the very top, with all the supporting details underneath, so you don't have to scroll so much in some cases with large logs/configs before getting to the issue itself.

![image](https://user-images.githubusercontent.com/17068090/65901287-81d2be00-e37d-11e9-9d44-de7049b58e71.png)
