### PR TITLE
Fix non-locallized subcategories in preferences

### DIFF
--- a/templates/show_preference_box.inc.php
+++ b/templates/show_preference_box.inc.php
@@ -55,9 +55,8 @@ if (Access::check('interface', 100) && $_REQUEST['action'] == 'admin') {
         if ($pref['subcategory'] != $lastsubcat) {
             $lastsubcat = $pref['subcategory'];
             $fsubcat    = $lastsubcat;
-            if (!empty($fsubcat)) {
-                $fsubcat = ucwords($fsubcat); ?>
-                <tr class="<?php echo UI::flip_class() ?>"><td colspan="4"><h5><?php echo T_($fsubcat) ?></h5></td></tr>
+            if (!empty($fsubcat)) { ?>
+                <tr class="<?php echo UI::flip_class() ?>"><td colspan="4"><h5><?php echo ucwords(T_($fsubcat)) ?></h5></td></tr>
                 <?php
             }
         } ?>


### PR DESCRIPTION
The preferences page shows a subcategory that until now has not been localized. The problem is the string was passed to ucwords _before_ being localized, and since that's the msgid, then it couldn't be found in the catalogue. Now ucwords is applied to the localized string instead.