### PR TITLE
Fix for issue #2374: Subsonic API returns lyrics of wrong song

### DIFF
--- a/lib/class/subsonic_api.class.php
+++ b/lib/class/subsonic_api.class.php
@@ -1917,13 +1917,13 @@ class Subsonic_Api
             $count = 0;
             if ($artist) {
                 $search['rule_' . $count . '_input']    = $artist;
-                $search['rule_' . $count . '_operator'] = 5;
+                $search['rule_' . $count . '_operator'] = 4;
                 $search['rule_' . $count . '']          = "artist";
                 ++$count;
             }
             if ($title) {
                 $search['rule_' . $count . '_input']    = $title;
-                $search['rule_' . $count . '_operator'] = 5;
+                $search['rule_' . $count . '_operator'] = 4;
                 $search['rule_' . $count . '']          = "title";
                 ++$count;
             }


### PR DESCRIPTION
Change operator for query in getlyrics from 'not equal' to 'equal'.
This way an SQL query is built that fetches song lyrics with Artist and Title **equal** to the given parameters instead of songs with Artist and Title **not equal** to the given parameters (which returns always the same song).