### PR TITLE
Negative tracknr

### DIFF
--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -2303,6 +2303,7 @@ abstract class Catalog extends database_object
     public static function check_tracknr($tracknr)
     {
         $retval = ((int) $tracknr > 65535) ? (int) substr($tracknr, -4, 4) : (int) ($tracknr);
+
         return ($retval >= 0) ? $retval : null;
     }
 

--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -2298,13 +2298,13 @@ abstract class Catalog extends database_object
      * Check to make sure the tracknr fits into the database: unsigned, max 65535
      *
      * @param string $tracknr
-     * @return int null if tracknr is negative
+     * @return int
      */
     public static function check_tracknr($tracknr)
     {
-        $retval = ((int) $tracknr > 65535) ? (int) substr($tracknr, -4, 4) : (int) ($tracknr);
+        $retval = abs((int) $tracknr);
 
-        return ($retval >= 0) ? $retval : null;
+        return ($retval > 65535) ? (int) substr($retval, -4, 4) : $retval;
     }
 
     /**

--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -2295,14 +2295,14 @@ abstract class Catalog extends database_object
 
     /**
      * check_tracknr
-     * Check to make sure the tracknr fits into the database: unsigned, max 5 digits
+     * Check to make sure the tracknr fits into the database: unsigned, max 65535
      *
      * @param string $tracknr
      * @return int null if tracknr is negative
      */
     public static function check_tracknr($tracknr)
     {
-        $retval = (strlen((string) $tracknr) > 5) ? (int) substr($tracknr, -5, 5) : (int) ($tracknr);
+        $retval = ((int) $tracknr > 65535) ? (int) substr($tracknr, -4, 4) : (int) ($tracknr);
         return ($retval >= 0) ? $retval : null;
     }
 

--- a/lib/class/catalog.class.php
+++ b/lib/class/catalog.class.php
@@ -1813,7 +1813,7 @@ abstract class Catalog extends database_object
             // fall back to last time if you fail to scan correctly
             $new_song->time = $song->time;
         }
-        $new_song->track    = (strlen((string) $results['track']) > 5) ? (int) substr($results['track'], -5, 5) : (int) ($results['track']);
+        $new_song->track    = self::check_tracknr($results['track']);
         $new_song->mbid     = $results['mb_trackid'];
         $new_song->composer = self::check_length($results['composer']);
         $new_song->mime     = $results['mime'];
@@ -2291,6 +2291,19 @@ abstract class Catalog extends database_object
         }
 
         return $string;
+    }
+
+    /**
+     * check_tracknr
+     * Check to make sure the tracknr fits into the database: unsigned, max 5 digits
+     *
+     * @param string $tracknr
+     * @return int null if tracknr is negative
+     */
+    public static function check_tracknr($tracknr)
+    {
+        $retval = (strlen((string) $tracknr) > 5) ? (int) substr($tracknr, -5, 5) : (int) ($tracknr);
+        return ($retval >= 0) ? $retval : null;
     }
 
     /**

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -392,6 +392,9 @@ class Song extends database_object implements media, library_item
         $original_year         = Catalog::normalize_year($results['original_year'] ?: 0);
         $barcode               = Catalog::check_length($results['barcode'], 64);
 
+        if ($track !== (int) $results['track']) {
+            debug_event('song.class', "Track nr '{$results['track']}' out of range. Changed into '$track'", 2);
+        }
         if (!in_array($mode, ['vbr', 'cbr', 'abr'])) {
             debug_event('song.class', 'Error analyzing: ' . $file . ' unknown file bitrate mode: ' . $mode, 2);
             $mode = null;

--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -365,7 +365,7 @@ class Song extends database_object implements media, library_item
         $mode                  = $results['mode'];
         $size                  = $results['size'] ?: 0;
         $time                  = $results['time'] ?: 0;
-        $track                 = $results['track'];
+        $track                 = Catalog::check_tracknr($results['track']);
         $track_mbid            = $results['mb_trackid'] ?: $results['mbid'];
         $track_mbid            = $track_mbid ?: null;
         $album_mbid            = $results['mb_albumid'];


### PR DESCRIPTION
sanitize track numbers, to prevent import fails
  negative track number are stored with an empty value
  big track numbers (>65535) are truncated to last 4 digits