### PR TITLE
Read vorbis rating tag

### DIFF
--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -846,6 +846,9 @@ class vainfo
                 case 'catalognumber':
                     $parsed['catalog_number'] = $data[0];
                     break;
+                case 'rating':
+                    $parsed['rating'][-1] = floor($data[0] * 5 / 100);
+                    break;
                 default:
                     $parsed[$tag] = $data[0];
                 break;


### PR DESCRIPTION
Vorbis files currently do not load the rating from the metadata correctly. This is because `$parsed['rating']` is expected to be an dictionary of ratings (0-5) for each user ID, but the Vorbis comment code does not know how to handle this. It simply sets `$parsed['rating']` directly to the Vorbis "RATING" tag value, without creating a dictionary nor scaling.

This pull request fixes this so that if there is a Vorbis "RATING" tag, it will be interpreted as a percentage, scaled and used for the rating tag for the super user (ID -1). This is the similar behaviour to the IDv3 POPM rating when the user in the tag is unknown, where it also defaults to the super user (ID -1).

The exact format of the rating tag used here (i.e. a percentage from 0-100) is the same as described in https://en.wikipedia.org/wiki/Vorbis_comment and used by MusicBee. The change has been tested on my personal Ampache instance and MusicBee-managed library, and it correctly grabs the ratings.

For reference, the scaling is done by truncating, so:
- 0-19 = 0 stars
- 20-39 = 1 star
- 40-59 = 2 stars
- 60-79 = 3 stars
- 80-99 = 4 stars
- 100 = 5 stars