### PR TITLE
Unnessary null check for XML tags function

### DIFF
--- a/lib/class/xml_data.class.php
+++ b/lib/class/xml_data.class.php
@@ -422,11 +422,7 @@ class XML_Data
     public static function tags($tags)
     {
         if (count($tags) > self::$limit || self::$offset > 0) {
-            if (null !== self::$limit) {
-                $tags = array_splice($tags, self::$offset, self::$limit);
-            } else {
-                $tags = array_splice($tags, self::$offset);
-            }
+            $tags = array_splice($tags, self::$offset, self::$limit);
         }
         $string = "<total_count>" . count($tags) . "</total_count>\n";
 


### PR DESCRIPTION
The third parameter for `array_splice` defaults to `null` if not provided. So this was an unnecessary check as both calls are identical.

`function array_splice (array &$input, $offset, $length = null, $replacement = null) {}`