### PR TITLE
[Gravatar Plugin] Make sure https is used when force_ssl is configured

### DIFF
--- a/modules/plugins/Gravatar/Gravatar.plugin.php
+++ b/modules/plugins/Gravatar/Gravatar.plugin.php
@@ -79,7 +79,8 @@ class AmpacheGravatar
     {
         $url = "";
         if (!empty($user->email)) {
-            if (filter_has_var(INPUT_SERVER, 'HTTPS') && Core::get_server('HTTPS') !== 'off') {
+            if (!empty(AmpConfig::get('force_ssl')) ||
+                (filter_has_var(INPUT_SERVER, 'HTTPS') && Core::get_server('HTTPS') !== 'off')) {
                 $url = "https://secure.gravatar.com";
             } else {
                 $url = "http://www.gravatar.com";


### PR DESCRIPTION
I discovered the issue with my own ampache installation. I had mixed-content warnings, while behind a reverse proxy with `force_ssl = true` in my ampache config file.

Note: I tested on my own install, it works as expected.