### PR TITLE
Fix the retrieval of art from musicbrainz.

### DIFF
--- a/lib/class/art.class.php
+++ b/lib/class/art.class.php
@@ -1120,6 +1120,9 @@ class Art extends database_object
                     case 'gather_google':
                         $data = $this->{$method_name}($limit, $options);
                     break;
+                    case 'gather_musicbrainz':
+                        $data = $this->{$method_name}($limit, $options);
+                    break;
                     default:
                         $data = $this->{$method_name}($limit);
                     break;
@@ -1179,8 +1182,8 @@ class Art extends database_object
             return $images;
         }
 
-        if ($data['mbid']) {
-            debug_event('art.class', "gather_musicbrainz Album MBID: " . $data['mbid'], 5);
+        if ($data['mb_albumid']) {
+            debug_event('art.class', "gather_musicbrainz Album MBID: " . $data['mb_albumid'], 5);
         } else {
             return $images;
         }
@@ -1190,7 +1193,7 @@ class Art extends database_object
             'url-rels'
         );
         try {
-            $release = $mb->lookup('release', $data['mbid'], $includes);
+            $release = $mb->lookup('release', $data['mb_albumid'], $includes);
         } catch (Exception $error) {
             debug_event('art.class', "gather_musicbrainz exception: " . $error, 3);
 


### PR DESCRIPTION
Two issues have been fixed:
1) The gather_musicbrainz() method didn't get the album data
2) The key used to retrieve the musicbrainz ID was wrongly "mbid",
   whereas the correct is "mb_albumid"

Before the fix the log would show:
Method used: gather_musicbrainz
Method used: gather_lastfm

After the fix:
2020-01-09 00:14:22 [admin] (art.class) -> Method used: gather_musicbrainz 
2020-01-09 00:14:22 [admin] (art.class) -> gather_musicbrainz Album MBID: e7e6caa2-fd69-309a-b684-57cf8cc8b23b 
2020-01-09 00:14:24 [admin] (art.class) -> gather_musicbrainz Found ASIN: B0000089DH 
2020-01-09 00:14:24 [admin] (art.class) -> gather_musicbrainz Evaluating Amazon URL: http://ec1.images-amazon.com/images/P/B0000089DH.01.LZZZZZZZ.jpg 
2020-01-09 00:14:24 [admin] (art.class) -> gather_musicbrainz Amazon URL added: http://ec1.images-amazon.com/images/P/B0000089DH.01.LZZZZZZZ.jpg 
2020-01-09 00:14:24 [admin] (art.class) -> Method used: gather_lastfm 
