### PR TITLE
Add Skipping functionality

### DIFF
--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -7,7 +7,7 @@
 ; if this config file is up to date
 ; this is compared against a value hard-coded
 ; into the init script
-config_version = 40
+config_version = 41
 
 ; Allow you to hard code a default git branch for Ampache
 ; If you set this value the inbuilt updater will use this branch for updates.

--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -395,6 +395,15 @@ default_auth_level = "guest"
 ; DEFAULT: true
 ratings = "true"
 
+; Skip Timer Threshold
+; This allows custom times to decide when a track is skipped
+; Allows an integer to denote seconds, or a float to denote percentage
+; POSSIBLE VALUES:
+; 20  = 20 seconds.
+; 0.3 = 30%
+; DEFAULT: 20
+;skip_timer = 20
+
 ; Enable filtering on browse pages for artists and albums.
 ; If you enable this setting the get_random and browse pages
 ; will remove artists and albums that are <= to that rating

--- a/lib/class/channel.class.php
+++ b/lib/class/channel.class.php
@@ -709,7 +709,7 @@ class Channel extends database_object implements media, library_item
         // Do nothing
     }
 
-    public function check_play_history($user)
+    public function check_play_history($user, $agent)
     {
         unset($user);
         // Do nothing

--- a/lib/class/channel.class.php
+++ b/lib/class/channel.class.php
@@ -711,7 +711,7 @@ class Channel extends database_object implements media, library_item
 
     public function check_play_history($user, $agent)
     {
-        unset($user);
+        unset($user, $agent);
         // Do nothing
     }
 

--- a/lib/class/live_stream.class.php
+++ b/lib/class/live_stream.class.php
@@ -387,7 +387,7 @@ class Live_Stream extends database_object implements media, library_item
 
     public function check_play_history($user, $agent)
     {
-        unset($user);
+        unset($user, $agent);
         // Do nothing
     }
 } // end live_stream.class

--- a/lib/class/live_stream.class.php
+++ b/lib/class/live_stream.class.php
@@ -385,7 +385,7 @@ class Live_Stream extends database_object implements media, library_item
         // Do nothing
     }
 
-    public function check_play_history($user)
+    public function check_play_history($user, $agent)
     {
         unset($user);
         // Do nothing

--- a/lib/class/media.interface.php
+++ b/lib/class/media.interface.php
@@ -63,5 +63,5 @@ interface media
 
     public function set_played($user, $agent, $location);
 
-    public function check_play_history($user);
+    public function check_play_history($user, $agent);
 } // end media.interface

--- a/lib/class/podcast_episode.class.php
+++ b/lib/class/podcast_episode.class.php
@@ -285,7 +285,7 @@ class Podcast_Episode extends database_object implements media, library_item
         return true;
     } // set_played
 
-    public function check_play_history($user)
+    public function check_play_history($user, $agent)
     {
         unset($user);
         // Do nothing

--- a/lib/class/podcast_episode.class.php
+++ b/lib/class/podcast_episode.class.php
@@ -287,7 +287,7 @@ class Podcast_Episode extends database_object implements media, library_item
 
     public function check_play_history($user, $agent)
     {
-        unset($user);
+        unset($user, $agent);
         // Do nothing
     }
 

--- a/lib/class/preference.class.php
+++ b/lib/class/preference.class.php
@@ -433,7 +433,7 @@ class Preference extends database_object
                     'access_control', 'require_localnet_session',
                     'downsample_remote', 'track_user_ip',
                     'xml_rpc', 'allow_zip_download', 'ratings',
-                    'shoutbox', 'resize_images',
+                    'shoutbox', 'resize_images', 'show_played_times', 'show_skipped_times',
                     'show_album_art', 'allow_public_registration',
                     'captcha_public_reg', 'admin_notify_reg',
                     'use_rss', 'download', 'force_http_play', 'cookie_secure',

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -1016,16 +1016,12 @@ class Song extends database_object implements media, library_item
             return false;
         }
 
