### PR TITLE
Fixed GROUP BY error in artist.class get_albums

### DIFF
--- a/lib/class/artist.class.php
+++ b/lib/class/artist.class.php
@@ -307,7 +307,8 @@ class Artist extends database_object implements library_item
                 $sql_sort = '`album`.`name` DESC' . $sort_disk;
                 break;
             default:
-                $sql_sort  = '`album`.`name`, `album`.`disk`, `album`.`year`';
+		$sql_sort  = '`album`.`name`, `album`.`disk`, `album`.`year`';
+		$sort_disk = ', `album`.`disk`';
         }
 
         $sql = "SELECT `album`.`id`, `album`.`release_type`, `album`.`mbid` FROM `album` LEFT JOIN `song` ON `song`.`album`=`album`.`id` $catalog_join " .
@@ -315,7 +316,7 @@ class Artist extends database_object implements library_item
 
         if (AmpConfig::get('album_group')) {
             $sql = "SELECT MAX(`album`.`id`) AS `id`, `album`.`release_type`, `album`.`mbid` FROM `album` LEFT JOIN `song` ON `song`.`album`=`album`.`id` $catalog_join " .
-                    "WHERE (`song`.`artist`='$this->id' OR `album`.`album_artist`='$this->id') $catalog_where GROUP BY `album`.`prefix`, `album`.`name`, `album`.`album_artist`, `album`.`release_type`, `album`.`mbid`, `album`.`year` ORDER BY $sql_sort"; //TODO mysql8 test
+                    "WHERE (`song`.`artist`='$this->id' OR `album`.`album_artist`='$this->id') $catalog_where GROUP BY `album`.`prefix`, `album`.`name`, `album`.`album_artist`, `album`.`release_type`, `album`.`mbid`, `album`.`year` $sort_disk ORDER BY $sql_sort";
         }
         //debug_event('artist.class', 'get_albums ' . $sql, 5);
 

--- a/lib/class/artist.class.php
+++ b/lib/class/artist.class.php
@@ -305,10 +305,9 @@ class Artist extends database_object implements library_item
                 break;
             case 'name_desc':
                 $sql_sort = '`album`.`name` DESC' . $sort_disk;
-                break;
+		break;
             default:
-                $sql_sort  = '`album`.`name`, `album`.`disk`, `album`.`year`';
-                $sort_disk = ', `album`.`disk`';
+                $sql_sort  = '`album`.`name`' . $sort_disk . ', `album`.`year`';
         }
 
         $sql = "SELECT `album`.`id`, `album`.`release_type`, `album`.`mbid` FROM `album` LEFT JOIN `song` ON `song`.`album`=`album`.`id` $catalog_join " .
@@ -316,7 +315,7 @@ class Artist extends database_object implements library_item
 
         if (AmpConfig::get('album_group')) {
             $sql = "SELECT MAX(`album`.`id`) AS `id`, `album`.`release_type`, `album`.`mbid` FROM `album` LEFT JOIN `song` ON `song`.`album`=`album`.`id` $catalog_join " .
-                    "WHERE (`song`.`artist`='$this->id' OR `album`.`album_artist`='$this->id') $catalog_where GROUP BY `album`.`prefix`, `album`.`name`, `album`.`album_artist`, `album`.`release_type`, `album`.`mbid`, `album`.`year` $sort_disk ORDER BY $sql_sort";
+                    "WHERE (`song`.`artist`='$this->id' OR `album`.`album_artist`='$this->id') $catalog_where GROUP BY `album`.`prefix`, `album`.`name`, `album`.`album_artist`, `album`.`release_type`, `album`.`mbid`, `album`.`year` ORDER BY $sql_sort";
         }
         //debug_event('artist.class', 'get_albums ' . $sql, 5);
 

--- a/lib/class/artist.class.php
+++ b/lib/class/artist.class.php
@@ -305,7 +305,7 @@ class Artist extends database_object implements library_item
                 break;
             case 'name_desc':
                 $sql_sort = '`album`.`name` DESC' . $sort_disk;
-		break;
+                break;
             default:
                 $sql_sort  = '`album`.`name`' . $sort_disk . ', `album`.`year`';
         }

