### PR TITLE
Repair global constant call

### DIFF
--- a/lib/class/art.class.php
+++ b/lib/class/art.class.php
@@ -75,10 +75,10 @@ class Art extends database_object
      */
     private static $enabled;
 
-    /*
+    /**
      * @const ART_SEARCH_LIMIT
      */
-    private const ART_SEARCH_LIMIT = 5;
+    public const ART_SEARCH_LIMIT = 5;
 
     /**
      * Constructor
@@ -1109,7 +1109,7 @@ class Art extends database_object
             return array();
         }
         if ($limit == 0) {
-            $limit   = (is_null(AmpConfig::get('art_search_limit'))) ? ART_SEARCH_LIMIT : AmpConfig::get('art_search_limit') ;
+            $limit   = (is_null(AmpConfig::get('art_search_limit'))) ? static::ART_SEARCH_LIMIT : AmpConfig::get('art_search_limit') ;
         }
         $config    = AmpConfig::get('art_order');
         $methods   = get_class_methods('Art');

--- a/templates/show_get_art.inc.php
+++ b/templates/show_get_art.inc.php
@@ -20,7 +20,7 @@
  *
  */ ?>
 <?php
-      $limit     = AmpConfig::get('art_search_limit', 5);
+      $limit     = AmpConfig::get('art_search_limit', Art::ART_SEARCH_LIMIT);
       $art_order = AmpConfig::get('art_order');
       $art_type  = ($object_type == 'album') ?'Cover Art' : 'Artist Art';
       UI::show_box_top(T_("Customize {$art_type} Search"), 'box box_get_albumart'); ?>


### PR DESCRIPTION
Also use the new ART_SEARCH_LIMIT constant in the template to define the
default.

References: d3e4aaeeab87ba697063f36d70d27cf5da915d05