### PR TITLE
Use outline for album art hover

### DIFF
--- a/public/themes/reborn/templates/dark.css
+++ b/public/themes/reborn/templates/dark.css
@@ -513,7 +513,7 @@ span.fatalerror {
 }
 
 .item_art:hover {
-    border-color: #ff9d00;
+    color: #ff9d00;
 }
 
 #information_actions ul li {

--- a/public/themes/reborn/templates/default.css
+++ b/public/themes/reborn/templates/default.css
@@ -1104,6 +1104,11 @@ table.tabledata tbody td.cel_userflag {
     max-width: 40px;
 }
 
+table.tabledata tbody .cel_cover {
+    overflow: visible;
+    padding-top: 10px;
+}
+
 table.tabledata tbody .cel_cover,
 table.tabledata tbody .cel_tags,
 table.tabledata tbody .cel_license {
@@ -1113,6 +1118,7 @@ table.tabledata tbody .cel_license {
 
 table.tabledata tbody td.mash_cover {
     height: auto;
+    overflow: visible;
 }
 
 table.tabledata tbody td.mash_userflag {
@@ -1125,14 +1131,7 @@ table.tabledata tbody .cel_cover img {
     -webkit-border-radius: 2px;
     -moz-border-radius: 2px;
     border-radius: 2px;
-    margin: 2px;
     object-fit: cover;
-}
-
-table.tabledata tbody .mash_cover img:hover,
-table.tabledata tbody .cel_cover img:hover {
-    border: 2px solid;
-    margin: 0;
 }
 
 table.tabledata .cel_drag {
@@ -1326,7 +1325,6 @@ table.disablegv td.cel_rating {
     -webkit-border-radius: 2px;
     -moz-border-radius: 2px;
     border-radius: 2px;
-    margin: 2px;
 }
 
 .random_selection .random_video .art_album img {
@@ -1337,11 +1335,6 @@ table.disablegv td.cel_rating {
     width: 100px;
     height: 150px;
     margin: 2px;
-}
-
-.random_selection .random_album .art_album img:hover {
-    border: 2px solid;
-    margin: 0;
 }
 
 .random_selection .random_album .star-rating,
@@ -1592,7 +1585,6 @@ span.fatalerror {
 }
 
 .item_art {
-    border: 2px solid transparent;
     display: inline-block;
     position: relative;
 }
@@ -1641,16 +1633,20 @@ span.fatalerror {
     -moz-border-radius: 2px;
     border-radius: 2px;
     float: left;
-    margin: 2px;
 }
 
-.item_art_actions img {
-    float: none;
+.item_art > a {
+    display: block;
 }
 
 .item_art:hover {
-    border: 2px solid;
-    margin: 0;
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+}
+
+.item_art_actions img {
+    margin: 2px;
+    float: none;
 }
 
 .item_art:hover  .item_art_actions {

--- a/public/themes/reborn/templates/light.css
+++ b/public/themes/reborn/templates/light.css
@@ -511,7 +511,7 @@ span.fatalerror {
 }
 
 .item_art:hover {
-    border-color: #1990db;
+    color: #1990db;
 }
 
 #information_actions ul li {


### PR DESCRIPTION
This addresses several issues

1. Major layout shift when hovering over last item of first row in mashup view (sporadic)
![firefox_le0KM5hqEk](https://user-images.githubusercontent.com/5735900/106215028-2ab85400-6224-11eb-871d-1cd6dc6bee1f.png)

2. Border appears when hovering over .item_art but no action is available; another border appears when the img is hovered which also has minor layout shift

Now a single outline appears when hovering over the art as expected

![firefox_o4z2AxRkXM](https://user-images.githubusercontent.com/5735900/106215198-85ea4680-6224-11eb-8389-62d58e3ad2c9.png) ![firefox_IAUtd1XQOR](https://user-images.githubusercontent.com/5735900/106215200-897dcd80-6224-11eb-8c83-08c2340bc213.png)

3. Cover art box-shadow was being clipped