--- a/lib/class/artist.class.php
+++ b/lib/class/artist.class.php
@@ -307,8 +307,8 @@ class Artist extends database_object implements library_item
                 $sql_sort = '`album`.`name` DESC' . $sort_disk;
                 break;
             default:
-		$sql_sort  = '`album`.`name`, `album`.`disk`, `album`.`year`';
-		$sort_disk = ', `album`.`disk`';
+                $sql_sort  = '`album`.`name`, `album`.`disk`, `album`.`year`';
+                $sort_disk = ', `album`.`disk`';
         }
 
         $sql = "SELECT `album`.`id`, `album`.`release_type`, `album`.`mbid` FROM `album` LEFT JOIN `song` ON `song`.`album`=`album`.`id` $catalog_join " .

--- a/lib/class/query.class.php
+++ b/lib/class/query.class.php
@@ -2350,8 +2350,10 @@ class Query
             $group_sql = " GROUP BY `" . $this->get_type() . '`.`id`';
             $order_sql = " ORDER BY ";
 
-            foreach ($this->_state['sort'] as $key => $value) {
-                $order_sql .= $this->sql_sort($key, $value);
+	    foreach ($this->_state['sort'] as $key => $value) {
+              $sql_sort = $this->sql_sort($key, $value);
+              $order_sql .= $sql_sort;
+              $group_sql .= ", " . substr($sql_sort, 0, strpos($sql_sort, " "));
             }
             // Clean her up
             $order_sql = rtrim((string) $order_sql, "ORDER BY ");

--- a/lib/class/query.class.php
+++ b/lib/class/query.class.php
@@ -2350,7 +2350,7 @@ class Query
             $group_sql = " GROUP BY `" . $this->get_type() . '`.`id`';
             $order_sql = " ORDER BY ";
 
-	    foreach ($this->_state['sort'] as $key => $value) {
+            foreach ($this->_state['sort'] as $key => $value) {
               $sql_sort = $this->sql_sort($key, $value);
               $order_sql .= $sql_sort;
               $group_sql .= ", " . substr($sql_sort, 0, strpos($sql_sort, " "));

--- a/lib/class/query.class.php
+++ b/lib/class/query.class.php
@@ -2351,9 +2351,9 @@ class Query
             $order_sql = " ORDER BY ";
 
             foreach ($this->_state['sort'] as $key => $value) {
-              $sql_sort = $this->sql_sort($key, $value);
-              $order_sql .= $sql_sort;
-              $group_sql .= ", " . substr($sql_sort, 0, strpos($sql_sort, " "));
+                $sql_sort = $this->sql_sort($key, $value);
+                $order_sql .= $sql_sort;
+                $group_sql .= ", " . substr($sql_sort, 0, strpos($sql_sort, " "));
             }
             // Clean her up
             $order_sql = rtrim((string) $order_sql, "ORDER BY ");


### PR DESCRIPTION
Hi @lachlan-00,

when using the current develop version I experienced an empty album list on the artist page. In the debug log the following error occurs:

` 2020-01-16 21:36:40 [xyz] (dba.class) -> Error_query SQL: SELECT MAX(``album``.``id``) AS ``id``, ``album``.``release_type``, ``album``.``mbid`` FROM ``album`` LEFT JOIN ``song`` ON ``song``.``album``=``album``.``id`` LEFT JOIN ``catalog`` ON ``catalog``.``id`` = ``song``.``catalog`` WHERE (``song``.``artist``='1234' OR ``album``.``album_artist``='1234')  GROUP BY ``album``.``prefix``, ``album``.``name``, ``album``.``album_artist``, ``album``.``release_type``, ``album``.``mbid``, ``album``.``year``  ORDER BY ``album``.``name``, ``album``.``disk``, ``album``.``year``
2020-01-16 21:36:40 [xyz] (dba.class) -> Error_query MSG: ["42000",1055,"Expression #2 of ORDER BY clause is not in GROUP BY clause and contains nonaggregated column 'ampache.album.disk' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by"] `

This error is independent of the used MySQL version (7.x or 8) and depends on the used sql_mode=only_full_group_by.

Please validate the provided fix and merge if it is ok for you.

Br