### PR TITLE
Add live streams to getindexes API method

### DIFF
--- a/lib/class/ApiMethods/GetIndexesMethod.php
+++ b/lib/class/ApiMethods/GetIndexesMethod.php
@@ -50,7 +50,7 @@ final class GetIndexesMethod
      * Added 'include' to allow indexing all song tracks (enabled for xml by default)
      *
      * @param array $input
-     * type    = (string) 'song', 'album', 'artist', 'album_artist', 'playlist', 'podcast', 'podcast_episode', 'video'
+     * type    = (string) 'song', 'album', 'artist', 'album_artist', 'playlist', 'podcast', 'podcast_episode', 'video', 'live_stream'
      * filter  = (string) //optional
      * exact   = (integer) 0,1, if true filter is exact rather then fuzzy //optional
      * add     = self::set_filter(date) //optional
@@ -79,7 +79,7 @@ final class GetIndexesMethod
         $user    = User::get_from_username(Session::username($input['auth']));
         $include = (int) $input['include'] == 1;
         // confirm the correct data
-        if (!in_array($type, array('song', 'album', 'artist', 'album_artist', 'playlist', 'podcast', 'podcast_episode', 'video'))) {
+        if (!in_array($type, array('song', 'album', 'artist', 'album_artist', 'playlist', 'podcast', 'podcast_episode', 'video', 'live_stream'))) {
             Api::error(sprintf(T_('Bad Request: %s'), $type), '4710', self::ACTION, 'type', $input['api_format']);
 
             return false;

--- a/lib/class/xml_data.class.php
+++ b/lib/class/xml_data.class.php
@@ -365,7 +365,7 @@ class XML_Data
      * we want
      *
      * @param  array $objects (description here...)
-     * @param  string $object_type 'artist'|'album'|'song'|'playlist'|'share'|'podcast'|'podcast_episode'
+     * @param  string $object_type 'artist'|'album'|'song'|'playlist'|'share'|'podcast'|'podcast_episode'|'live_stream'
      * @param  boolean $full_xml whether to return a full XML document or just the node.
      * @param  boolean $include include episodes from podcasts or tracks in a playlist
      * @return string   return xml
@@ -377,7 +377,7 @@ class XML_Data
         }
         $string = "<total_count>" . Catalog::get_count($object_type) . "</total_count>\n";
 
-        // 'artist'|'album'|'song'|'playlist'|'share'|'podcast'|'podcast_episode'
+        // 'artist'|'album'|'song'|'playlist'|'share'|'podcast'|'podcast_episode'|'live_stream'
         foreach ($objects as $object_id) {
             switch ($object_type) {
                 case 'artist':
@@ -480,6 +480,14 @@ class XML_Data
                 case 'video':
                     $string .= self::videos($objects);
                     break;
+                case 'live_stream':
+                    $live_stream = new Live_Stream($object_id);
+                    $live_stream->format();
+                    $string .= "<$object_type id=\"" . $object_id . "\">\n" .
+                        "\t<name><![CDATA[" . $live_stream->f_name . "]]></name>\n" .
+                        "\t<url><![CDATA[" . $live_stream->url . "]]></url>\n" .
+                        "\t<codec><![CDATA[" . $live_stream->codec . "]]></codec>\n" .
+                        "</$object_type>\n";
             }
         } // end foreach objects
 


### PR DESCRIPTION
Hi,

I would like to support Radio Stations in my client. This pull request adds them to the get_indexes API method. Please consider for inclusion in the next version.

Thank you