### PR TITLE
Improve performance by loading .mo gettext files rather than .po

### DIFF
--- a/lib/i18n.php
+++ b/lib/i18n.php
@@ -31,11 +31,11 @@ use Gettext\Translator;
 function load_gettext()
 {
     $lang   = AmpConfig::get('lang');
-    $popath = AmpConfig::get('prefix') . '/locale/' . $lang . '/LC_MESSAGES/messages.po';
+    $mopath = AmpConfig::get('prefix') . '/locale/' . $lang . '/LC_MESSAGES/messages.mo';
 
     $gettext = new Translator();
-    if (file_exists($popath)) {
-        $translations = Gettext\Translations::fromPoFile($popath);
+    if (file_exists($mopath)) {
+        $translations = Gettext\Translations::fromMoFile($mopath);
         $gettext->loadTranslations($translations);
     }
     $gettext->register();


### PR DESCRIPTION
When loading every single page the localized .po files are loaded. However I managed to improve the performance by loading the .mo files, which are machine readable and therefore optimized for machine parsing, rather than the .po files which are meant for human readability.
Using a Raspberry Pi 2 as an ampache server, the load times of simple pages were before in the order of ~0.9s (as reported in the page footer). After this change, load times have been reduced by ~0.4s on average, which is a big boost. The test has been done with es_ES, de_DE and ja_JP localizations, all showing similar performance improvements.