### PR TITLE
mailauth is an integer and not boolean

### DIFF
--- a/lib/class/mailer.class.php
+++ b/lib/class/mailer.class.php
@@ -193,7 +193,7 @@ class Mailer
                 $mail->IsSMTP();
                 $mail->Host = $mailhost;
                 $mail->Port = $mailport;
-                if ($mailauth === true) {
+                if ($mailauth) {
                     $mail->SMTPAuth = true;
                     $mail->Username = $mailuser;
                     $mail->Password = $mailpass;


### PR DESCRIPTION
the "true"/"false" values in ini file is parsed as 1/0 and thus strict equality check won't work