### PR TITLE
jPlayer fullscreen shortcut disabled

### DIFF
--- a/lib/javascript/jplayer.ext.js
+++ b/lib/javascript/jplayer.ext.js
@@ -1,0 +1,2 @@
+// Disable fullscreen on f key down
+$.jPlayer.prototype.options.keyBindings.fullScreen = {}

--- a/templates/show_html5_player_headers.inc.php
+++ b/templates/show_html5_player_headers.inc.php
@@ -35,6 +35,7 @@ function update_action()
 <?php
 } ?>
 <script src="<?php echo AmpConfig::get('web_path'); ?>/lib/vendor/happyworm/jplayer/dist/jplayer/jquery.jplayer.min.js"></script>
+<script src="<?php echo AmpConfig::get('web_path'); ?>/lib/javascript/jplayer.ext.js"></script>
 <script src="<?php echo AmpConfig::get('web_path'); ?>/lib/vendor/happyworm/jplayer/dist/add-on/jplayer.playlist.min.js"></script>
 <script src="<?php echo AmpConfig::get('web_path'); ?>/lib/javascript/jplayer.playlist.ext.js"></script>
 


### PR DESCRIPTION
A long time annoying issue removed. I love to use the well known shortcut `CTRL+f` to find something on the page but jPlayer bind the `f` key without checking if `CTRL` was pressed too. With the useless fullscreen view, we don't need to bother anymore.

Have a nice day.