### PR TITLE
Support returning a response in JSON format if the subsonic api method does not exist

### DIFF
--- a/rest/index.php
+++ b/rest/index.php
@@ -172,4 +172,4 @@ foreach ($methods as $method) {
 
 // If we manage to get here, we still need to hand out an XML document
 ob_end_clean();
-echo Subsonic_XML_Data::createError(Subsonic_XML_Data::SSERROR_DATA_NOTFOUND, 'subsonic_api', $version)->asXml();
+Subsonic_Api::apiOutput2($f, Subsonic_XML_Data::createError(Subsonic_XML_Data::SSERROR_DATA_NOTFOUND, 'subsonic_api', $version), $callback);


### PR DESCRIPTION
The Subsonic API allows to ask for a given format of the response with parameter f. However if the method does not exist the server ignores the parameter f (in this case JSON):
$ curl "https://ampache.server/rest/NonExistingMethod.view?v=1.8.0&c=curl&u=user&p=enc:xxx&f=json"
<?xml version="1.0" encoding="UTF-8"?>
<subsonic-response xmlns="http://subsonic.org/restapi" status="failed" version="1.13.0"><error code="70" message="subsonic_api"/></subsonic-response>

After this commit the answer looks like this:
$ curl "https://ampache.server/rest/NonExistingMethod.view?v=1.8.0&c=curl&u=user&p=enc:xxx&f=json"
{
    "subsonic-response": {
        "status": "failed",
        "version": "1.13.0",
        "error": {
            "code": 70,
            "message": "subsonic_api"
        }
    }
}