### PR TITLE
Move interface inheritance checker into a separate class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ php:
 before_install:
  - export PATH="$PATH:$HOME/.composer/vendor/bin"
  - composer global require friendsofphp/php-cs-fixer:~2.15.0
- - 
+
 before_script:
  - chmod +x scripts/tests/syntax.sh
  - chmod +x scripts/tests/codestyle.sh
+ - composer update
 
 script:
  - scripts/tests/syntax.sh
  - scripts/tests/codestyle.sh
+ - composer test

--- a/Module/Util/InterfaceImplementationChecker.php
+++ b/Module/Util/InterfaceImplementationChecker.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=0);
+/* vim:set softtabstop=4 shiftwidth=4 expandtab: */
+/**
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright 2001 - 2020 Ampache.org
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Module\Util;
+
+use library_item;
+use media;
+use playable_item;
+
+/**
+ * Provides utility methods to check whether an object implements a certain interface
+ */
+final class InterfaceImplementationChecker
+{
+
+    /**
+     * Checks if an object implements a certain interface
+     *
+     * @param string $instance The subject to search in
+     * @param string $interface_name The interface name to search for
+     */
+    private static function is_class_typeof(string $instance, string $interface_name): bool
+    {
+        if (class_exists($instance)) {
+            return in_array(
+                $interface_name,
+                array_map(
+                    static function (string $name): string {
+                        return strtolower($name);
+                    },
+                    class_implements($instance)
+                )
+            );
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $instance The subject to search in
+     */
+    public static function is_playable_item(string $instance): bool
+    {
+        return self::is_class_typeof($instance, playable_item::class);
+    }
+
+    /**
+     * @param string $instance The subject to search in
+     */
+    public static function is_library_item(string $instance): bool
+    {
+        return self::is_class_typeof($instance, library_item::class);
+    }
+
+    /**
+     * @param string $instance The subject to search in
+     */
+    public static function is_media(string $instance): bool
+    {
+        return self::is_class_typeof($instance, media::class);
+    }
+}

--- a/arts.php
+++ b/arts.php
@@ -20,13 +20,15 @@
  *
  */
 
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 require_once 'lib/init.php';
 
 require_once AmpConfig::get('prefix') . UI::find_template('header.inc.php');
 
 $object_type = filter_input(INPUT_GET, 'object_type', FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
 $object_id   = (int) filter_input(INPUT_GET, 'object_id', FILTER_SANITIZE_NUMBER_INT);
-if (!Core::is_library_item($object_type)) {
+if (!InterfaceImplementationChecker::is_library_item($object_type)) {
     UI::access_denied();
 
     return false;

--- a/batch.php
+++ b/batch.php
@@ -20,6 +20,8 @@
  *
  */
 
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 if (!defined('NO_SESSION')) {
     if (isset($_REQUEST['ssid'])) {
         define('NO_SESSION', 1);
@@ -61,7 +63,7 @@ if (!check_can_zip($object_type)) {
     return false;
 }
 
-if (Core::is_playable_item($object_type)) {
+if (InterfaceImplementationChecker::is_playable_item($object_type)) {
     $object_id = $_REQUEST['id'];
     if (!is_array($object_id)) {
         $object_id = array($object_id);

--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,10 @@
         "wikimedia/composer-merge-plugin": "1.*",
         "xdan/datetimepicker": "2.*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^7",
+        "mockery/mockery": "^1.3"
+    },
     "repositories":
     [
         {
@@ -334,7 +338,11 @@
     "autoload": {
         "psr-4": {
             "Lib\\": "lib/class",
-            "Beets\\": "modules/Beets"
+            "Beets\\": "modules/Beets",
+            "Ampache\\": ["./", "tests/"]
         }
+    },
+    "scripts": {
+        "test": "./lib/vendor/bin/phpunit tests"
     }
 }

--- a/docs/RELEASE-PROCESS.md
+++ b/docs/RELEASE-PROCESS.md
@@ -20,7 +20,7 @@ It's easy to use a program like github desktop to compare between branches.
 * Commit merge for new version (e.g. 4.x.x) but **do not push!**
 * Browse changes to check for things you've missed in the changelog
 * Add pchart to composer
-  * composer require szymach/c-pchart "2.*"
+  * composer require --update-no-dev szymach/c-pchart "2.*"
 * ~~Run composer install~~ (adding pchart updates everything)
 * Remove broken symbolic links
 

--- a/graph.php
+++ b/graph.php
@@ -22,6 +22,8 @@
 
 // This file is a little weird it needs to allow API session
 // this needs to be done a little better, but for now... eah
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 define('NO_SESSION', '1');
 require_once 'lib/init.php';
 
@@ -40,7 +42,7 @@ $type = $_REQUEST['type'];
 
 $user_id     = (int) ($_REQUEST['user_id']);
 $object_type = (string) scrub_in($_REQUEST['object_type']);
-if (!Core::is_library_item($object_type)) {
+if (!InterfaceImplementationChecker::is_library_item($object_type)) {
     $object_type = null;
 }
 $object_id  = (int) ($_REQUEST['object_id']);

--- a/lib/class/ampache_rss.class.php
+++ b/lib/class/ampache_rss.class.php
@@ -21,6 +21,8 @@ declare(strict_types=0);
  *
  */
 
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 /**
  * Ampache_RSS Class
  *
@@ -62,7 +64,7 @@ class Ampache_RSS
             if ($params != null && is_array($params)) {
                 $object_type = $params['object_type'];
                 $object_id   = $params['object_id'];
-                if (Core::is_library_item($object_type)) {
+                if (InterfaceImplementationChecker::is_library_item($object_type)) {
                     $libitem = new $object_type($object_id);
                     if ($libitem->id) {
                         $libitem->format();

--- a/lib/class/api.class.php
+++ b/lib/class/api.class.php
@@ -21,6 +21,8 @@ declare(strict_types=0);
  *
  */
 
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 /**
  * API Class
  *
@@ -1992,7 +1994,7 @@ class Api
             return false;
         }
         $share = array();
-        if (!Core::is_library_item($object_type) || !$object_id) {
+        if (!InterfaceImplementationChecker::is_library_item($object_type) || !$object_id) {
             self::message('error', T_('Wrong library item type'), '401', $input['format']);
         } else {
             $item = new $object_type($object_id);
@@ -3075,7 +3077,7 @@ class Api
             return false;
         }
 
-        if (!Core::is_library_item($type) || !$object_id) {
+        if (!InterfaceImplementationChecker::is_library_item($type) || !$object_id) {
             self::message('error', T_('Wrong library item type'), '401', $input['format']);
         } else {
             $item = new $type($object_id);
@@ -3133,7 +3135,7 @@ class Api
             return false;
         }
 
-        if (!Core::is_library_item($type) || !$object_id) {
+        if (!InterfaceImplementationChecker::is_library_item($type) || !$object_id) {
             self::message('error', T_('Wrong library item type'), '401', $input['format']);
         } else {
             $item = new $type($object_id);

--- a/lib/class/art.class.php
+++ b/lib/class/art.class.php
@@ -21,6 +21,7 @@ declare(strict_types=0);
  *
  */
 
+use Ampache\Module\Util\InterfaceImplementationChecker;
 use MusicBrainz\MusicBrainz;
 use MusicBrainz\HttpAdapters\RequestsHttpAdapter;
 use SpotifyWebAPI\SpotifyWebAPI;
@@ -98,7 +99,7 @@ class Art extends database_object
      */
     public static function is_valid_type($type)
     {
-        return (Core::is_library_item($type) || $type == 'user');
+        return (InterfaceImplementationChecker::is_library_item($type) || $type == 'user');
     }
 
     /**

--- a/lib/class/core.class.php
+++ b/lib/class/core.class.php
@@ -31,6 +31,8 @@ declare(strict_types=0);
 class Core
 {
     /**
+     * @deprecated An empty constructor which returns false? Seems to be garbage
+     *
      * constructor
      * This doesn't do anything
      */
@@ -49,7 +51,6 @@ class Core
      */
     public static function autoload($class)
     {
-        $possiblePaths = array();
         if (strpos($class, '\\') === false) {
             $possiblePaths = self::getNonNamespacedPaths($class);
         } else {
@@ -139,6 +140,8 @@ class Core
     }
 
     /**
+     * @deprecated Not in use
+     *
      * get_cookie
      * Return a $COOKIE variable instead of calling directly
      *
@@ -372,7 +375,6 @@ class Core
      */
     public static function gen_secure_token($length)
     {
-        $buffer = '';
         if (function_exists('random_bytes')) {
             $buffer = random_bytes($length);
         } elseif (function_exists('openssl_random_pseudo_bytes')) {
@@ -522,49 +524,6 @@ class Core
         }
 
         return false;
-    }
-
-    /**
-     * is_class_typeof
-     *
-     * @param $classname
-     * @param string $typeofname
-     * @return boolean
-     */
-    private static function is_class_typeof($classname, $typeofname)
-    {
-        if (class_exists($classname)) {
-            return in_array($typeofname, array_map('strtolower', class_implements($classname)));
-        }
-
-        return false;
-    }
-
-    /**
-     * @param $classname
-     * @return boolean
-     */
-    public static function is_playable_item($classname)
-    {
-        return self::is_class_typeof($classname, 'playable_item');
-    }
-
-    /**
-     * @param $classname
-     * @return boolean
-     */
-    public static function is_library_item($classname)
-    {
-        return self::is_class_typeof($classname, 'library_item');
-    }
-
-    /**
-     * @param $classname
-     * @return boolean
-     */
-    public static function is_media($classname)
-    {
-        return self::is_class_typeof($classname, 'media');
     }
 
     /**

--- a/lib/class/graph.class.php
+++ b/lib/class/graph.class.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=0);
 /* vim:set softtabstop=4 shiftwidth=4 expandtab: */
+
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 /**
  *
  * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
@@ -89,7 +92,7 @@ class Graph
         }
 
         $object_id = (int) ($object_id);
-        if (Core::is_library_item($object_type)) {
+        if (InterfaceImplementationChecker::is_library_item($object_type)) {
             $sql .= " AND `object_count`.`object_type` = '" . $object_type . "'";
             if ($object_id > 0) {
                 $sql .= " AND `object_count`.`object_id` = '" . $object_id . "'";
@@ -677,7 +680,7 @@ class Graph
 
         $libitem  = null;
         $owner_id = 0;
-        if (($object_id) && (Core::is_library_item($object_type))) {
+        if (($object_id) && (InterfaceImplementationChecker::is_library_item($object_type))) {
             $libitem  = new $object_type($object_id);
             $owner_id = $libitem->get_user_owner();
         }

--- a/lib/class/playlist_object.abstract.php
+++ b/lib/class/playlist_object.abstract.php
@@ -20,6 +20,8 @@
  *
  */
 
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 /**
  * playlist_object
  * Abstracting out functionality needed by both normal and smart playlists
@@ -211,7 +213,7 @@ abstract class playlist_object extends database_object implements library_item
             $media_arts = array();
             shuffle($medias);
             foreach ($medias as $media) {
-                if (Core::is_library_item($media['object_type'])) {
+                if (InterfaceImplementationChecker::is_library_item($media['object_type'])) {
                     if (!Art::has_db($media['object_id'], $media['object_type'])) {
                         $libitem = new $media['object_type']($media['object_id']);
                         $parent  = $libitem->get_parent();

--- a/lib/class/shoutbox.class.php
+++ b/lib/class/shoutbox.class.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=0);
 /* vim:set softtabstop=4 shiftwidth=4 expandtab: */
+
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 /**
  *
  * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
@@ -176,7 +179,7 @@ class Shoutbox
      */
     public static function get_object($type, $object_id)
     {
-        if (!Core::is_library_item($type)) {
+        if (!InterfaceImplementationChecker::is_library_item($type)) {
             return null;
         }
 
@@ -218,7 +221,7 @@ class Shoutbox
      */
     public static function create(array $data)
     {
-        if (!Core::is_library_item($data['object_type'])) {
+        if (!InterfaceImplementationChecker::is_library_item($data['object_type'])) {
             return false;
         }
 

--- a/lib/class/subsonic_xml_data.class.php
+++ b/lib/class/subsonic_xml_data.class.php
@@ -21,6 +21,8 @@ declare(strict_types=0);
  *
  */
 
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 /**
  * XML_Data Class
  *
@@ -1155,7 +1157,7 @@ class Subsonic_XML_Data
      */
     private static function setIfStarred($xml, $objectType, $object_id)
     {
-        if (Core::is_library_item($objectType)) {
+        if (InterfaceImplementationChecker::is_library_item($objectType)) {
             if (AmpConfig::get('userflags')) {
                 $starred = new Userflag($object_id, $objectType);
                 if ($res = $starred->get_flag(null, true)) {

--- a/lib/class/tag.class.php
+++ b/lib/class/tag.class.php
@@ -21,6 +21,8 @@ declare(strict_types=0);
  *
  */
 
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 /**
  * Tag Class
  *
@@ -107,7 +109,7 @@ class Tag extends database_object implements library_item
             return false;
         }
 
-        if (!Core::is_library_item($type)) {
+        if (!InterfaceImplementationChecker::is_library_item($type)) {
             return false;
         }
 
@@ -152,7 +154,7 @@ class Tag extends database_object implements library_item
      */
     public static function add($type, $object_id, $value, $user = true)
     {
-        if (!Core::is_library_item($type)) {
+        if (!InterfaceImplementationChecker::is_library_item($type)) {
             return false;
         }
 
@@ -327,7 +329,7 @@ class Tag extends database_object implements library_item
             $uid = (int) ($user);
         }
 
-        if (!Core::is_library_item($type)) {
+        if (!InterfaceImplementationChecker::is_library_item($type)) {
             debug_event('tag.class', $type . " is not a library item.", 3);
 
             return false;
@@ -447,7 +449,7 @@ class Tag extends database_object implements library_item
      */
     public static function tag_map_exists($type, $object_id, $tag_id, $user)
     {
-        if (!Core::is_library_item($type)) {
+        if (!InterfaceImplementationChecker::is_library_item($type)) {
             debug_event('tag.class', 'Requested type is not a library item.', 3);
 
             return false;
@@ -472,7 +474,7 @@ class Tag extends database_object implements library_item
      */
     public static function get_top_tags($type, $object_id, $limit = 10)
     {
-        if (!Core::is_library_item($type)) {
+        if (!InterfaceImplementationChecker::is_library_item($type)) {
             return array();
         }
 
@@ -504,7 +506,7 @@ class Tag extends database_object implements library_item
      */
     public static function get_object_tags($type, $object_id = null)
     {
-        if (!Core::is_library_item($type)) {
+        if (!InterfaceImplementationChecker::is_library_item($type)) {
             return false;
         }
 
@@ -537,7 +539,7 @@ class Tag extends database_object implements library_item
      */
     public static function get_tag_objects($type, $tag_id, $count = '', $offset = '')
     {
-        if (!Core::is_library_item($type)) {
+        if (!InterfaceImplementationChecker::is_library_item($type)) {
             return array();
         }
 
@@ -577,7 +579,7 @@ class Tag extends database_object implements library_item
      */
     public static function get_tag_ids($type, $count = '', $offset = '')
     {
-        if (!Core::is_library_item($type)) {
+        if (!InterfaceImplementationChecker::is_library_item($type)) {
             return array();
         }
 
@@ -815,7 +817,7 @@ class Tag extends database_object implements library_item
      */
     public function remove_map($type, $object_id, $user = true)
     {
-        if (!Core::is_library_item($type)) {
+        if (!InterfaceImplementationChecker::is_library_item($type)) {
             return false;
         }
 
@@ -983,7 +985,7 @@ class Tag extends database_object implements library_item
             return true;
         }
 
-        if (Core::is_library_item($object_type)) {
+        if (InterfaceImplementationChecker::is_library_item($object_type)) {
             $libitem = new $object_type($object_id);
             $owner   = $libitem->get_user_owner();
 

--- a/lib/class/useractivity.class.php
+++ b/lib/class/useractivity.class.php
@@ -304,9 +304,9 @@ class Useractivity extends database_object
         echo $descr;
 
         /*
-        if (Core::is_library_item($this->object_type)) {
-            echo ' ';
-            $libitem->display_art(10);
+        if (\Ampache\Module\Util\InterfaceImplementationChecker::is_library_item($this->object_type)) {
+        echo ' ';
+        $libitem->display_art(10);
         }
         echo '</div>';
          */

--- a/lib/class/webplayer.class.php
+++ b/lib/class/webplayer.class.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=0);
 /* vim:set softtabstop=4 shiftwidth=4 expandtab: */
+
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 /**
  *
  * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
@@ -96,7 +99,7 @@ class WebPlayer
     public static function get_media_object($urlinfo)
     {
         $media = null;
-        if ($urlinfo['id'] && Core::is_media($urlinfo['type'])) {
+        if ($urlinfo['id'] && InterfaceImplementationChecker::is_media($urlinfo['type'])) {
             $media = new $urlinfo['type']($urlinfo['id']);
         } else {
             if ($urlinfo['id'] && $urlinfo['type'] == 'song_preview') {

--- a/mashup.php
+++ b/mashup.php
@@ -20,12 +20,14 @@
  *
  */
 
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 require_once 'lib/init.php';
 
 session_start();
 
 $object_type = Core::get_request('action');
-if (!Core::is_library_item($object_type)) {
+if (!InterfaceImplementationChecker::is_library_item($object_type)) {
     return UI::access_denied();
 }
 

--- a/server/ajax.server.php
+++ b/server/ajax.server.php
@@ -25,6 +25,8 @@
  */
 
 // Set that this is an ajax include
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 define('AJAX_INCLUDE', '1');
 require_once '../lib/init.php';
 
@@ -122,7 +124,7 @@ switch ($action) {
         $object_type = $_REQUEST['type'] ?: $_REQUEST['object_type'];
         $object_id   = $_REQUEST['id'] ?: $_REQUEST['object_id'];
 
-        if (Core::is_playable_item($object_type)) {
+        if (InterfaceImplementationChecker::is_playable_item($object_type)) {
             if (!is_array($object_id)) {
                 $object_id = array($object_id);
             }

--- a/server/browse.ajax.php
+++ b/server/browse.ajax.php
@@ -23,6 +23,9 @@
 /**
  * Sub-Ajax page, requires AJAX_INCLUDE
  */
+
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 require_once '../lib/init.php';
 
 if (!Core::is_session_started()) {
@@ -210,7 +213,7 @@ switch ($_REQUEST['action']) {
         $object_type = Core::get_request('object_type');
         $object_id   = (int) filter_input(INPUT_GET, 'object_id', FILTER_SANITIZE_NUMBER_INT);
 
-        if (Core::is_library_item($object_type) && $object_id > 0) {
+        if (InterfaceImplementationChecker::is_library_item($object_type) && $object_id > 0) {
             Share::display_ui_links($object_type, $object_id);
 
             return false;

--- a/server/edit.server.php
+++ b/server/edit.server.php
@@ -25,6 +25,8 @@
  */
 
 // Set that this is an ajax include
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 define('AJAX_INCLUDE', '1');
 
 require_once '../lib/init.php';
@@ -46,7 +48,7 @@ if (empty($type)) {
     $object_type = implode('_', explode('_', $type, -1));
 }
 
-if (!Core::is_library_item($object_type) && $object_type != 'share') {
+if (!InterfaceImplementationChecker::is_library_item($object_type) && $object_type != 'share') {
     debug_event('edit.server', 'Type `' . $type . '` is not based on an item library.', 3);
 
     return false;

--- a/server/playlist.ajax.php
+++ b/server/playlist.ajax.php
@@ -23,6 +23,9 @@
 /**
  * Sub-Ajax page, requires AJAX_INCLUDE
  */
+
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 if (!defined('AJAX_INCLUDE')) {
     return false;
 }
@@ -83,7 +86,7 @@ switch ($_REQUEST['action']) {
         $item_id   = $_REQUEST['item_id'];
         $item_type = $_REQUEST['item_type'];
 
-        if (!empty($item_type) && Core::is_playable_item($item_type)) {
+        if (!empty($item_type) && InterfaceImplementationChecker::is_playable_item($item_type)) {
             debug_event('playlist.ajax', 'Adding all medias of ' . $item_type . '(s) {' . $item_id . '}...', 5);
             $item_ids = explode(',', $item_id);
             foreach ($item_ids as $iid) {

--- a/server/stream.ajax.php
+++ b/server/stream.ajax.php
@@ -24,6 +24,9 @@
 /**
  * Sub-Ajax page, requires AJAX_INCLUDE
  */
+
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 if (!defined('AJAX_INCLUDE')) {
     return false;
 }
@@ -83,7 +86,7 @@ switch ($_REQUEST['action']) {
         }
         debug_event('stream.ajax', 'Called for ' . $object_type . ': {' . $object_id . '}', 5);
 
-        if (Core::is_playable_item($object_type)) {
+        if (InterfaceImplementationChecker::is_playable_item($object_type)) {
             $_SESSION['iframe']['target'] = AmpConfig::get('web_path') . '/stream.php?action=play_item&object_type=' . $object_type . '&object_id=' . $object_id;
             if ($_REQUEST['custom_play_action']) {
                 $_SESSION['iframe']['target'] .= '&custom_play_action=' . $_REQUEST['custom_play_action'];

--- a/shout.php
+++ b/shout.php
@@ -20,6 +20,8 @@
  *
  */
 
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 require_once 'lib/init.php';
 
 UI::show_header();
@@ -48,7 +50,7 @@ switch ($_REQUEST['action']) {
             unset($_POST['date']);
         }
 
-        if (!Core::is_library_item(Core::get_post('object_type'))) {
+        if (!InterfaceImplementationChecker::is_library_item(Core::get_post('object_type'))) {
             UI::access_denied();
 
             return false;

--- a/stream.php
+++ b/stream.php
@@ -20,6 +20,8 @@
  *
  */
 
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 require_once 'lib/init.php';
 
 if (!Core::get_request('action')) {
@@ -80,7 +82,7 @@ switch ($_REQUEST['action']) {
         $object_type = $_REQUEST['object_type'];
         $object_ids  = explode(',', Core::get_get('object_id'));
 
-        if (Core::is_playable_item($object_type)) {
+        if (InterfaceImplementationChecker::is_playable_item($object_type)) {
             foreach ($object_ids as $object_id) {
                 $item      = new $object_type($object_id);
                 $media_ids = array_merge($media_ids, $item->get_medias());

--- a/templates/show_playlist_medias.inc.php
+++ b/templates/show_playlist_medias.inc.php
@@ -20,6 +20,8 @@
  *
  */
 
+use Ampache\Module\Util\InterfaceImplementationChecker;
+
 $web_path = AmpConfig::get('web_path'); ?>
 <?php if ($browse->is_show_header()) {
     require AmpConfig::get('prefix') . UI::find_template('list_header.inc.php');
@@ -57,7 +59,7 @@ $web_path = AmpConfig::get('web_path'); ?>
             $object = (array) $object;
         }
         $object_type = $object['object_type'];
-        if (Core::is_library_item($object_type)) {
+        if (InterfaceImplementationChecker::is_library_item($object_type)) {
             $libitem = new $object_type($object['object_id']);
             $libitem->format();
             $playlist_track = $object['track']; ?>

--- a/tests/Module/Util/InterfaceImplementationCheckerTest.php
+++ b/tests/Module/Util/InterfaceImplementationCheckerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ampache\Module\Util;
+
+use Channel;
+use library_item;
+use media;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use playable_item;
+use Song_Preview;
+
+class InterfaceImplementationCheckerTest extends MockeryTestCase
+{
+    public function testIsPlayableItemReturnsTrueIfImplemented(): void
+    {
+        $instance = Mockery::mock(Song_Preview::class, playable_item::class);
+
+        $this->assertTrue(
+            InterfaceImplementationChecker::is_playable_item(get_class($instance))
+        );
+    }
+
+    public function testIsPlayableItemReturnsFalseIfNotImplemented(): void
+    {
+        $instance = Mockery::mock(Song_Preview::class);
+
+        $this->assertFalse(
+            InterfaceImplementationChecker::is_playable_item(get_class($instance))
+        );
+    }
+
+    public function testIsLibraryItemReturnsTrueIfImplemented(): void
+    {
+        $instance = Mockery::mock(Channel::class, library_item::class);
+
+        $this->assertTrue(
+            InterfaceImplementationChecker::is_library_item(get_class($instance))
+        );
+    }
+
+    public function testIsLibraryItemReturnsFalseIfNotImplemented(): void
+    {
+        $instance = Mockery::mock(Song_Preview::class);
+
+        $this->assertFalse(
+            InterfaceImplementationChecker::is_library_item(get_class($instance))
+        );
+    }
+
+    public function testIsMediaReturnsTrueIfImplemented(): void
+    {
+        $instance = Mockery::mock(Channel::class, media::class);
+
+        $this->assertTrue(
+            InterfaceImplementationChecker::is_media(get_class($instance))
+        );
+    }
+
+    public function testIsMediaReturnsFalseIfNotImplemented(): void
+    {
+        $instance = Mockery::mock(Song_Preview::class);
+
+        $this->assertFalse(
+            InterfaceImplementationChecker::is_media(get_class($instance))
+        );
+    }
+}


### PR DESCRIPTION
Hi there

I was thinking: Why not start to add some unittests to improve quality and maintainability in the future? To be able to write those tests, it is necessary to follow the `single responsibility principle`. So I moved methods, which perform some interface-implementation-checks into a single class and added tests for them.

I also introduced a global namespace (`Ampache`) to start over with a `clean` PSR-4 structure which will improve autoloading and maintainaability in future. If you're ok with this, I will create some follow-up PRs to move more code into Utility-classes.

Please let me know what you think about adding tests. And let me know, if you're ok with this kind of 'janitorial work'.

And if the amount/frequency of PRs bothers you, please say so.