### PR TITLE
recognize opus in _clean_type

### DIFF
--- a/lib/class/vainfo.class.php
+++ b/lib/class/vainfo.class.php
@@ -757,6 +757,7 @@ class vainfo
             case 'mpeg3':
                 return 'mp3';
             case 'vorbis':
+            case 'opus':
                 return 'ogg';
             case 'flac':
             case 'flv':


### PR DESCRIPTION
When updating the catalog, it was not able to determine the file type of opus files:
```
2021-01-09T21:23:47+00:00 [admin] (vainfo.class) -> Unable to determine file type from opus on file /data/musik/Porcupine Tree/2008 - We Lost the Skyline/01. The Sky Moves Sideways.opus
2021-01-09T21:23:47+00:00 [admin] (vainfo.class) -> Checking /(.+?)\/([0-9]+?)\s\-\s(.+?)\/([0-9]+?)\.\s(.+?)\..+$/ _ Array on Porcupine Tree/2008 - We Lost the Skyline/01. The Sky Moves Sideways.opus
2021-01-09T21:23:47+00:00 [admin] (vainfo.class) -> /(.+?)\/([0-9]+?)\s\-\s(.+?)\/([0-9]+?)\.\s(.+?)\..+$/ matched Porcupine Tree/2008 - We Lost the Skyline/01. The Sky Moves Sideways.opus on Porcupine Tree/2008 - We Lost the Skyline/01. The Sky Moves Sideways.opus
2021-01-09T21:23:47+00:00 [admin] (vainfo.class) -> Cleaning vorbis
```

After the change:
```
2021-01-09T21:39:17+00:00 [admin] (vainfo.class) -> Checking /(.+?)\/([0-9]+?)\s\-\s(.+?)\/([0-9]+?)\.\s(.+?)\..+$/ _ Array on Porcupine Tree/2008 - We Lost the Skyline/01. The Sky Moves Sideways.opus
2021-01-09T21:39:17+00:00 [admin] (vainfo.class) -> /(.+?)\/([0-9]+?)\s\-\s(.+?)\/([0-9]+?)\.\s(.+?)\..+$/ matched Porcupine Tree/2008 - We Lost the Skyline/01. The Sky Moves Sideways.opus on Porcupine Tree/2008 - We Lost the Skyline/01. The Sky Moves Sideways.opus
2021-01-09T21:39:17+00:00 [admin] (vainfo.class) -> Cleaning vorbis
```

Might be related to #2679, though it doesn't fix it.