### PR TITLE
Update session code to use 'stream' instead of 'api'

### DIFF
--- a/modules/localplay/upnp/UPnPDevice.php
+++ b/modules/localplay/upnp/UPnPDevice.php
@@ -73,7 +73,7 @@ class UPnPDevice
         $this->_settings['descriptionURL'] = $descriptionUrl;
 
         Session::create(array(
-            'type' => 'api',
+            'type' => 'stream',
             'sid' => 'upnp_dev_' . $descriptionUrl,
             'value' => json_encode($this->_settings)
         ));

--- a/modules/localplay/upnp/UPnPPlaylist.php
+++ b/modules/localplay/upnp/UPnPPlaylist.php
@@ -168,8 +168,8 @@ class UPnPPlaylist
             'upnp_playlist' => $this->_songs,
             'upnp_current' => $this->_current
         ));
-        if (! Session::exists('api', $sid)) {
-            Session::create(array('type' => 'api', 'sid' => $sid, 'value' => $pls_data ));
+        if (! Session::exists('stream', $sid)) {
+            Session::create(array('type' => 'stream', 'sid' => $sid, 'value' => $pls_data ));
         } else {
             Session::write($sid, $pls_data);
         }

--- a/modules/localplay/upnp/upnpplayer.class.php
+++ b/modules/localplay/upnp/upnpplayer.class.php
@@ -419,8 +419,8 @@ class UPnPPlayer
 
         $sid  = 'upnp_ply_' . $this->_description_url;
         $data = json_encode($this->_intState);
-        if (! Session::exists('api', $sid)) {
-            Session::create(array('type' => 'api', 'sid' => $sid, 'value' => $data ));
+        if (! Session::exists('stream', $sid)) {
+            Session::create(array('type' => 'stream', 'sid' => $sid, 'value' => $data ));
         } else {
             Session::write($sid, $data);
         }


### PR DESCRIPTION
The UPnP localplay code expects to retrieve session information using named keys.
The Session::create and Session::exists functions now use 'stream',
which allows the $sid to be set.
Should address #2446.