### PR TITLE
Fix metadata plugin

### DIFF
--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -663,9 +663,6 @@ class vainfo
     private function _get_plugin_tags()
     {
         $tag_order = $this->get_metadata_order();
-        if (!empty($tag_order)) {
-            $tag_order = array($tag_order);
-        }
 
         $plugin_names = Plugin::get_plugins('get_metadata');
         foreach ($tag_order as $tag_source) {


### PR DESCRIPTION
Currently, metadata plugin doesn't work in `develop`.
This probably broke [here](https://github.com/ampache/ampache/commit/1919bbf0b5ce5a73350379724096d5ce48645896#diff-f2e481950543ffffda33cd96e45effdcf291fbde50e3c2000c60f9a79c6a63daR640).

`$tag_order` is always an array.
I think this wrapping is unnecessarily.

