### PR TITLE
[subsonic API] artistInfo2 & similarSongs2 correct return childs

### DIFF
--- a/lib/class/subsonic_api.class.php
+++ b/lib/class/subsonic_api.class.php
@@ -1961,7 +1961,7 @@ class Subsonic_Api
      * Takes artist id in parameter with optional similar artist count and if not present similar artist should be returned.
      * @param array $input
      */
-    public static function getartistinfo($input)
+    public static function getartistinfo($input, $child = "artistInfo")
     {
         $id                = self::check_parameter($input, 'id');
         $count             = $input['count'] ?: 20;
@@ -1972,7 +1972,7 @@ class Subsonic_Api
             $info      = Recommendation::get_artist_info($artist_id);
             $similars  = Recommendation::get_artists_like($artist_id, $count, !$includeNotPresent);
             $response  = Subsonic_XML_Data::createSuccessResponse('getartistinfo');
-            Subsonic_XML_Data::addArtistInfo($response, $info, $similars);
+            Subsonic_XML_Data::addArtistInfo($response, $info, $similars, $child);
         } else {
             $response = Subsonic_XML_Data::createError(Subsonic_XML_Data::SSERROR_DATA_NOTFOUND, '', 'getartistinfo');
         }
@@ -1987,7 +1987,7 @@ class Subsonic_Api
      */
     public static function getartistinfo2($input)
     {
-        self::getartistinfo($input);
+        self::getartistinfo($input, 'artistInfo2');
     }
 
     /**
@@ -1996,7 +1996,7 @@ class Subsonic_Api
      * Takes song/album/artist id in parameter with optional similar songs count.
      * @param array $input
      */
-    public static function getsimilarsongs($input)
+    public static function getsimilarsongs($input, $child = "similarSongs")
     {
         if (!AmpConfig::get('show_similar')) {
             $response = Subsonic_XML_Data::createError(Subsonic_XML_Data::SSERROR_DATA_NOTFOUND, "Show similar must be enabled", 'getsimilarsongs');
@@ -2038,7 +2038,7 @@ class Subsonic_Api
             $response = Subsonic_XML_Data::createError(Subsonic_XML_Data::SSERROR_DATA_NOTFOUND, '', 'getsimilarsongs');
         } else {
             $response = Subsonic_XML_Data::createSuccessResponse('getsimilarsongs');
-            Subsonic_XML_Data::addSimilarSongs($response, $songs);
+            Subsonic_XML_Data::addSimilarSongs($response, $songs, $child);
         }
 
         self::apiOutput($input, $response);
@@ -2051,7 +2051,7 @@ class Subsonic_Api
      */
     public static function getsimilarsongs2($input)
     {
-        self::getsimilarsongs($input);
+        self::getsimilarsongs($input, "similarSongs2");
     }
 
     /**

--- a/lib/class/subsonic_xml_data.class.php
+++ b/lib/class/subsonic_xml_data.class.php
@@ -1384,11 +1384,11 @@ class Subsonic_XML_Data
      * @param $info
      * @param $similars
      */
-    public static function addArtistInfo($xml, $info, $similars)
+    public static function addArtistInfo($xml, $info, $similars, $child)
     {
         $artist = new Artist($info['id']);
 
-        $xartist = $xml->addChild('artistInfo');
+        $xartist = $xml->addChild($child);
         $xartist->addChild('biography', htmlspecialchars(trim((string) $info['summary'])));
         $xartist->addChild('musicBrainzId', $artist->mbid);
         //$xartist->addChild('lastFmUrl', "");
@@ -1408,9 +1408,9 @@ class Subsonic_XML_Data
      * @param SimpleXMLElement $xml
      * @param array $similar_songs
      */
-    public static function addSimilarSongs($xml, $similar_songs)
+    public static function addSimilarSongs($xml, $similar_songs, $child)
     {
-        $xsimilar = $xml->addChild('similarSongs');
+        $xsimilar = $xml->addChild($child);
         foreach ($similar_songs as $similar_song) {
             $song = new Song($similar_song['id']);
             $song->format();


### PR DESCRIPTION
returning getArtistInfo2 and getSimilarSongs2 into respectivly 'artistInfo2' and 'similarSongs2' childs.

previously returning into 'artistInfo' et 'similarSongs' childs.