### PR TITLE
#2527 Playlist duration added to UI

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ This means Ampache now **requires** php-intl module/dll to be enabled.
 * Disable API/Subsonic password resets in 'simple_user_mode'
 * NEW plugin: 'Personal Favorites'. Show a shortcut to a favorite smartlist or playlist on the homepage
 * Run garbage collection after catalog_update.inc 'clean' or 'verify'
+* Added duration when browsing playlists and smartlists
 
 ### Changed
 

--- a/lib/class/browse.class.php
+++ b/lib/class/browse.class.php
@@ -38,6 +38,11 @@ class Browse extends Query
     public $show_header;
 
     /**
+     * @var integer $duration
+     */
+    public $duration;
+
+    /**
      * Constructor.
      *
      * @param integer|null $browse_id

--- a/templates/show_playlist.inc.php
+++ b/templates/show_playlist.inc.php
@@ -124,6 +124,7 @@ UI::show_box_top('<div id="playlist_row_' . $playlist->id . '">' . $title . '</d
     $browse->set_type('playlist_media');
     $browse->add_supplemental_object('playlist', $playlist->id);
     $browse->set_static_content(true);
+    $browse->duration = Search::get_total_duration($object_ids);
     $browse->show_objects($object_ids, true);
     $browse->store(); ?>
 </div>

--- a/templates/show_playlist_medias.inc.php
+++ b/templates/show_playlist_medias.inc.php
@@ -21,7 +21,7 @@
  */
 
 $web_path = AmpConfig::get('web_path');
