### PR TITLE
Added translation of settings that cannot be changed by user

### DIFF
--- a/lib/preferences.php
+++ b/lib/preferences.php
@@ -137,9 +137,9 @@ function create_preference_input($name, $value)
 {
     if (!Preference::has_access($name)) {
         if ($value == '1') {
-            echo "Enabled";
+            echo T_("Enabled");
         } elseif ($value == '0') {
-            echo "Disabled";
+            echo T_("Disabled");
         } else {
             if (preg_match('/_pass$/', $name) || preg_match('/_api_key$/', $name)) {
                 echo "******";


### PR DESCRIPTION
The preference settings that the user doesn't have the permissions to change had a hardcoded string ("Disabled", "Enabled) so no translation is shown in the UI.
This PR fixes that, by adding the corresponding T_().
I have executed gather-messages.sh -g to generate a new messages.pot which I have included in the PR. However it is not clear to me whether the .po and .mo files need to be regenerated (with gather-messages.sh -ma I guess) or whether this is done automatically by transifex once a new messages.pot is there. If the former, I can easily run the command and remove the obsolete strings (there are two unrelated obsolete strings) to this PR.