### PR TITLE
Add last_count to search table

### DIFF
--- a/lib/class/search.class.php
+++ b/lib/class/search.class.php
@@ -1131,7 +1131,7 @@ class Search extends playlist_object
      * set_last_count
      *
      * Returns the name of the saved search corresponding to the given ID
-     * @param integer $search count
+     * @param integer $count
      */
     private function set_last_count($count)
     {

--- a/lib/class/search.class.php
+++ b/lib/class/search.class.php
@@ -1138,7 +1138,6 @@ class Search extends playlist_object
     {
         $sql = "Update `search` SET `last_count`=" . $count . " WHERE `id`=" . $this->id;
         Dba::write($sql);
-
     }
 
     /**

--- a/lib/class/search.class.php
+++ b/lib/class/search.class.php
@@ -1122,7 +1122,7 @@ class Search extends playlist_object
                 'object_type' => $this->searchtype
             );
         }
-        self::set_last_count(count($results));
+        $this->set_last_count(count($results));
 
         return $results;
     }

--- a/lib/class/search.class.php
+++ b/lib/class/search.class.php
@@ -1122,8 +1122,22 @@ class Search extends playlist_object
                 'object_type' => $this->searchtype
             );
         }
+        self::set_last_count(count($results));
 
         return $results;
+    }
+
+    /**
+     * set_last_count
+     *
+     * Returns the name of the saved search corresponding to the given ID
+     * @param integer $search count
+     */
+    private function set_last_count($count)
+    {
+        $sql = "Update `search` SET `last_count`=". $count . " WHERE `id`=" . $this->id;
+        Dba::write($sql);
+
     }
 
     /**

--- a/lib/class/search.class.php
+++ b/lib/class/search.class.php
@@ -1135,7 +1135,7 @@ class Search extends playlist_object
      */
     private function set_last_count($count)
     {
-        $sql = "Update `search` SET `last_count`=". $count . " WHERE `id`=" . $this->id;
+        $sql = "Update `search` SET `last_count`=" . $count . " WHERE `id`=" . $this->id;
         Dba::write($sql);
 
     }

--- a/lib/class/search.class.php
+++ b/lib/class/search.class.php
@@ -33,6 +33,7 @@ class Search extends playlist_object
     public $type           = 'public';
     public $random         = false;
     public $limit          = 0;
+    public $last_count     = 0;
 
     public $basetypes;
     public $types;

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -1926,7 +1926,7 @@ class Song extends database_object implements media, library_item
         $media_name = preg_replace("/[^a-zA-Z0-9\. ]+/", "-", $media_name);
         $media_name = rawurlencode($media_name);
 
-        $url = Stream::get_base_url($local) . "type=" . $object_type . "&oid=" . $object_id . "&uid=" . $uid . $additional_params;
+        $url = Stream::get_base_url($local) . "type=" . $object_type . "&oid=" . $object_id . "&uid=" . (string) $uid . $additional_params;
         if ($player !== '') {
             $url .= "&player=" . $player;
         }

--- a/lib/class/update.class.php
+++ b/lib/class/update.class.php
@@ -1031,7 +1031,7 @@ class Update
     public static function update_400005()
     {
         $retval = true;
-        $sql    = "ALTER TABLE `search` ADD `last_count` INT(1) NULL;";
+        $sql    = "ALTER TABLE `search` ADD `last_count` INT(11) NULL;";
         $retval &= Dba::write($sql);
 
         return $retval;

--- a/lib/class/update.class.php
+++ b/lib/class/update.class.php
@@ -186,6 +186,7 @@ class Update
 
         $update_string = "* Add a last_count to search table to speed up access requests<br />";
         $version[]     = array('version' => '400005', 'description' => $update_string);
+
         return $version;
     }
 

--- a/lib/class/update.class.php
+++ b/lib/class/update.class.php
@@ -184,6 +184,8 @@ class Update
         $update_string = "* Delete upload_user_artist database settings<br />";
         $version[]     = array('version' => '400004', 'description' => $update_string);
 
+        $update_string = "* Add a last_count to search table to speed up access requests<br />";
+        $version[]     = array('version' => '400005', 'description' => $update_string);
         return $version;
     }
 
@@ -1016,6 +1018,19 @@ class Update
 
         $sql = "DELETE FROM `preference` " .
                "WHERE `preference`.`name` = 'upload_user_artist';";
+        $retval &= Dba::write($sql);
+
+        return $retval;
+    }
+    /**
+     * update_400005
+     *
+     * Add a last_count to searches to speed up access requests
+     */
+    public static function update_400005()
+    {
+        $retval = true;
+        $sql    = "ALTER TABLE `search` ADD `last_count` INT(1) NULL;";
         $retval &= Dba::write($sql);
 
         return $retval;

--- a/lib/class/xml_data.class.php
+++ b/lib/class/xml_data.class.php
@@ -678,7 +678,8 @@ class XML_Data
                 } else {
                     $playlist_user  = $playlist->type;
                 }
-                $playitem_total = ($playlist->limit == 0) ? 5000 : $playlist->limit;
+                $last_count     = ((int) $playlist->last_count > 0) ? $playlist->last_count : 5000;
+                $playitem_total = ($playlist->limit == 0) ? $last_count : $playlist->limit;
                 $playlist_type  = $playlist->type;
             }
             // Build this element


### PR DESCRIPTION
Set the count when you get_items for a search allowing you to use a more relevant total instead of an arbitrary limit.