-        $timekeeper = 0.1;
-
-        if ($timekeeper > 1) {
+        $timekeeper = AmpConfig::get('skip_timer');
+        $skiptime   = 20;
+        if ((int) $timekeeper > 1) {
             $skiptime = $timekeeper;
         } elseif ($timekeeper < 1 && $timekeeper > 0) {
-            $skiptime = intval($previous["time"] * $timekeeper);
-        } else {
-            debug_event('song.class', $timekeeper . ' for the timekeeper value is an invalid option. Choose another one. There will be no playcount update.', 3);
-
-            return false;
+            $skiptime = (int) ($previous['time'] * $timekeeper);
         }
 
         // when the difference between recordings is too short, the song has been skipped, so note that

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -519,6 +519,7 @@ class Song extends database_object implements media, library_item
         while ($row = Dba::fetch_assoc($db_results)) {
             if (AmpConfig::get('show_played_times')) {
                 $row['object_cnt'] = Stats::get_object_count('song', $row['id'], $limit_threshold);
+                $row['skip_cnt'] = Stats::get_object_count('song', $row['id'], $limit_threshold, $count_type = 'skip');
             }
             parent::add_to_cache('song', $row['id'], $row);
             $artists[$row['artist']] = $row['artist'];
@@ -578,6 +579,7 @@ class Song extends database_object implements media, library_item
         if (isset($results['id'])) {
             if (AmpConfig::get('show_played_times')) {
                 $results['object_cnt'] = Stats::get_object_count('song', $results['id'], $limit_threshold);
+                $results['skip_cnt'] = Stats::get_object_count('song', $results['id'], $limit_threshold, $count_type='skip');
             }
 
             parent::add_to_cache('song', $id, $results);
@@ -1038,7 +1040,7 @@ class Song extends database_object implements media, library_item
         // Remove some stuff we don't care about as this function only needs to check song information.
         unset($song->catalog, $song->played, $song->enabled, $song->addition_time, $song->update_time, $song->type);
         $string_array = array('title', 'comment', 'lyrics', 'composer', 'tags', 'artist', 'album');
-        $skip_array   = array('id', 'tag_id', 'mime', 'mbid', 'waveform', 'object_cnt', 'albumartist', 'artist_mbid', 'album_mbid', 'albumartist_mbid', 'mb_albumid_group');
+        $skip_array   = array('id', 'tag_id', 'mime', 'mbid', 'waveform', 'object_cnt', 'skip_cnt', 'albumartist', 'artist_mbid', 'album_mbid', 'albumartist_mbid', 'mb_albumid_group');
 
         return self::compare_media_information($song, $new_song, $string_array, $skip_array);
     } // compare_song_information

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -1016,8 +1016,19 @@ class Song extends database_object implements media, library_item
             return false;
         }
 
-        // try to keep a difference between recording stats but also allowing short songs
-        if ($diff < 20 && !$this->time < 20) {
+        $timekeeper = 0.1;
+
+        if ($timekeeper > 1) {
+            $skiptime = $timekeeper;
+        } elseif ($timekeeper < 1) {
+            $skiptime = intval($previous["time"] * $timekeeper);
+        } else {
+            debug_event('song.class', $timekeeper . ' for the timekeeper value is an invalid option. Choose another one. There will be no playcount update.', 3);
+            return false;
+        }
+
+        // when the difference between recordings is too short, the song has been skipped, so note that
+        if ($diff < $skiptime && !$previous["time"] < $skiptime) {
             debug_event('song.class', 'Last song played within ' . $diff . ' seconds, skipping ' . $previous['id'], 3);
             Stats::skip_last_song($previous['id']);
             Useractivity::del_activity($previous['id']);

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -519,7 +519,7 @@ class Song extends database_object implements media, library_item
         while ($row = Dba::fetch_assoc($db_results)) {
             if (AmpConfig::get('show_played_times')) {
                 $row['object_cnt'] = Stats::get_object_count('song', $row['id'], $limit_threshold);
-                $row['skip_cnt'] = Stats::get_object_count('song', $row['id'], $limit_threshold, $count_type = 'skip');
+                $row['skip_cnt']   = Stats::get_object_count('song', $row['id'], $limit_threshold, $count_type = 'skip');
             }
             parent::add_to_cache('song', $row['id'], $row);
             $artists[$row['artist']] = $row['artist'];
@@ -579,7 +579,7 @@ class Song extends database_object implements media, library_item
         if (isset($results['id'])) {
             if (AmpConfig::get('show_played_times')) {
                 $results['object_cnt'] = Stats::get_object_count('song', $results['id'], $limit_threshold);
-                $results['skip_cnt'] = Stats::get_object_count('song', $results['id'], $limit_threshold, $count_type='skip');
+                $results['skip_cnt']   = Stats::get_object_count('song', $results['id'], $limit_threshold, $count_type='skip');
             }
 
             parent::add_to_cache('song', $id, $results);
@@ -1024,6 +1024,7 @@ class Song extends database_object implements media, library_item
             $skiptime = intval($previous["time"] * $timekeeper);
         } else {
             debug_event('song.class', $timekeeper . ' for the timekeeper value is an invalid option. Choose another one. There will be no playcount update.', 3);
+
             return false;
         }
 

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -999,7 +999,7 @@ class Song extends database_object implements media, library_item
      * @param string $agent
      * @return boolean
      */
-    public function check_play_history($user, $agent='')
+    public function check_play_history($user, $agent)
     {
         if ($user == -1) {
             return false;
@@ -1016,9 +1016,8 @@ class Song extends database_object implements media, library_item
 
         // try to keep a difference between recording stats but also allowing short songs
         if ($diff < 20 && !$this->time < 20) {
-            debug_event('song.class', 'Last song played within ' . $diff . ' seconds, not recording stats', 3);
-            Stats::set_to_skipped($previous['id']);
-            return false;
+            debug_event('song.class', 'Last song played within ' . $diff . ' seconds, skipping ' . $previous['id'], 3);
+            Stats::skip_last_song($previous['id']);
         }
 
         return true;

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -1020,6 +1020,7 @@ class Song extends database_object implements media, library_item
         if ($diff < 20 && !$this->time < 20) {
             debug_event('song.class', 'Last song played within ' . $diff . ' seconds, skipping ' . $previous['id'], 3);
             Stats::skip_last_song($previous['id']);
+            Useractivity::del_activity($previous['id']);
         }
 
         return true;

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -519,7 +519,7 @@ class Song extends database_object implements media, library_item
         while ($row = Dba::fetch_assoc($db_results)) {
             if (AmpConfig::get('show_played_times')) {
                 $row['object_cnt'] = Stats::get_object_count('song', $row['id'], $limit_threshold);
-                $row['skip_cnt']   = Stats::get_object_count('song', $row['id'], $limit_threshold, $count_type = 'skip');
+                $row['skip_cnt']   = Stats::get_object_count('song', $row['id'], $limit_threshold, 'skip');
             }
             parent::add_to_cache('song', $row['id'], $row);
             $artists[$row['artist']] = $row['artist'];
@@ -579,7 +579,7 @@ class Song extends database_object implements media, library_item
         if (isset($results['id'])) {
             if (AmpConfig::get('show_played_times')) {
                 $results['object_cnt'] = Stats::get_object_count('song', $results['id'], $limit_threshold);
-                $results['skip_cnt']   = Stats::get_object_count('song', $results['id'], $limit_threshold, $count_type='skip');
+                $results['skip_cnt']   = Stats::get_object_count('song', $results['id'], $limit_threshold, 'skip');
             }
 
             parent::add_to_cache('song', $id, $results);

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -1020,7 +1020,7 @@ class Song extends database_object implements media, library_item
 
         if ($timekeeper > 1) {
             $skiptime = $timekeeper;
-        } elseif ($timekeeper < 1) {
+        } elseif ($timekeeper < 1 && $timekeeper > 0) {
             $skiptime = intval($previous["time"] * $timekeeper);
         } else {
             debug_event('song.class', $timekeeper . ' for the timekeeper value is an invalid option. Choose another one. There will be no playcount update.', 3);

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -519,6 +519,8 @@ class Song extends database_object implements media, library_item
         while ($row = Dba::fetch_assoc($db_results)) {
             if (AmpConfig::get('show_played_times')) {
                 $row['object_cnt'] = Stats::get_object_count('song', $row['id'], $limit_threshold);
+            }
+            if (AmpConfig::get('show_skipped_times')) {
                 $row['skip_cnt']   = Stats::get_object_count('song', $row['id'], $limit_threshold, 'skip');
             }
             parent::add_to_cache('song', $row['id'], $row);
@@ -579,6 +581,8 @@ class Song extends database_object implements media, library_item
         if (isset($results['id'])) {
             if (AmpConfig::get('show_played_times')) {
                 $results['object_cnt'] = Stats::get_object_count('song', $results['id'], $limit_threshold);
+            }
+            if (AmpConfig::get('show_skipped_times')) {
                 $results['skip_cnt']   = Stats::get_object_count('song', $results['id'], $limit_threshold, 'skip');
             }
 

--- a/lib/class/song_preview.class.php
+++ b/lib/class/song_preview.class.php
@@ -344,7 +344,7 @@ class Song_Preview extends database_object implements media, playable_item
 
     public function check_play_history($user, $agent)
     {
-        unset($user);
+        unset($user, $agent);
         // Do nothing
     }
 

--- a/lib/class/song_preview.class.php
+++ b/lib/class/song_preview.class.php
@@ -342,7 +342,7 @@ class Song_Preview extends database_object implements media, playable_item
         // Do nothing
     }
 
-    public function check_play_history($user)
+    public function check_play_history($user, $agent)
     {
         unset($user);
         // Do nothing

--- a/lib/class/stats.class.php
+++ b/lib/class/stats.class.php
@@ -239,7 +239,7 @@ class Stats
         if (AmpConfig::get('catalog_disable')) {
             $sql .= "LEFT JOIN `catalog` ON `catalog`.`id` = `song`.`catalog` ";
         }
-        $sql .= "WHERE `object_count`.`user` = ? AND `object_count`.`object_type`='song' AND `object_count`.`count_type`='stream' ";
+        $sql .= "WHERE `object_count`.`user` = ? AND `object_count`.`object_type`='song' AND `object_count`.`count_type` IN ('stream', 'skip') ";
         if (AmpConfig::get('catalog_disable')) {
             $sql .= "AND `catalog`.`enabled` = '1' ";
         }
@@ -256,14 +256,17 @@ class Stats
     } // get_last_song
 
     /**
-     * set_to_skipped
+     * skip_last_song
      * this sets the object_counts count type to skipped
      * Gets called when the next song is played in quick succession
+     * 
+     * @param integer $object_id
      */
-    public static function set_to_skipped($id)
+    public static function skip_last_song($object_id)
     {
-        $sql = "UPDATE `object_count` SET `count_type` = 'skipped' WHERE `object_count`.`id` = ?";
-        $db_results = Dba::read($sql, array($id));
+        $sql = "UPDATE `object_count` SET `count_type` = 'skip' WHERE `object_count`.`object_id` = ? ORDER BY `object_count`.`date` DESC LIMIT 1";
+
+        return Dba::write($sql, array($object_id));
     }
 
 

--- a/lib/class/stats.class.php
+++ b/lib/class/stats.class.php
@@ -259,21 +259,22 @@ class Stats
      * skip_last_song
      * this sets the object_counts count type to skipped
      * Gets called when the next song is played in quick succession
-     * 
+     *
      * @param integer $object_id
      */
     public static function skip_last_song($object_id)
     {
-        $sql = "UPDATE `object_count` SET `count_type` = 'skip' WHERE `object_id` = ? ORDER BY `date` DESC LIMIT 1";
+        $sql        = "UPDATE `object_count` SET `count_type` = 'skip' WHERE `object_id` = ? ORDER BY `date` DESC LIMIT 1";
         $db_results = Dba::write($sql, array($object_id));
         
         //Now the just updated skipped value is taken
-        $sql = "SELECT * FROM `object_count` WHERE `count_type` = 'skip' ORDER BY `object_count`.`date` DESC LIMIT 1";
+        $sql        = "SELECT * FROM `object_count` WHERE `count_type` = 'skip' ORDER BY `object_count`.`date` DESC LIMIT 1";
         $db_results = Dba::write($sql, array());
-        $skipped = Dba::fetch_assoc($db_results);
+        $skipped    = Dba::fetch_assoc($db_results);
         
         //To remove associated album and artist entries
         $sql = "DELETE FROM `object_count` WHERE (`object_type` = 'album' OR `object_type` = 'artist') AND `agent` = ? AND `date` BETWEEN ? AND ?";
+
         return Dba::write($sql, array($skipped['agent'], $skipped['date'] - 2, $skipped['date'] + 2));
     }
 

--- a/lib/class/stats.class.php
+++ b/lib/class/stats.class.php
@@ -264,9 +264,17 @@ class Stats
      */
     public static function skip_last_song($object_id)
     {
-        $sql = "UPDATE `object_count` SET `count_type` = 'skip' WHERE `object_count`.`object_id` = ? ORDER BY `object_count`.`date` DESC LIMIT 1";
-
-        return Dba::write($sql, array($object_id));
+        $sql = "UPDATE `object_count` SET `count_type` = 'skip' WHERE `object_id` = ? ORDER BY `date` DESC LIMIT 1";
+        $db_results = Dba::write($sql, array($object_id));
+        
+        //Now the just updated skipped value is taken
+        $sql = "SELECT * FROM `object_count` WHERE `count_type` = 'skip' ORDER BY `object_count`.`date` DESC LIMIT 1";
+        $db_results = Dba::write($sql, array());
+        $skipped = Dba::fetch_assoc($db_results);
+        
+        //To remove associated album and artist entries
+        $sql = "DELETE FROM `object_count` WHERE (`object_type` = 'album' OR `object_type` = 'artist') AND `agent` = ? AND `date` BETWEEN ? AND ?";
+        return Dba::write($sql, array($skipped['agent'], $skipped['date'] - 2, $skipped['date'] + 2));
     }
 
 

--- a/lib/class/stats.class.php
+++ b/lib/class/stats.class.php
@@ -273,9 +273,9 @@ class Stats
         $skipped    = Dba::fetch_assoc($db_results);
         
         //To remove associated album and artist entries
-        $sql = "DELETE FROM `object_count` WHERE (`object_type` = 'album' OR `object_type` = 'artist') AND `agent` = ? AND `date` BETWEEN ? AND ?";
+        $sql = "DELETE FROM `object_count` WHERE (`object_type` = 'album' OR `object_type` = 'artist') AND `agent` = ? AND `date` = ?";
 
-        return Dba::write($sql, array($skipped['agent'], $skipped['date'] - 2, $skipped['date'] + 2));
+        return Dba::write($sql, array($skipped['agent'], $skipped['date']));
     }
 
 

--- a/lib/class/subsonic_api.class.php
+++ b/lib/class/subsonic_api.class.php
@@ -2243,9 +2243,10 @@ class Subsonic_Api
         $current  = (int) $input['current'];
         $position = (int) $input['position'];
         $username = (string) $input['u'];
+        $client   = (string) $input['c'];
         $user_id  = User::get_from_username($username)->id;
         $song_id  = Subsonic_XML_Data::getAmpacheId($current);
-        $previous = Stats::get_last_song($user_id);
+        $previous = Stats::get_last_song($user_id, $client);
         $song     = new Song($song_id);
         //only record repeated play stats using this method (repeates aren't processed the same way.)
         if ($previous['object_id'] == $song_id && $position == 0 && $song->id && !stats::is_already_inserted('song', $song->id, $user_id, 'stream', time(), $song->time)) {

--- a/lib/class/subsonic_api.class.php
+++ b/lib/class/subsonic_api.class.php
@@ -1793,7 +1793,6 @@ class Subsonic_Api
             $oid   = $rid;
         }
 
-        $counter = 0;
         foreach ($oid as $object) {
             $aid   = Subsonic_XML_Data::getAmpacheId($object);
             $type  = Subsonic_XML_Data::getAmpacheType($object);

--- a/lib/class/subsonic_api.class.php
+++ b/lib/class/subsonic_api.class.php
@@ -1800,11 +1800,6 @@ class Subsonic_Api
             $media = new $type($aid);
             $media->format();
 
-            // internal scrobbling (user_activity and object_count tables)
-            if (($submission === 'true' || $submission === '1') && $counter == 0) {
-                $media->set_played($user->id, $input['c'], array(), time());
-                $counter++;
-            }
             //scrobble plugins
             if ($submission === 'true' || $submission === '1') {
                 // stream has finished
@@ -1815,6 +1810,8 @@ class Subsonic_Api
                 debug_event('subsonic_api.class', 'now_playing: ' . $media->id . ' for ' . $user->username . ' using ' . $input['c'] . ' ' . (string) $time, 5);
                 Stream::garbage_collection();
                 Stream::insert_now_playing((int) $media->id, (int) $user->id, (int) $media->time, $user->username, $type);
+                //internal scrobbling is triggered by the now playing, as otherwise parts will be left out
+                $media->set_played($user->id, $input['c'], array(), time());
             }
         }
 

--- a/lib/class/update.class.php
+++ b/lib/class/update.class.php
@@ -191,7 +191,8 @@ class Update
                          "* Drop localplay_shoutcast table if present.<br />";
         $version[]     = array('version' => '400006', 'description' => $update_string);
 
-        $update_string = "* Add ui option for skip_count display.<br />";
+        $update_string = "* Add ui option for skip_count display.<br />" .
+                         "* Add ui option for displaying dates in a custom format.<br />";
         $version[]     = array('version' => '400007', 'description' => $update_string);
 
         return $version;
@@ -1074,13 +1075,21 @@ class Update
      * update_400007
      *
      * Add ui option for skip_count display
+     * Add ui option for displaying dates in a custom format
      */
     public static function update_400007()
     {
         $retval = true;
 
         $sql = "INSERT INTO `preference` (`name`, `value`, `description`, `level`, `type`, `catagory`, `subcatagory`) " .
-            "VALUES ('show_skipped_times', '0', 'Show # skipped',0, 'boolean', 'interface', 'library')";
+            "VALUES ('show_skipped_times', '0', 'Show # skipped', 0, 'boolean', 'interface', 'library')";
+        $retval &= Dba::write($sql);
+        $row_id = Dba::insert_id();
+        $sql    = "INSERT INTO `user_preference` VALUES (-1,?, '0')";
+        $retval &= Dba::write($sql, array($row_id));
+
+        $sql = "INSERT INTO `preference` (`name`, `value`, `description`, `level`, `type`, `catagory`, `subcatagory`) " .
+            "VALUES ('custom_datetime', '', 'Custom datetime', 25, 'string', 'interface', 'custom')";
         $retval &= Dba::write($sql);
         $row_id = Dba::insert_id();
         $sql    = "INSERT INTO `user_preference` VALUES (-1,?, '0')";

--- a/lib/class/update.class.php
+++ b/lib/class/update.class.php
@@ -1082,7 +1082,7 @@ class Update
         $retval = true;
 
         $sql = "INSERT INTO `preference` (`name`, `value`, `description`, `level`, `type`, `catagory`, `subcatagory`) " .
-            "VALUES ('show_skipped_times', '0', 'Show # skipped', 0, 'boolean', 'interface', 'library')";
+            "VALUES ('show_skipped_times', '0', 'Show # skipped', 25, 'boolean', 'interface', 'library')";
         $retval &= Dba::write($sql);
         $row_id = Dba::insert_id();
         $sql    = "INSERT INTO `user_preference` VALUES (-1,?, '0')";

--- a/lib/class/update.class.php
+++ b/lib/class/update.class.php
@@ -191,6 +191,9 @@ class Update
                          "* Drop localplay_shoutcast table if present.<br />";
         $version[]     = array('version' => '400006', 'description' => $update_string);
 
+        $update_string = "* Add ui option for skip_count display.<br />";
+        $version[]     = array('version' => '400007', 'description' => $update_string);
+
         return $version;
     }
 
@@ -1063,6 +1066,25 @@ class Update
 
         $sql = "DROP TABLE IF EXISTS `localplay_shoutcast`";
         $retval &= Dba::write($sql);
+
+        return $retval;
+    }
+
+    /**
+     * update_400007
+     *
+     * Add ui option for skip_count display
+     */
+    public static function update_400007()
+    {
+        $retval = true;
+
+        $sql = "INSERT INTO `preference` (`name`, `value`, `description`, `level`, `type`, `catagory`, `subcatagory`) " .
+            "VALUES ('show_skipped_times', '0', 'Show # skipped',0, 'boolean', 'interface', 'library')";
+        $retval &= Dba::write($sql);
+        $row_id = Dba::insert_id();
+        $sql    = "INSERT INTO `user_preference` VALUES (-1,?, '0')";
+        $retval &= Dba::write($sql, array($row_id));
 
         return $retval;
     }

--- a/lib/class/update.class.php
+++ b/lib/class/update.class.php
@@ -1092,7 +1092,7 @@ class Update
             "VALUES ('custom_datetime', '', 'Custom datetime', 25, 'string', 'interface', 'custom')";
         $retval &= Dba::write($sql);
         $row_id = Dba::insert_id();
-        $sql    = "INSERT INTO `user_preference` VALUES (-1,?, '0')";
+        $sql    = "INSERT INTO `user_preference` VALUES (-1,?, '')";
         $retval &= Dba::write($sql, array($row_id));
 
         return $retval;

--- a/lib/class/useractivity.class.php
+++ b/lib/class/useractivity.class.php
@@ -195,6 +195,7 @@ class Useractivity extends database_object
     public static function del_activity($object_id, $object_type = 'song')
     {
         $sql = "DELETE FROM `user_activity` WHERE `object_type` = ? AND `object_id` = ? ORDER BY `date` DESC LIMIT 1";
+
         return Dba::write($sql, array($object_type, $object_id));
     }
 

--- a/lib/class/useractivity.class.php
+++ b/lib/class/useractivity.class.php
@@ -187,6 +187,18 @@ class Useractivity extends database_object
     }
 
     /**
+     * del_activity
+     * Deletes last acticity
+     * @param integer $object_id
+     * @param string $object_type
+     */
+    public static function del_activity($object_id, $object_type = 'song')
+    {
+        $sql = "DELETE FROM `user_activity` WHERE `object_type` = ? AND `object_id` = ? ORDER BY `date` DESC LIMIT 1";
+        return Dba::write($sql, array($object_type, $object_id));
+    }
+
+    /**
      * get_activities
      * @param integer $user_id
      * @param integer $limit

--- a/lib/class/useractivity.class.php
+++ b/lib/class/useractivity.class.php
@@ -188,7 +188,7 @@ class Useractivity extends database_object
 
     /**
      * del_activity
-     * Deletes last acticity
+     * Deletes last activity
      * @param integer $object_id
      * @param string $object_type
      */

--- a/lib/class/video.class.php
+++ b/lib/class/video.class.php
@@ -753,7 +753,7 @@ class Video extends database_object implements media, library_item
         return true;
     } // set_played
 
-    public function check_play_history($user)
+    public function check_play_history($user, $agent)
     {
         unset($user);
         // Do nothing

--- a/lib/class/video.class.php
+++ b/lib/class/video.class.php
@@ -755,7 +755,7 @@ class Video extends database_object implements media, library_item
 
     public function check_play_history($user, $agent)
     {
-        unset($user);
+        unset($user, $agent);
         // Do nothing
     }
 

--- a/lib/login.php
+++ b/lib/login.php
@@ -194,6 +194,8 @@ if (isset($auth) && $auth['success'] && isset($user)) {
     if (AmpConfig::get('autoupdate') && Access::check('interface', '100')) {
         AutoUpdate::is_update_available(true);
     }
+    // fix preferences that are missing for user
+    User::fix_preferences($user->id);
 
     /* Make sure they are actually trying to get to this site and don't try
      * to redirect them back into an admin section

--- a/lib/preferences.php
+++ b/lib/preferences.php
@@ -164,6 +164,7 @@ function create_preference_input($name, $value)
         case 'ajax_load':
         case 'now_playing_per_user':
         case 'show_played_times':
+        case 'show_skipped_times':
         case 'song_page_title':
         case 'subsonic_backend':
         case 'plex_backend':

--- a/templates/show_song.inc.php
+++ b/templates/show_song.inc.php
@@ -168,6 +168,7 @@ $button_flip_state_id = 'button_flip_state_' . $song->id; ?>
     $songprops[T_('Added')]   = date("d/m/Y H:i", $song->addition_time);
     if (AmpConfig::get('show_played_times')) {
         $songprops[T_('# Played')]   = scrub_out($song->object_cnt);
+        $songprops[T_('# Skipped')]  = scrub_out($song->skip_cnt);
     }
 
     if (AmpConfig::get('show_lyrics')) {

--- a/templates/show_song.inc.php
+++ b/templates/show_song.inc.php
@@ -168,6 +168,8 @@ $button_flip_state_id = 'button_flip_state_' . $song->id; ?>
     $songprops[T_('Added')]   = date("d/m/Y H:i", $song->addition_time);
     if (AmpConfig::get('show_played_times')) {
         $songprops[T_('# Played')]   = scrub_out($song->object_cnt);
+    }
+    if (AmpConfig::get('show_skipped_times')) {
         $songprops[T_('# Skipped')]  = scrub_out($song->skip_cnt);
     }
 

--- a/templates/show_song_row.inc.php
+++ b/templates/show_song_row.inc.php
@@ -65,11 +65,11 @@ if ($libitem->enabled || Access::check('interface', '50')) { ?>
 <td class="cel_time"><?php echo $libitem->f_time ?></td>
 <?php if (AmpConfig::get('licensing')) { ?>
 <td class="cel_license"><?php echo $libitem->f_license ?></td>
-<?php
-    } ?>
-
+<?php } ?>
 <?php if (AmpConfig::get('show_played_times')) { ?>
 <td class="cel_counter"><?php echo $libitem->object_cnt ?></td>
+<?php } ?>
+<?php if (AmpConfig::get('show_skipped_times')) { ?>
 <td class="cel_counter"><?php echo $libitem->skip_cnt ?></td>
 <?php
     }

--- a/templates/show_song_row.inc.php
+++ b/templates/show_song_row.inc.php
@@ -70,6 +70,7 @@ if ($libitem->enabled || Access::check('interface', '50')) { ?>
 
 <?php if (AmpConfig::get('show_played_times')) { ?>
 <td class="cel_counter"><?php echo $libitem->object_cnt ?></td>
+<td class="cel_counter"><?php echo $libitem->skip_cnt ?></td>
 <?php
     }
     if (User::is_registered()) {

--- a/templates/show_songs.inc.php
+++ b/templates/show_songs.inc.php
@@ -42,6 +42,7 @@ $thcount  = 8; ?>
 } ?>
             <?php if (AmpConfig::get('show_played_times')) { ?>
             <th class="cel_counter optional"><?php echo T_('# Played'); ?></th>
+            <th class="cel_counter optional"><?php echo T_('# Skipped'); ?></th>
             <?php
     } ?>
             <?php if (User::is_registered()) { ?>
@@ -100,6 +101,7 @@ $thcount  = 8; ?>
             } ?>
             <?php if (AmpConfig::get('show_played_times')) { ?>
             <th class="cel_counter optional"><?php echo T_('# Played'); ?></th>
+            <th class="cel_counter optional"><?php echo T_('# Skipped'); ?></th>
             <?php
             } ?>
             <?php if (User::is_registered()) { ?>

--- a/templates/show_songs.inc.php
+++ b/templates/show_songs.inc.php
@@ -106,8 +106,7 @@ $thcount  = 8; ?>
             <?php } ?>
             <?php if (AmpConfig::get('show_skipped_times')) { ?>
             <th class="cel_counter optional"><?php echo T_('# Skipped'); ?></th>
-            <?php
-            } ?>
+            <?php } ?>
             <?php if (User::is_registered()) { ?>
                 <?php if (AmpConfig::get('ratings')) { ?>
                     <th class="cel_rating"><?php echo T_('Rating'); ?></th>

--- a/templates/show_songs.inc.php
+++ b/templates/show_songs.inc.php
@@ -103,6 +103,8 @@ $thcount  = 8; ?>
             } ?>
             <?php if (AmpConfig::get('show_played_times')) { ?>
             <th class="cel_counter optional"><?php echo T_('# Played'); ?></th>
+            <?php } ?>
+            <?php if (AmpConfig::get('show_skipped_times')) { ?>
             <th class="cel_counter optional"><?php echo T_('# Skipped'); ?></th>
             <?php
             } ?>

--- a/templates/show_songs.inc.php
+++ b/templates/show_songs.inc.php
@@ -42,6 +42,8 @@ $thcount  = 8; ?>
 } ?>
             <?php if (AmpConfig::get('show_played_times')) { ?>
             <th class="cel_counter optional"><?php echo T_('# Played'); ?></th>
+            <?php } ?>
+            <?php if (AmpConfig::get('show_skipped_times')) { ?>
             <th class="cel_counter optional"><?php echo T_('# Skipped'); ?></th>
             <?php
     } ?>


### PR DESCRIPTION
As explained in #2288, this adds the capability for ampache to recognize whether a song is skipped. 
Therefore, there is an adjustable skipping threshold (how much time played counts as not skipped), a skipping counter in the GUI and of course the database infrastructure and recognition to recognize and save the skip count. 
Subsonic API is supported as well, however with a little change that will make a delayed entry of played or skipped impossible (DSub for example is working on an offline mode submitting changes later). On the good side however, it is working without turning on scrobbling in the client.