### PR TITLE
case insensitive sort on metadata field list in advanced search

### DIFF
--- a/lib/javascript/search.js
+++ b/lib/javascript/search.js
@@ -185,7 +185,7 @@ var SearchRow = {
         if (type.widget[0] == "subtypes") {
             var $select = SearchRow.createSelect({
                 name: "rule_" + targetID + "_subtype"
-            }, type.subtypes);
+            }, type.subtypes, undefined, true);
             $(this).after($select);
         }
         else {
@@ -201,14 +201,20 @@ var SearchRow = {
         input.remove();
         input_cell.append(SearchRow.constructInput(this.selectedIndex, targetID, oldinput));
     },
-    createSelect(attributes, options, selected) {
+    createSelect(attributes, options, selected, sort=false) {
         var $select = $("<select>");
         $.each(attributes, function (key, value) {
             $select.attr(key, value);
         });
 
-        $.each(options, function (key, value) {
-            $("<option>").attr("value", key).text(value).appendTo($select);
+        let optionValues = Object.keys(options);
+        if (sort) {
+            optionValues = optionValues.sort(function(a,b){
+                return options[a].toLowerCase() > options[b].toLowerCase() ? 1 : -1;
+            })
+        }
+        optionValues.forEach(function (value, index) {
+            $("<option>").attr("value", value).text(options[value]).appendTo($select);
         });
         $select.val(selected);
         return $select;
@@ -219,7 +225,7 @@ var SearchRow = {
         if (type["widget"][0] == "subtypes") {
             var $input = SearchRow.createSelect({
                 name: "rule_" + ruleNumber + "_subtype"
-            }, type.subtypes, subtype);
+            }, type.subtypes, subtype, true);
             return $input[0];
         }
     }


### PR DESCRIPTION
proposal for feature #2425 

sorting is done in javascript. Because the subtypes are stored as objects in `var types` via search-data.php, it's not possible to do the sorting on the server side.