-$seconds  = (isset($search) ? $search->last_duration : $playlist->last_duration;
+$seconds  = (isset($search)) ? $search->last_duration : $playlist->last_duration;
 $duration = floor($seconds / 3600) . gmdate(":i:s", $seconds % 3600)
 ?>
 <?php if ($browse->is_show_header()) {

--- a/templates/show_playlist_medias.inc.php
+++ b/templates/show_playlist_medias.inc.php
@@ -21,10 +21,12 @@
  */
 
 $web_path = AmpConfig::get('web_path');
-$playlist_duration = $playlist === NULL ? $search->get_total_duration($object_ids) : $playlist->get_total_duration();?>
+$playlist_duration_s = $playlist === NULL ? $search->get_total_duration($object_ids) : $playlist->get_total_duration();
+$playlist_duration = floor($playlist_duration_s / 3600) . gmdate(":i:s", $playlist_duration_s % 3600)
+?>
 <?php if ($browse->is_show_header()) {
     require AmpConfig::get('prefix') . UI::find_template('list_header.inc.php');
-    echo '<span class="item-duration">' . '| ' . T_('Duration') . ': ' . gmdate("H:i:s", $playlist_duration) . '</span>';
+    echo '<span class="item-duration">' . '| ' . T_('Duration') . ': ' . $playlist_duration . '</span>';
 } ?>
 <form method="post" id="reorder_playlist_<?php echo $playlist->id; ?>">
     <table id="reorder_playlist_table" class="tabledata <?php echo $browse->get_css_class() ?>" data-objecttype="media">
@@ -100,5 +102,5 @@ $playlist_duration = $playlist === NULL ? $search->get_total_duration($object_id
 <?php show_table_render($argument); ?>
 <?php if ($browse->is_show_header()) {
         require AmpConfig::get('prefix') . UI::find_template('list_header.inc.php');
-        echo '<span class="item-duration">' . '| ' . T_('Duration') . ': ' . gmdate("H:i:s",$playlist_duration) . '</span>';
+        echo '<span class="item-duration">' . '| ' . T_('Duration') . ': ' . $playlist_duration . '</span>';
     } ?>

--- a/templates/show_playlist_medias.inc.php
+++ b/templates/show_playlist_medias.inc.php
@@ -21,7 +21,7 @@
  */
 
 $web_path = AmpConfig::get('web_path');
-$seconds  = (isset($search)) ? $search->last_duration : $playlist->last_duration;
+$seconds  = $browse->duration;
 $duration = floor($seconds / 3600) . gmdate(":i:s", $seconds % 3600)
 ?>
 <?php if ($browse->is_show_header()) {

--- a/templates/show_playlist_medias.inc.php
+++ b/templates/show_playlist_medias.inc.php
@@ -21,7 +21,7 @@
  */
 
 $web_path = AmpConfig::get('web_path');
-$playlist_duration_s = $playlist === NULL ? $search->get_total_duration($object_ids) : $playlist->get_total_duration();
+$playlist_duration_s = $playlist === NULL ? $search->last_duration : $playlist->last_duration;
 $playlist_duration = floor($playlist_duration_s / 3600) . gmdate(":i:s", $playlist_duration_s % 3600)
 ?>
 <?php if ($browse->is_show_header()) {

--- a/templates/show_playlist_medias.inc.php
+++ b/templates/show_playlist_medias.inc.php
@@ -23,6 +23,7 @@
 $web_path = AmpConfig::get('web_path'); ?>
 <?php if ($browse->is_show_header()) {
     require AmpConfig::get('prefix') . UI::find_template('list_header.inc.php');
+    echo '<span class="item-count">' . '| ' . T_('Duration') . ': ' . gmdate("H:i:s",$playlist->get_total_duration()) . '</span>';
 } ?>
 <form method="post" id="reorder_playlist_<?php echo $playlist->id; ?>">
     <table id="reorder_playlist_table" class="tabledata <?php echo $browse->get_css_class() ?>" data-objecttype="media">
@@ -98,4 +99,5 @@ $web_path = AmpConfig::get('web_path'); ?>
 <?php show_table_render($argument); ?>
 <?php if ($browse->is_show_header()) {
         require AmpConfig::get('prefix') . UI::find_template('list_header.inc.php');
+        echo '<span class="item-count">' . '| ' . T_('Duration') . ': ' . gmdate("H:i:s",$playlist->get_total_duration()) . '</span>';
     } ?>

--- a/templates/show_playlist_medias.inc.php
+++ b/templates/show_playlist_medias.inc.php
@@ -20,10 +20,11 @@
  *
  */
 
-$web_path = AmpConfig::get('web_path'); ?>
+$web_path = AmpConfig::get('web_path');
+$playlist_duration =  $playlist->get_total_duration()?>
 <?php if ($browse->is_show_header()) {
     require AmpConfig::get('prefix') . UI::find_template('list_header.inc.php');
-    echo '<span class="item-count">' . '| ' . T_('Duration') . ': ' . gmdate("H:i:s",$playlist->get_total_duration()) . '</span>';
+    echo '<span class="item-duration">' . '| ' . T_('Duration') . ': ' . gmdate("H:i:s", $playlist_duration) . '</span>';
 } ?>
 <form method="post" id="reorder_playlist_<?php echo $playlist->id; ?>">
     <table id="reorder_playlist_table" class="tabledata <?php echo $browse->get_css_class() ?>" data-objecttype="media">
@@ -99,5 +100,5 @@ $web_path = AmpConfig::get('web_path'); ?>
 <?php show_table_render($argument); ?>
 <?php if ($browse->is_show_header()) {
         require AmpConfig::get('prefix') . UI::find_template('list_header.inc.php');
-        echo '<span class="item-count">' . '| ' . T_('Duration') . ': ' . gmdate("H:i:s",$playlist->get_total_duration()) . '</span>';
+        echo '<span class="item-duration">' . '| ' . T_('Duration') . ': ' . gmdate("H:i:s",$playlist_duration) . '</span>';
     } ?>

--- a/templates/show_playlist_medias.inc.php
+++ b/templates/show_playlist_medias.inc.php
@@ -21,12 +21,12 @@
  */
 
 $web_path = AmpConfig::get('web_path');
-$playlist_duration_s = $playlist === NULL ? $search->last_duration : $playlist->last_duration;
-$playlist_duration = floor($playlist_duration_s / 3600) . gmdate(":i:s", $playlist_duration_s % 3600)
+$seconds  = (isset($search) ? $search->last_duration : $playlist->last_duration;
+$duration = floor($seconds / 3600) . gmdate(":i:s", $seconds % 3600)
 ?>
 <?php if ($browse->is_show_header()) {
     require AmpConfig::get('prefix') . UI::find_template('list_header.inc.php');
-    echo '<span class="item-duration">' . '| ' . T_('Duration') . ': ' . $playlist_duration . '</span>';
+    echo '<span class="item-duration">' . '| ' . T_('Duration') . ': ' . $duration . '</span>';
 } ?>
 <form method="post" id="reorder_playlist_<?php echo $playlist->id; ?>">
     <table id="reorder_playlist_table" class="tabledata <?php echo $browse->get_css_class() ?>" data-objecttype="media">
@@ -102,5 +102,5 @@ $playlist_duration = floor($playlist_duration_s / 3600) . gmdate(":i:s", $playli
 <?php show_table_render($argument); ?>
 <?php if ($browse->is_show_header()) {
         require AmpConfig::get('prefix') . UI::find_template('list_header.inc.php');
-        echo '<span class="item-duration">' . '| ' . T_('Duration') . ': ' . $playlist_duration . '</span>';
+        echo '<span class="item-duration">' . '| ' . T_('Duration') . ': ' . $duration . '</span>';
     } ?>

--- a/templates/show_playlist_medias.inc.php
+++ b/templates/show_playlist_medias.inc.php
@@ -21,7 +21,7 @@
  */
 
 $web_path = AmpConfig::get('web_path');
-$playlist_duration =  $playlist->get_total_duration()?>
+$playlist_duration = $playlist === NULL ? $search->get_total_duration($object_ids) : $playlist->get_total_duration();?>
 <?php if ($browse->is_show_header()) {
     require AmpConfig::get('prefix') . UI::find_template('list_header.inc.php');
     echo '<span class="item-duration">' . '| ' . T_('Duration') . ': ' . gmdate("H:i:s", $playlist_duration) . '</span>';

--- a/templates/show_playlist_row.inc.php
+++ b/templates/show_playlist_row.inc.php
@@ -60,6 +60,7 @@
 <td class="cel_last_update"><?php echo $libitem->f_last_update ?></td>
 <td class="cel_type"><?php echo $libitem->f_type; ?></td>
 <td class="cel_medias"><?php echo $libitem->get_media_count(); ?></td>
+<td class="cel_duration"><?php echo gmdate("H:i:s",$libitem->get_total_duration()); ?></td>
 <td class="cel_owner"><?php echo scrub_out($libitem->f_user); ?></td>
 <?php
     if (User::is_registered()) {

--- a/templates/show_playlist_row.inc.php
+++ b/templates/show_playlist_row.inc.php
@@ -60,7 +60,6 @@
 <td class="cel_last_update"><?php echo $libitem->f_last_update ?></td>
 <td class="cel_type"><?php echo $libitem->f_type; ?></td>
 <td class="cel_medias"><?php echo $libitem->get_media_count(); ?></td>
-<td class="cel_duration"><?php echo gmdate("H:i:s",$libitem->get_total_duration()); ?></td>
 <td class="cel_owner"><?php echo scrub_out($libitem->f_user); ?></td>
 <?php
     if (User::is_registered()) {

--- a/templates/show_playlists.inc.php
+++ b/templates/show_playlists.inc.php
@@ -35,6 +35,7 @@
             <th class="cel_last_update optional"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&type=playlist&sort=last_update', T_('Last Update'), 'playlist_sort_last_update'); ?></th>
             <th class="cel_type optional"><?php echo T_('Type'); ?></th>
             <th class="cel_medias optional"><?php /* HINT: Number of items in a playlist */ echo T_('# Items'); ?></th>
+            <th class="cel_duration optional"><?php echo T_('Duration'); ?></th>
             <th class="cel_owner optional"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&type=playlist&sort=user', T_('Owner'), 'playlist_sort_owner'); ?></th>
             <?php if (User::is_registered()) { ?>
                 <?php if (AmpConfig::get('ratings')) { ?>
@@ -83,6 +84,7 @@
             <th class="cel_last_update"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&type=playlist&sort=last_update', T_('Last Update'), 'playlist_sort_last_update_bottom'); ?></th>
             <th class="cel_type optional"><?php echo T_('Type'); ?></th>
             <th class="cel_medias optional"><?php /* HINT: Number of items in a playlist */ echo T_('# Items'); ?></th>
+            <th class="cel_duration optional"><?php echo T_('Duration'); ?></th>
             <th class="cel_owner optional"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&type=playlist&sort=user', T_('Owner'), 'playlist_sort_owner_bottom'); ?></th>
             <?php if (User::is_registered()) { ?>
                 <?php if (AmpConfig::get('ratings')) { ?>

--- a/templates/show_playlists.inc.php
+++ b/templates/show_playlists.inc.php
@@ -35,7 +35,6 @@
             <th class="cel_last_update optional"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&type=playlist&sort=last_update', T_('Last Update'), 'playlist_sort_last_update'); ?></th>
             <th class="cel_type optional"><?php echo T_('Type'); ?></th>
             <th class="cel_medias optional"><?php /* HINT: Number of items in a playlist */ echo T_('# Items'); ?></th>
-            <th class="cel_duration optional"><?php echo T_('Duration'); ?></th>
             <th class="cel_owner optional"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&type=playlist&sort=user', T_('Owner'), 'playlist_sort_owner'); ?></th>
             <?php if (User::is_registered()) { ?>
                 <?php if (AmpConfig::get('ratings')) { ?>
@@ -84,7 +83,6 @@
             <th class="cel_last_update"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&type=playlist&sort=last_update', T_('Last Update'), 'playlist_sort_last_update_bottom'); ?></th>
             <th class="cel_type optional"><?php echo T_('Type'); ?></th>
             <th class="cel_medias optional"><?php /* HINT: Number of items in a playlist */ echo T_('# Items'); ?></th>
-            <th class="cel_duration optional"><?php echo T_('Duration'); ?></th>
             <th class="cel_owner optional"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&type=playlist&sort=user', T_('Owner'), 'playlist_sort_owner_bottom'); ?></th>
             <?php if (User::is_registered()) { ?>
                 <?php if (AmpConfig::get('ratings')) { ?>

--- a/templates/show_search.inc.php
+++ b/templates/show_search.inc.php
@@ -65,6 +65,7 @@ UI::show_box_top('<div id="smartplaylist_row_' . $playlist->id . '">' . $title .
     $browse->set_type('playlist_media');
     $browse->add_supplemental_object('search', $playlist->id);
     $browse->set_static_content(false);
+    $browse->duration = Search::get_total_duration($object_ids);
     $browse->show_objects($object_ids);
     $browse->store(); ?>
 </div>

--- a/themes/reborn/templates/dark.css
+++ b/themes/reborn/templates/dark.css
@@ -609,7 +609,9 @@ div.jp-playlist li {
     border-color: #1d1d1d;
 }
 
-span.item-count, span.item-duration, span.query-count {
+span.item-count,
+span.item-duration,
+span.query-count {
     color: #999;
 }
 

--- a/themes/reborn/templates/dark.css
+++ b/themes/reborn/templates/dark.css
@@ -609,8 +609,7 @@ div.jp-playlist li {
     border-color: #1d1d1d;
 }
 
-span.item-count,
-span.query-count {
+span.item-count, span.item-duration, span.query-count {
     color: #999;
 }
 

--- a/themes/reborn/templates/default.css
+++ b/themes/reborn/templates/default.css
@@ -1887,7 +1887,8 @@ input.list-header-navmenu-input {
     text-align: center;
 }
 
-span.item-count, span.item-duration {
+span.item-count,
+span.item-duration {
     font-size: 11px;
 }
 

--- a/themes/reborn/templates/default.css
+++ b/themes/reborn/templates/default.css
@@ -1887,7 +1887,7 @@ input.list-header-navmenu-input {
     text-align: center;
 }
 
-span.item-count {
+span.item-count, span.item-duration {
     font-size: 11px;
 }
 

--- a/themes/reborn/templates/light.css
+++ b/themes/reborn/templates/light.css
@@ -614,8 +614,7 @@ div.jp-playlist li {
     border-color: #fff;
 }
 
-span.item-count,
-span.query-count {
+span.item-count, span.item-duration, span.query-count {
     color: #000;
 }
 

--- a/themes/reborn/templates/light.css
+++ b/themes/reborn/templates/light.css
@@ -614,7 +614,9 @@ div.jp-playlist li {
     border-color: #fff;
 }
 
-span.item-count, span.item-duration, span.query-count {
+span.item-count,
+span.item-duration,
+span.query-count {
     color: #000;
 }
 


### PR DESCRIPTION
Initially, it was added as a column in `show_playlists.inc.php`, however, after user feedback, it has been changed to be shown inside `show_playlist_medias.inc.php` for a better look.

![2527](https://user-images.githubusercontent.com/2078392/98666238-00ee4000-234d-11eb-8802-f5c54f807337.png)

note 1: It works both for normal playlists and smart playlists.
note 2: In case the duration is >86400 seconds (a day) the hour format takes in all the extra hours i.e. 99728s = 27:42:08.