### PR TITLE
Fix problem when an artist has a dash in its name, like AC-DC.

### DIFF
--- a/lib/class/webdav_directory.class.php
+++ b/lib/class/webdav_directory.class.php
@@ -74,7 +74,7 @@ class WebDAV_Directory extends DAV\Collection
     {
         // Clean song name
         if (strtolower(get_class($this->libitem)) === "album") {
-            $splitname = explode('-', (string) $name, 3);
+            $splitname = explode(' - ', (string) $name, 3);
             $name      = trim((string) $splitname[count($splitname) - 1]);
             $nameinfo  = pathinfo($name);
             $name      = $nameinfo['filename'];


### PR DESCRIPTION
This fix will correctly grab the song name from the "artist" "song number" "song name" string.