### PR TITLE
Make http_host auto-estimation more robust

### DIFF
--- a/lib/init.php
+++ b/lib/init.php
@@ -83,7 +83,13 @@ if (isset($ow_config) && is_array($ow_config)) {
 
 $results['raw_web_path'] = $results['web_path'];
 if (empty($results['http_host'])) {
-    $results['http_host'] = $_SERVER['SERVER_NAME'];
+    if (!empty($_SERVER['HTTP_HOST'])) {
+        $results['http_host'] = $_SERVER['HTTP_HOST'];
+    } elseif (!empty($_SERVER['SERVER_NAME'])) {
+        $results['http_host'] = $_SERVER['SERVER_NAME'];
+    } else {
+        $results['http_host'] = 'localhost';
+    }
 }
 if (empty($results['local_web_path'])) {
     $results['local_web_path'] = $http_type . $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] . $results['raw_web_path'];


### PR DESCRIPTION
Prefer `HTTP_HOST` over `SERVER_NAME`, if defined. SERVER_NAME is not reliable as it depends on the webserver config and might be empty, set to the local server hostname, a wildcard/regex or another invalid string for internal identification only. HTTP_HOST matches the client request and should hence work the same way it did for the current client request, when using for redirects. If in unexpected circumstances both variables are not set or empty, "localhost" is used as fallback.
_________
Other uses of SERVER_NAME:

I see `local_web_path` below using SERVER_NAME as well, but since it shall be a local URL explicitly, SERVER_NAME is probably the better guess based on how most webservers set it by default.

What I do not understand is the CLI block below:
```
if (!defined('CLI')) {
    $_SERVER['SERVER_NAME'] = $_SERVER['SERVER_NAME'] ?: '';
}
```
It seems like to have zero effect, assigning the same value if it is set and an empty string if not?

Probably it makes sense to use `$results['http_host']` as well for the OAuth module here: https://github.com/ampache/ampache/blob/develop/modules/oauth/OAuth.php#L374