### PR TITLE
Fix the played count when the cron_cache option is enabled

### DIFF
--- a/lib/class/stats.class.php
+++ b/lib/class/stats.class.php
@@ -209,14 +209,10 @@ class Stats
             $threshold = 0;
         }
 
-        if (AmpConfig::get('cron_cache') && !defined('NO_CRON_CACHE')) {
-            $sql = "SELECT `count` AS `object_cnt` FROM `cache_object_count` WHERE `object_type`= ? AND `object_id` = ? AND `count_type` = ? AND `threshold` = " . $threshold;
-        } else {
-            $sql = "SELECT COUNT(*) AS `object_cnt` FROM `object_count` WHERE `object_type`= ? AND `object_id` = ? AND `count_type` = ?";
-            if ($threshold > 0) {
-                $date = time() - (86400 * (int) $threshold);
-                $sql .= "AND `date` >= '" . $date . "'";
-            }
+        $sql = "SELECT COUNT(*) AS `object_cnt` FROM `object_count` WHERE `object_type`= ? AND `object_id` = ? AND `count_type` = ?";
+        if ($threshold > 0) {
+            $date = time() - (86400 * (int) $threshold);
+            $sql .= "AND `date` >= '" . $date . "'";
         }
 
         $db_results = Dba::read($sql, array($object_type, $object_id, $count_type));


### PR DESCRIPTION
As reported in #2587, if cron_cache option is enabled, then the number of times an object has been played is not properly shown in the UI until the bin/cron.inc script is executed.
This commit simply uses the object_count database always, as it used to be. It doesn't seem to be any advantage on using the cache_object_count as far as I can see, since it still needs to do a similar DB query.