### PR TITLE
Drop non-working `match` functionality

### DIFF
--- a/artists.php
+++ b/artists.php
@@ -88,33 +88,6 @@ switch ($_REQUEST['action']) {
         $target_url = AmpConfig::get('web_path') . "/artists.php?action=show&amp;artist=" . $object_id;
         require_once AmpConfig::get('prefix') . UI::find_template('show_update_items.inc.php');
         break;
-    case 'match':
-    case 'Match':
-        $match = scrub_in($_REQUEST['match']);
-        if ($match == "Browse" || $match == "Show_all") {
-            $chr = "";
-        } else {
-            $chr = $match;
-        }
-        /* Enclose this in the purty box! */
-        require AmpConfig::get('prefix') . UI::find_template('show_box_top.inc.php');
-        show_alphabet_list('artists', 'artists.php', $match);
-        show_alphabet_form($chr, T_('Show Artists starting with'), "artists.php?action=match");
-        require AmpConfig::get('prefix') . UI::find_template('show_box_bottom.inc.php');
-
-        if ($match === "Browse") {
-            show_artists();
-        } elseif ($match === "Show_all") {
-            $offset_limit = 999999;
-            show_artists();
-        } else {
-            if ($chr == '') {
-                show_artists('A');
-            } else {
-                show_artists($chr);
-            }
-        }
-        break;
     case 'show_missing':
         set_time_limit(600);
         $mbid    = $_REQUEST['mbid'];

--- a/tvshows.php
+++ b/tvshows.php
@@ -66,33 +66,6 @@ switch ($_REQUEST['action']) {
         $object_type = 'tvshow_season';
         require_once AmpConfig::get('prefix') . UI::find_template('show_tvshow.inc.php');
         break;
-    case 'match':
-    case 'Match':
-        $match = (string) scrub_in($_REQUEST['match']);
-        if ($match == "Browse") {
-            $chr = "";
-        } else {
-            $chr = $match;
-        }
-        /* Enclose this in the purty box! */
-        require AmpConfig::get('prefix') . UI::find_template('show_box_top.inc.php');
-        show_alphabet_list('tvshows', 'tvshows.php', $match);
-        show_alphabet_form($chr, T_('Show TV Shows starting with'), "tvshows.php?action=match");
-        require AmpConfig::get('prefix') . UI::find_template('show_box_bottom.inc.php');
-
-        if ($match === "Browse") {
-            show_tvshows();
-        } elseif ($match === "Show_all") {
-            $offset_limit = 999999;
-            show_tvshows();
-        } else {
-            if ($chr == '') {
-                show_tvshows('A');
-            } else {
-                show_tvshows($chr);
-            }
-        }
-        break;
 } // end switch
 
 // Show the Footer


### PR DESCRIPTION
It looks like that functionality is unused.
Also, some of the used methods in here (`show_alphabet_list`, `show_alphabet_form`, ...) do not longer exist, so it's at least broken.

Or - if there's some magic behind this - someone could enlighten me :bulb: 