### PR TITLE
Added Ajax::button_with_text to have img and text in single link

### DIFF
--- a/public/templates/show_album.inc.php
+++ b/public/templates/show_album.inc.php
@@ -133,13 +133,11 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
         $play       = T_('Play');
         $playlast   = T_('Play Last'); ?>
         <li>
-            <?php echo Ajax::button('?page=stream&action=directplay&object_type=album&' . $album->get_http_album_query_ids('object_id'), 'play', $play, 'directplay_full_' . $album->id); ?>
-            <?php echo Ajax::text('?page=stream&action=directplay&object_type=album&' . $album->get_http_album_query_ids('object_id'), $play, 'directplay_full_text_' . $album->id); ?>
+            <?php echo Ajax::button_with_text('?page=stream&action=directplay&object_type=album&' . $album->get_http_album_query_ids('object_id'), 'play', $play, 'directplay_full_' . $album->id); ?>
         </li>
             <?php if (Stream_Playlist::check_autoplay_append()) { ?>
         <li>
-            <?php echo Ajax::button('?page=stream&action=directplay&object_type=album&' . $album->get_http_album_query_ids('object_id') . '&append=true', 'play_add', $playlast, 'addplay_album_' . $album->id); ?>
-            <?php echo Ajax::text('?page=stream&action=directplay&object_type=album&' . $album->get_http_album_query_ids('object_id') . '&append=true', $playlast, 'addplay_album_text_' . $album->id); ?>
+            <?php echo Ajax::button_with_text('?page=stream&action=directplay&object_type=album&' . $album->get_http_album_query_ids('object_id') . '&append=true', 'play_add', $playlast, 'addplay_album_' . $album->id); ?>
         </li>
             <?php
         } ?>
@@ -151,18 +149,14 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
         $randtotemp = T_('Random to Temporary Playlist');
         $addtoexist = T_('Add to playlist'); ?>
         <li>
-            <?php echo Ajax::button('?action=basket&type=album&' . $album->get_http_album_query_ids('id'), 'add', $addtotemp, 'play_full_' . $album->id); ?>
-            <?php echo Ajax::text('?action=basket&type=album&' . $album->get_http_album_query_ids('id'), $addtotemp, 'play_full_text_' . $album->id); ?>
+            <?php echo Ajax::button_with_text('?action=basket&type=album&' . $album->get_http_album_query_ids('id'), 'add', $addtotemp, 'play_full_' . $album->id); ?>
         </li>
         <li>
-            <?php echo Ajax::button('?action=basket&type=album_random&' . $album->get_http_album_query_ids('id'), 'random', $randtotemp, 'play_random_' . $album->id); ?>
-            <?php echo Ajax::text('?action=basket&type=album_random&' . $album->get_http_album_query_ids('id'), $randtotemp, 'play_random_text_' . $album->id); ?>
+            <?php echo Ajax::button_with_text('?action=basket&type=album_random&' . $album->get_http_album_query_ids('id'), 'random', $randtotemp, 'play_random_' . $album->id); ?>
         </li>
         <li>
             <a id="<?php echo 'add_playlist_' . $album->id ?>" onclick="showPlaylistDialog(event, 'album', '<?php echo $album->id ?>')">
                 <?php echo Ui::get_icon('playlist_add', $addtoexist); ?>
-            </a>
-            <a id="<?php echo 'add_playlist_' . $album->id ?>" onclick="showPlaylistDialog(event, 'album', '<?php echo $album->id ?>')">
                 <?php echo $addtoexist ?>
             </a>
         </li>
@@ -178,8 +172,10 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
             <?php if (AmpConfig::get('sociable')) {
         $postshout = T_('Post Shout'); ?>
             <li>
-                <a href="<?php echo AmpConfig::get('web_path'); ?>/shout.php?action=show_add_shout&type=album&id=<?php echo $album->id; ?>"><?php echo UI::get_icon('comment', $postshout); ?></a>
-                <a href="<?php echo AmpConfig::get('web_path'); ?>/shout.php?action=show_add_shout&type=album&id=<?php echo $album->id; ?>"><?php echo $postshout; ?></a>
+                <a href="<?php echo AmpConfig::get('web_path'); ?>/shout.php?action=show_add_shout&type=album&id=<?php echo $album->id; ?>">
+                    <?php echo UI::get_icon('comment', $postshout); ?>
+                    <?php echo $postshout; ?>
+                </a>
             </li>
             <?php
     } ?>
@@ -198,8 +194,10 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
         $saveorder  = T_('Save Track Order'); ?>
         <?php if (AmpConfig::get('statistical_graphs') && is_dir(__DIR__ . '/../../vendor/szymach/c-pchart/src/Chart/')) { ?>
             <li>
-                <a href="<?php echo AmpConfig::get('web_path'); ?>/stats.php?action=graph&object_type=album&object_id=<?php echo $album->id; ?>"><?php echo Ui::get_icon('statistics', T_('Graphs')); ?></a>
-                <a href="<?php echo AmpConfig::get('web_path'); ?>/stats.php?action=graph&object_type=album&object_id=<?php echo $album->id; ?>"><?php echo T_('Graphs'); ?></a>
+                <a href="<?php echo AmpConfig::get('web_path'); ?>/stats.php?action=graph&object_type=album&object_id=<?php echo $album->id; ?>">
+                    <?php echo Ui::get_icon('statistics', T_('Graphs')); ?>
+                    <?php echo T_('Graphs'); ?>
+                </a>
             </li>
         <?php
         } ?>
@@ -207,11 +205,14 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
             <a onclick="submitNewItemsOrder('<?php echo $album->id; ?>', 'reorder_songs_table_<?php echo $album->id; ?>', 'song_',
                                             '<?php echo AmpConfig::get('web_path'); ?>/albums.php?action=set_track_numbers', '<?php echo RefreshAlbumSongsAction::REQUEST_KEY; ?>')">
                 <?php echo Ui::get_icon('save', $saveorder); ?>
-                &nbsp;&nbsp;<?php echo $saveorder; ?>
+                <?php echo $saveorder; ?>
             </a>
         </li>
         <li>
-            <a href="javascript:NavigateTo('<?php echo $web_path; ?>/albums.php?action=update_from_tags&amp;album_id=<?php echo $album->id; ?>');" onclick="return confirm('<?php echo T_('Do you really want to update from tags?'); ?>');"><?php echo Ui::get_icon('file_refresh', T_('Update from tags')); ?> &nbsp;&nbsp;<?php echo T_('Update from tags'); ?></a>
+            <a href="javascript:NavigateTo('<?php echo $web_path; ?>/albums.php?action=update_from_tags&amp;album_id=<?php echo $album->id; ?>');" onclick="return confirm('<?php echo T_('Do you really want to update from tags?'); ?>');">
+                <?php echo Ui::get_icon('file_refresh', T_('Update from tags')); ?>
+                <?php echo T_('Update from tags'); ?>
+            </a>
         </li>
         <?php
     } ?>
@@ -222,7 +223,7 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
                 <li>
                     <a href="<?php echo $web_path; ?>/upload.php?artist=<?php echo($album->album_artist ? $album->album_artist : $album->artist_id); ?>&album=<?php echo $album->id ?>">
                         <?php echo Ui::get_icon('upload', $t_upload); ?>
-                        &nbsp;&nbsp;<?php echo $t_upload; ?>
+                        <?php echo $t_upload; ?>
                     </a>
                 </li>
             <?php
@@ -230,8 +231,6 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
         <li>
             <a id="<?php echo 'edit_album_' . $album->id ?>" onclick="showEditDialog('album_row', '<?php echo $album->id ?>', '<?php echo 'edit_album_' . $album->id ?>', '<?php echo $albumedit ?>', '')">
                 <?php echo Ui::get_icon('edit', T_('Edit')); ?>
-            </a>
-            <a id="<?php echo 'edit_album_' . $album->id ?>" onclick="showEditDialog('album_row', '<?php echo $album->id ?>', '<?php echo 'edit_album_' . $album->id ?>', '<?php echo $albumedit ?>', '')">
                 <?php echo T_('Edit Album'); ?>
             </a>
         </li>
@@ -244,8 +243,10 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
         if (Access::check_function('batch_download') && $zipHandler->isZipable('album')) {
             $download   = T_('Download'); ?>
         <li>
-            <a class="nohtml" href="<?php echo $web_path; ?>/batch.php?action=album&<?php echo $album->get_http_album_query_ids('id'); ?>"><?php echo Ui::get_icon('batch_download', $download); ?></a>
-            <a class="nohtml" href="<?php echo $web_path; ?>/batch.php?action=album&<?php echo $album->get_http_album_query_ids('id'); ?>"><?php echo $download; ?></a>
+            <a class="nohtml" href="<?php echo $web_path; ?>/batch.php?action=album&<?php echo $album->get_http_album_query_ids('id'); ?>">
+                <?php echo Ui::get_icon('batch_download', $download); ?>
+                <?php echo $download; ?>
+            </a>
         </li>
         <?php
         } ?>
@@ -253,7 +254,8 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
             $delete = T_('Delete'); ?>
         <li>
             <a id="<?php echo 'delete_album_' . $album->id ?>" href="<?php echo AmpConfig::get('web_path'); ?>/albums.php?action=delete&album_id=<?php echo $album->id; ?>">
-                <?php echo Ui::get_icon('delete', $delete); ?> <?php echo $delete; ?>
+                <?php echo Ui::get_icon('delete', $delete); ?>
+                <?php echo $delete; ?>
             </a>
         </li>
         <?php

--- a/public/templates/show_album_group_disks.inc.php
+++ b/public/templates/show_album_group_disks.inc.php
@@ -99,13 +99,11 @@ $zipHandler = $dic->get(ZipHandlerInterface::class);
     <ul>
         <?php if ($show_direct_play) { ?>
         <li>
-            <?php echo Ajax::button('?page=stream&action=directplay&object_type=album&' . $album->get_http_album_query_ids('object_id'), 'play', T_('Play'), 'directplay_full_'); ?>
-            <?php echo Ajax::text('?page=stream&action=directplay&object_type=album&' . $album->get_http_album_query_ids('object_id'), T_('Play'), 'directplay_full_text_'); ?>
+            <?php echo Ajax::button_with_text('?page=stream&action=directplay&object_type=album&' . $album->get_http_album_query_ids('object_id'), 'play', T_('Play'), 'directplay_full_'); ?>
         </li>
             <?php if (Stream_Playlist::check_autoplay_append()) { ?>
         <li>
-            <?php echo Ajax::button('?page=stream&action=directplay&object_type=album&' . $album->get_http_album_query_ids('object_id') . '&append=true', 'play_add', T_('Play Last'), 'addplay_album_'); ?>
-            <?php echo Ajax::text('?page=stream&action=directplay&object_type=album&' . $album->get_http_album_query_ids('object_id') . '&append=true', T_('Play Last'), 'addplay_album_text_'); ?>
+            <?php echo Ajax::button_with_text('?page=stream&action=directplay&object_type=album&' . $album->get_http_album_query_ids('object_id') . '&append=true', 'play_add', T_('Play Last'), 'addplay_album_'); ?>
         </li>
             <?php
         } ?>
@@ -113,25 +111,28 @@ $zipHandler = $dic->get(ZipHandlerInterface::class);
     } ?>
         <?php if ($show_playlist_add) { ?>
         <li>
-            <?php echo Ajax::button('?action=basket&type=album&' . $album->get_http_album_query_ids('id'), 'add', T_('Add to Temporary Playlist'), 'play_full_'); ?>
-            <?php echo Ajax::text('?action=basket&type=album&' . $album->get_http_album_query_ids('id'), T_('Add to Temporary Playlist'), 'play_full_text_'); ?>
+            <?php echo Ajax::button_with_text('?action=basket&type=album&' . $album->get_http_album_query_ids('id'), 'add', T_('Add to Temporary Playlist'), 'play_full_'); ?>
         </li>
         <li>
-            <?php echo Ajax::button('?action=basket&type=album_random&' . $album->get_http_album_query_ids('id'), 'random', T_('Random to Temporary Playlist'), 'play_random_'); ?>
-            <?php echo Ajax::text('?action=basket&type=album_random&' . $album->get_http_album_query_ids('id'), T_('Random to Temporary Playlist'), 'play_random_text_'); ?>
+            <?php echo Ajax::button_with_text('?action=basket&type=album_random&' . $album->get_http_album_query_ids('id'), 'random', T_('Random to Temporary Playlist'), 'play_random_'); ?>
         </li>
         <?php
     } ?>
         <?php if (Access::check('interface', 50)) { ?>
             <li>
-                <a href="javascript:NavigateTo('<?php echo $web_path; ?>/albums.php?action=update_group_from_tags&amp;album_id=<?php echo $album->id; ?>');" onclick="return confirm('<?php echo T_('Do you really want to update from tags?'); ?>');"><?php echo Ui::get_icon('file_refresh', T_('Update from tags')); ?> &nbsp;&nbsp;<?php echo T_('Update from tags'); ?></a>
+                <a href="javascript:NavigateTo('<?php echo $web_path; ?>/albums.php?action=update_group_from_tags&amp;album_id=<?php echo $album->id; ?>');" onclick="return confirm('<?php echo T_('Do you really want to update from tags?'); ?>');">
+                    <?php echo Ui::get_icon('file_refresh', T_('Update from tags')); ?>
+                    <?php echo T_('Update from tags'); ?>
+                </a>
             </li>
             <?php
         } ?>
         <?php if (Access::check_function('batch_download') && $zipHandler->isZipable('album')) { ?>
         <li>
-            <a class="nohtml" href="<?php echo $web_path; ?>/batch.php?action=album&<?php echo $album->get_http_album_query_ids('id'); ?>"><?php echo Ui::get_icon('batch_download', T_('Download')); ?></a>
-            <a class="nohtml" href="<?php echo $web_path; ?>/batch.php?action=album&<?php echo $album->get_http_album_query_ids('id'); ?>"><?php echo T_('Download'); ?></a>
+            <a class="nohtml" href="<?php echo $web_path; ?>/batch.php?action=album&<?php echo $album->get_http_album_query_ids('id'); ?>">
+                <?php echo Ui::get_icon('batch_download', T_('Download')); ?>
+                <?php echo T_('Download'); ?>
+            </a>
         </li>
         <?php
     } ?>

--- a/public/templates/show_artist.inc.php
+++ b/public/templates/show_artist.inc.php
@@ -124,28 +124,25 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
         <li>
             <?php if ($object_type == 'album') { ?>
             <a href="<?php echo $web_path; ?>/artists.php?action=show_all_songs&amp;artist=<?php echo $artist->id; ?>">
-            <?php echo Ui::get_icon('view', T_("Show All")); ?></a>
-            <a href="<?php echo $web_path; ?>/artists.php?action=show_all_songs&amp;artist=<?php echo $artist->id; ?>">
+                <?php echo Ui::get_icon('view', T_("Show All")); ?>
                 <?php echo T_("Show All"); ?>
             </a>
             <?php
     } else { ?>
             <a href="<?php echo $web_path; ?>/artists.php?action=show&amp;artist=<?php echo $artist->id; ?>">
-            <?php echo Ui::get_icon('view', T_("Show Albums")); ?></a>
-            <a href="<?php echo $web_path; ?>/artists.php?action=show&amp;artist=<?php echo $artist->id; ?>">
-            <?php echo T_("Show Albums"); ?></a>
+                <?php echo Ui::get_icon('view', T_("Show Albums")); ?>
+                <?php echo T_("Show Albums"); ?>
+            </a>
             <?php
     } ?>
         </li>
         <?php if ($show_direct_play) { ?>
         <li>
-            <?php echo Ajax::button('?page=stream&action=directplay&object_type=artist&object_id=' . $artist->id, 'play', T_('Play All'), 'directplay_full_' . $artist->id); ?>
-            <?php echo Ajax::text('?page=stream&action=directplay&object_type=artist&object_id=' . $artist->id, T_('Play All'), 'directplay_full_text_' . $artist->id); ?>
+            <?php echo Ajax::button_with_text('?page=stream&action=directplay&object_type=artist&object_id=' . $artist->id, 'play', T_('Play All'), 'directplay_full_' . $artist->id); ?>
         </li>
             <?php if (Stream_Playlist::check_autoplay_append()) { ?>
         <li>
-            <?php echo Ajax::button('?page=stream&action=directplay&object_type=artist&object_id=' . $artist->id . '&append=true', 'play_add', T_('Play All Last'), 'addplay_artist_' . $artist->id); ?>
-            <?php echo Ajax::text('?page=stream&action=directplay&object_type=artist&object_id=' . $artist->id . '&append=true', T_('Play All Last'), 'addplay_artist_text_' . $artist->id); ?>
+            <?php echo Ajax::button_with_text('?page=stream&action=directplay&object_type=artist&object_id=' . $artist->id . '&append=true', 'play_add', T_('Play All Last'), 'addplay_artist_' . $artist->id); ?>
         </li>
             <?php
         } ?>
@@ -153,18 +150,19 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
     } ?>
         <?php if ($show_playlist_add) { ?>
         <li>
-            <?php echo Ajax::button('?action=basket&type=artist&id=' . $artist->id, 'add', T_('Add All to Temporary Playlist'), 'add_' . $artist->id); ?>
-            <?php echo Ajax::text('?action=basket&type=artist&id=' . $artist->id, T_('Add All to Temporary Playlist'), 'add_text_' . $artist->id); ?>
+            <?php echo Ajax::button_with_text('?action=basket&type=artist&id=' . $artist->id, 'add', T_('Add All to Temporary Playlist'), 'add_' . $artist->id); ?>
         </li>
         <li>
-            <?php echo Ajax::button('?action=basket&type=artist_random&id=' . $artist->id, 'random', T_('Random All to Temporary Playlist'), 'random_' . $artist->id); ?>
-            <?php echo Ajax::text('?action=basket&type=artist_random&id=' . $artist->id, T_('Random All to Temporary Playlist'), 'random_text_' . $artist->id); ?>
+            <?php echo Ajax::button_with_text('?action=basket&type=artist_random&id=' . $artist->id, 'random', T_('Random All to Temporary Playlist'), 'random_' . $artist->id); ?>
         </li>
         <?php
     } ?>
         <?php if (Access::check('interface', 50)) { ?>
         <li>
-            <a href="javascript:NavigateTo('<?php echo $web_path; ?>/artists.php?action=update_from_tags&amp;artist=<?php echo $artist->id; ?>');" onclick="return confirm('<?php echo T_('Do you really want to update from tags?'); ?>');"><?php echo Ui::get_icon('file_refresh', T_('Update from tags')); ?> &nbsp;&nbsp;<?php echo T_('Update from tags'); ?></a>
+            <a href="javascript:NavigateTo('<?php echo $web_path; ?>/artists.php?action=update_from_tags&amp;artist=<?php echo $artist->id; ?>');" onclick="return confirm('<?php echo T_('Do you really want to update from tags?'); ?>');">
+                <?php echo Ui::get_icon('file_refresh', T_('Update from tags')); ?>
+                <?php echo T_('Update from tags'); ?>
+            </a>
         </li>
         <?php
     } ?>
@@ -177,8 +175,12 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
         <?php if (!AmpConfig::get('use_auth') || Access::check('interface', 25)) { ?>
             <?php if (AmpConfig::get('sociable')) {
         $postshout = T_('Post Shout'); ?>
-                <a href="<?php echo AmpConfig::get('web_path'); ?>/shout.php?action=show_add_shout&type=artist&id=<?php echo $artist->id; ?>"><?php echo Ui::get_icon('comment', $postshout); ?></a>
-                <a href="<?php echo AmpConfig::get('web_path'); ?>/shout.php?action=show_add_shout&type=artist&id=<?php echo $artist->id; ?>"><?php echo $postshout; ?></a>
+        <li>
+            <a href="<?php echo AmpConfig::get('web_path'); ?>/shout.php?action=show_add_shout&type=artist&id=<?php echo $artist->id; ?>">
+                <?php echo Ui::get_icon('comment', $postshout); ?>
+                <?php echo $postshout; ?>
+            </a>
+        </li>
             <?php
     } ?>
         <?php
@@ -190,16 +192,20 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
         if (Access::check_function('batch_download') && $zipHandler->isZipable('artist')) {
             $download = T_('Download'); ?>
         <li>
-            <a class="nohtml" href="<?php echo $web_path; ?>/batch.php?action=artist&id=<?php echo $artist->id; ?>"><?php echo Ui::get_icon('batch_download', $download); ?></a>
-            <a class="nohtml" href="<?php echo $web_path; ?>/batch.php?action=artist&id=<?php echo $artist->id; ?>"><?php echo $download; ?></a>
+            <a class="nohtml" href="<?php echo $web_path; ?>/batch.php?action=artist&id=<?php echo $artist->id; ?>">
+                <?php echo Ui::get_icon('batch_download', $download); ?>
+                <?php echo $download; ?>
+            </a>
         </li>
         <?php
         } ?>
         <?php if (($owner_id > 0 && $owner_id == $GLOBALS['user']->id) || Access::check('interface', 50)) { ?>
             <?php if (AmpConfig::get('statistical_graphs') && is_dir(__DIR__ . '/../../vendor/szymach/c-pchart/src/Chart/')) { ?>
                 <li>
-                    <a href="<?php echo AmpConfig::get('web_path'); ?>/stats.php?action=graph&object_type=artist&object_id=<?php echo $artist->id; ?>"><?php echo Ui::get_icon('statistics', T_('Graphs')); ?></a>
-                    <a href="<?php echo AmpConfig::get('web_path'); ?>/stats.php?action=graph&object_type=artist&object_id=<?php echo $artist->id; ?>"><?php echo T_('Graphs'); ?></a>
+                    <a href="<?php echo AmpConfig::get('web_path'); ?>/stats.php?action=graph&object_type=artist&object_id=<?php echo $artist->id; ?>">
+                        <?php echo Ui::get_icon('statistics', T_('Graphs')); ?>
+                        <?php echo T_('Graphs'); ?>
+                    </a>
                 </li>
             <?php
         } ?>
@@ -212,7 +218,7 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
                 <li>
                     <a href="<?php echo $web_path; ?>/upload.php?artist=<?php echo $artist->id; ?>">
                         <?php echo Ui::get_icon('upload', $t_upload); ?>
-                        &nbsp;&nbsp;<?php echo $t_upload; ?>
+                        <?php echo $t_upload; ?>
                     </a>
                 </li>
             <?php
@@ -220,8 +226,6 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
             <li>
                 <a id="<?php echo 'edit_artist_' . $artist->id ?>" onclick="showEditDialog('artist_row', '<?php echo $artist->id ?>', '<?php echo 'edit_artist_' . $artist->id ?>', '<?php echo $artistedit ?>', '')">
                     <?php echo Ui::get_icon('edit', T_('Edit')); ?>
-                </a>
-                <a id="<?php echo 'edit_artist_' . $artist->id ?>" onclick="showEditDialog('artist_row', '<?php echo $artist->id ?>', '<?php echo 'edit_artist_' . $artist->id ?>', '<?php echo $artistedit ?>', '')">
                     <?php echo T_('Edit Artist'); ?>
                 </a>
             </li>
@@ -231,7 +235,8 @@ if (AmpConfig::get('sociable') && $owner_id > 0) {
         $delete = T_('Delete'); ?>
         <li>
             <a id="<?php echo 'delete_artist_' . $artist->id ?>" href="<?php echo AmpConfig::get('web_path'); ?>/artists.php?action=delete&artist_id=<?php echo $artist->id; ?>">
-                <?php echo Ui::get_icon('delete', $delete); ?> <?php echo $delete; ?>
+                <?php echo Ui::get_icon('delete', $delete); ?>
+                <?php echo $delete; ?>
             </a>
         </li>
         <?php

--- a/public/templates/show_democratic.inc.php
+++ b/public/templates/show_democratic.inc.php
@@ -39,18 +39,17 @@ Ui::show_box_top($string, 'info-box'); ?>
 } ?>
 <?php if (Access::check('interface', 75)) { ?>
 <li>
-    <a href="<?php echo AmpConfig::get('web_path'); ?>/democratic.php?action=manage"><?php echo Ui::get_icon('server_lightning', T_('Configure Democratic Playlist')); ?>
-    &nbsp;
-    <?php echo T_('Configure Democratic Playlist'); ?></a>
+    <a href="<?php echo AmpConfig::get('web_path'); ?>/democratic.php?action=manage">
+        <?php echo Ui::get_icon('server_lightning', T_('Configure Democratic Playlist')); ?>
+        <?php echo T_('Configure Democratic Playlist'); ?>
+    </a>
 </li>
 <?php if ($democratic->is_enabled()) { ?>
 <li>
-    <?php echo Ajax::button('?page=democratic&action=send_playlist&democratic_id=' . $democratic->id, 'all', T_('Play'), 'play_democratic'); ?>
-    <?php echo Ajax::text('?page=democratic&action=send_playlist&democratic_id=' . $democratic->id, T_('Play Democratic Playlist'), 'play_democratic_full_text'); ?>
+    <?php echo Ajax::button_with_text('?page=democratic&action=send_playlist&democratic_id=' . $democratic->id, 'all', T_('Play'), 'play_democratic'); ?>
 </li>
 <li>
-    <?php echo Ajax::button('?page=democratic&action=clear_playlist&democratic_id=' . $democratic->id, 'delete', T_('Clear Playlist'), 'clear_democratic'); ?>
-    <?php echo Ajax::text('?page=democratic&action=clear_playlist&democratic_id=' . $democratic->id, T_('Clear Playlist'), 'clear_democratic_full_text'); ?>
+    <?php echo Ajax::button_with_text('?page=democratic&action=clear_playlist&democratic_id=' . $democratic->id, 'delete', T_('Clear Playlist'), 'clear_democratic'); ?>
 </li>
 <?php
         } ?>

--- a/public/templates/show_ip_history.inc.php
+++ b/public/templates/show_ip_history.inc.php
@@ -29,12 +29,16 @@ use Ampache\Module\Util\Ui;
 <ul>
 <li>
 <?php if (isset($_REQUEST['all'])) { ?>
-    <a href="<?php echo AmpConfig::get('web_path')?>/admin/users.php?action=show_ip_history&user_id=<?php echo $working_user->id?>"><?php echo Ui::get_icon('disable', T_('Disable')); ?></a>
-    <?php echo T_('Show Unique'); ?>
+    <a href="<?php echo AmpConfig::get('web_path')?>/admin/users.php?action=show_ip_history&user_id=<?php echo $working_user->id?>">
+        <?php echo Ui::get_icon('disable', T_('Disable')); ?>
+        <?php echo T_('Show Unique'); ?>
+    </a>
 <?php
 } else { ?>
-    <a href="<?php echo AmpConfig::get('web_path')?>/admin/users.php?action=show_ip_history&user_id=<?php echo $working_user->id?>&all"><?php echo Ui::get_icon('add', T_('Add')); ?></a>
-    <?php echo T_('Show All'); ?>
+    <a href="<?php echo AmpConfig::get('web_path')?>/admin/users.php?action=show_ip_history&user_id=<?php echo $working_user->id?>&all">
+        <?php echo Ui::get_icon('add', T_('Add')); ?>
+        <?php echo T_('Show All'); ?>
+    </a>
 <?php
     }?>
 </li>

--- a/public/templates/show_label.inc.php
+++ b/public/templates/show_label.inc.php
@@ -63,8 +63,10 @@ if ($label->website) {
         <?php if (!AmpConfig::get('use_auth') || Access::check('interface', 25)) { ?>
             <?php if (AmpConfig::get('sociable')) { ?>
             <li>
-                <a href="<?php echo AmpConfig::get('web_path'); ?>/shout.php?action=show_add_shout&type=label&id=<?php echo $label->id; ?>"><?php echo Ui::get_icon('comment', T_('Post Shout')); ?></a>
-                <a href="<?php echo AmpConfig::get('web_path'); ?>/shout.php?action=show_add_shout&type=label&id=<?php echo $label->id; ?>"><?php echo T_('Post Shout'); ?></a>
+                <a href="<?php echo AmpConfig::get('web_path'); ?>/shout.php?action=show_add_shout&type=label&id=<?php echo $label->id; ?>">
+                    <?php echo Ui::get_icon('comment', T_('Post Shout')); ?>
+                    <?php echo T_('Post Shout'); ?>
+                </a>
             </li>
             <?php
     } ?>
@@ -72,8 +74,10 @@ if ($label->website) {
 } ?>
         <?php if ($label->email) { ?>
         <li>
-            <a href="mailto:<?php echo scrub_out($label->email); ?>"><?php echo Ui::get_icon('mail', T_('Send E-mail')); ?></a>
-            <a href="mailto:<?php echo scrub_out($label->email); ?>"><?php echo T_('Send E-mail'); ?></a>
+            <a href="mailto:<?php echo scrub_out($label->email); ?>">
+                <?php echo Ui::get_icon('mail', T_('Send E-mail')); ?>
+                <?php echo T_('Send E-mail'); ?>
+            </a>
         </li>
         <?php
     } ?>
@@ -81,8 +85,6 @@ if ($label->website) {
         <li>
             <a id="<?php echo 'edit_label_' . $label->id ?>" onclick="showEditDialog('label_row', '<?php echo $label->id ?>', '<?php echo 'edit_label_' . $label->id ?>', '<?php echo T_('Label Edit') ?>', '')">
                 <?php echo Ui::get_icon('edit', T_('Edit')); ?>
-            </a>
-            <a id="<?php echo 'edit_label_' . $label->id ?>" onclick="showEditDialog('label_row', '<?php echo $label->id ?>', '<?php echo 'edit_label_' . $label->id ?>', '<?php echo T_('Label Edit') ?>', '')">
                 <?php echo T_('Edit Label'); ?>
             </a>
         </li>
@@ -91,7 +93,8 @@ if ($label->website) {
         <?php if (Catalog::can_remove($label)) { ?>
         <li>
             <a id="<?php echo 'delete_label_' . $label->id ?>" href="<?php echo AmpConfig::get('web_path'); ?>/labels.php?action=delete&label_id=<?php echo $label->id; ?>">
-                <?php echo Ui::get_icon('delete', T_('Delete')); ?> <?php echo T_('Delete'); ?>
+                <?php echo Ui::get_icon('delete', T_('Delete')); ?>
+                <?php echo T_('Delete'); ?>
             </a>
         </li>
         <?php

--- a/public/templates/show_labels.inc.php
+++ b/public/templates/show_labels.inc.php
@@ -31,7 +31,12 @@ $thcount = 6; ?>
 <?php if (Access::check('interface', 50) || AmpConfig::get('upload_allow_edit')) { ?>
 <div id="information_actions">
     <ul>
-        <li><?php echo Ui::get_icon('add', T_('Add')); ?> <a href="<?php echo AmpConfig::get('web_path'); ?>/labels.php?action=show_add_label"><?php echo T_('Create Label'); ?></a></li>
+        <li>
+            <a href="<?php echo AmpConfig::get('web_path'); ?>/labels.php?action=show_add_label">
+                <?php echo Ui::get_icon('add', T_('Add')); ?>
+                <?php echo T_('Create Label'); ?>
+            </a>
+        </li>
     </ul>
 </div>
 <?php

--- a/public/templates/show_live_streams.inc.php
+++ b/public/templates/show_live_streams.inc.php
@@ -32,7 +32,10 @@ use Ampache\Module\Util\Ui;
 <div id="information_actions">
 <ul>
 <li>
-    <a href="<?php echo AmpConfig::get('web_path'); ?>/radio.php?action=show_create"><?php echo Ui::get_icon('add', T_('Add')); ?> <?php echo T_('Add Radio Station'); ?></a>
+    <a href="<?php echo AmpConfig::get('web_path'); ?>/radio.php?action=show_create">
+        <?php echo Ui::get_icon('add', T_('Add')); ?>
+        <?php echo T_('Add Radio Station'); ?>
+    </a>
 </li>
 </ul>
 </div>

--- a/public/templates/show_playlist.inc.php
+++ b/public/templates/show_playlist.inc.php
@@ -72,16 +72,20 @@ Ui::show_box_top('<div id="playlist_row_' . $playlist->id . '">' . $title . '</d
             <a onclick="submitNewItemsOrder('<?php echo $playlist->id; ?>', 'reorder_playlist_table', 'track_',
                                             '<?php echo AmpConfig::get('web_path'); ?>/playlist.php?action=set_track_numbers&playlist_id=<?php echo $playlist->id; ?>', '<?php echo RefreshPlaylistMediasAction::REQUEST_KEY ?>')">
                 <?php echo Ui::get_icon('save', T_('Save Track Order')); ?>
-                &nbsp;&nbsp;<?php echo T_('Save Track Order'); ?>
+                <?php echo T_('Save Track Order'); ?>
             </a>
         </li>
         <li>
-            <a href="<?php echo AmpConfig::get('web_path'); ?>/playlist.php?action=sort_tracks&playlist_id=<?php echo $playlist->id; ?>"><?php echo Ui::get_icon('sort', T_('Sort Tracks by Artist, Album, Song')); ?>
-            &nbsp;&nbsp;<?php echo T_('Sort Tracks by Artist, Album, Song'); ?></a>
+            <a href="<?php echo AmpConfig::get('web_path'); ?>/playlist.php?action=sort_tracks&playlist_id=<?php echo $playlist->id; ?>">
+                <?php echo Ui::get_icon('sort', T_('Sort Tracks by Artist, Album, Song')); ?>
+                <?php echo T_('Sort Tracks by Artist, Album, Song'); ?>
+            </a>
         </li>
         <li>
-            <a href="<?php echo AmpConfig::get('web_path'); ?>/playlist.php?action=remove_duplicates&playlist_id=<?php echo $playlist->id; ?>"><?php echo Ui::get_icon('wand', T_('Remove Duplicates')); ?>
-            &nbsp;&nbsp;<?php echo T_('Remove Duplicates'); ?></a>
+            <a href="<?php echo AmpConfig::get('web_path'); ?>/playlist.php?action=remove_duplicates&playlist_id=<?php echo $playlist->id; ?>">
+                <?php echo Ui::get_icon('wand', T_('Remove Duplicates')); ?>
+                <?php echo T_('Remove Duplicates'); ?>
+            </a>
         </li>
     <?php
     } ?>
@@ -93,38 +97,34 @@ Ui::show_box_top('<div id="playlist_row_' . $playlist->id . '">' . $title . '</d
         <li>
             <a class="nohtml" href="<?php echo AmpConfig::get('web_path'); ?>/batch.php?action=playlist&amp;id=<?php echo $playlist->id; ?>">
                 <?php echo Ui::get_icon('batch_download', T_('Batch Download')); ?>
-                &nbsp;&nbsp;<?php echo T_('Batch Download'); ?>
+                <?php echo T_('Batch Download'); ?>
             </a>
         </li>
     <?php
     } ?>
     <?php if (AmpConfig::get('directplay')) { ?>
         <li>
-            <?php echo Ajax::button('?page=stream&action=directplay&object_type=playlist&object_id=' . $playlist->id, 'play', T_('Play All'), 'directplay_full_' . $playlist->id); ?>
-            <?php echo Ajax::text('?page=stream&action=directplay&object_type=playlist&object_id=' . $playlist->id, T_('Play All'), 'directplay_full_text_' . $playlist->id); ?>
+            <?php echo Ajax::button_with_text('?page=stream&action=directplay&object_type=playlist&object_id=' . $playlist->id, 'play', T_('Play All'), 'directplay_full_' . $playlist->id); ?>
         </li>
     <?php
     } ?>
     <?php if (Stream_Playlist::check_autoplay_append()) { ?>
         <li>
-            <?php echo Ajax::button('?page=stream&action=directplay&object_type=playlist&object_id=' . $playlist->id . '&append=true', 'play_add', T_('Play All Last'), 'addplay_playlist_' . $playlist->id); ?>
-            <?php echo Ajax::text('?page=stream&action=directplay&object_type=playlist&object_id=' . $playlist->id . '&append=true', T_('Play All Last'), 'addplay_playlist_text_' . $playlist->id); ?>
+            <?php echo Ajax::button_with_text('?page=stream&action=directplay&object_type=playlist&object_id=' . $playlist->id . '&append=true', 'play_add', T_('Play All Last'), 'addplay_playlist_' . $playlist->id); ?>
         </li>
     <?php
     } ?>
         <li>
-            <?php echo Ajax::button('?action=basket&type=playlist&id=' . $playlist->id, 'add', T_('Add All to Temporary Playlist'), 'play_playlist'); ?>
-            <?php echo Ajax::text('?action=basket&type=playlist&id=' . $playlist->id, T_('Add All to Temporary Playlist'), 'play_playlist_text'); ?>
+            <?php echo Ajax::button_with_text('?action=basket&type=playlist&id=' . $playlist->id, 'add', T_('Add All to Temporary Playlist'), 'play_playlist'); ?>
         </li>
         <li>
-            <?php echo Ajax::button('?action=basket&type=playlist_random&id=' . $playlist->id, 'random', T_('Random All to Temporary Playlist'), 'play_playlist_random'); ?>
-            <?php echo Ajax::text('?action=basket&type=playlist_random&id=' . $playlist->id, T_('Random All to Temporary Playlist'), 'play_playlist_random_text'); ?>
+            <?php echo Ajax::button_with_text('?action=basket&type=playlist_random&id=' . $playlist->id, 'random', T_('Random All to Temporary Playlist'), 'play_playlist_random'); ?>
         </li>
     <?php if (Core::get_global('user')->has_access('50') && AmpConfig::get('channel')) { ?>
         <li>
             <a href="<?php echo AmpConfig::get('web_path'); ?>/channel.php?action=show_create&type=playlist&id=<?php echo $playlist->id; ?>">
                 <?php echo Ui::get_icon('flow'); ?>
-                &nbsp;&nbsp;<?php echo T_('Create channel'); ?>
+                <?php echo T_('Create channel'); ?>
             </a>
         </li>
     <?php
@@ -133,7 +133,7 @@ Ui::show_box_top('<div id="playlist_row_' . $playlist->id . '">' . $title . '</d
         <li>
             <a href="javascript:NavigateTo('<?php echo AmpConfig::get('web_path'); ?>/playlist.php?action=delete_playlist&playlist_id=<?php echo $playlist->id; ?>');" onclick="return confirm('<?php echo T_('Do you really want to delete this Playlist?'); ?>');">
                 <?php echo Ui::get_icon('delete'); ?>
-                &nbsp;&nbsp;<?php echo T_('Delete'); ?>
+                <?php echo T_('Delete'); ?>
             </a>
         </li>
     <?php

--- a/public/templates/show_podcast.inc.php
+++ b/public/templates/show_podcast.inc.php
@@ -68,23 +68,23 @@ Ui::show_box_top($podcast->f_title, 'info-box'); ?>
     <ul>
         <?php if (AmpConfig::get('directplay')) { ?>
         <li>
-            <?php echo Ajax::button('?page=stream&action=directplay&object_type=podcast&object_id=' . $podcast->id, 'play', T_('Play All'), 'directplay_full_' . $podcast->id); ?>
-            <?php echo Ajax::text('?page=stream&action=directplay&object_type=podcast&object_id=' . $podcast->id, T_('Play All'), 'directplay_full_text_' . $podcast->id); ?>
+            <?php echo Ajax::button_with_text('?page=stream&action=directplay&object_type=podcast&object_id=' . $podcast->id, 'play', T_('Play All'), 'directplay_full_' . $podcast->id); ?>
         </li>
         <?php
     } ?>
         <?php if (Stream_Playlist::check_autoplay_append()) { ?>
         <li>
-            <?php echo Ajax::button('?page=stream&action=directplay&object_type=podcast&object_id=' . $podcast->id . '&append=true', 'play_add', T_('Play All Last'), 'addplay_podcast_' . $podcast->id); ?>
-            <?php echo Ajax::text('?page=stream&action=directplay&object_type=podcast&object_id=' . $podcast->id . '&append=true', T_('Play All Last'), 'addplay_podcast_text_' . $podcast->id); ?>
+            <?php echo Ajax::button_with_text('?page=stream&action=directplay&object_type=podcast&object_id=' . $podcast->id . '&append=true', 'play_add', T_('Play All Last'), 'addplay_podcast_' . $podcast->id); ?>
         </li>
         <?php
     } ?>
         <?php if (Access::check('interface', 50)) { ?>
         <?php if (AmpConfig::get('statistical_graphs') && is_dir(__DIR__ . '/../../vendor/szymach/c-pchart/src/Chart/')) { ?>
             <li>
-                <a href="<?php echo AmpConfig::get('web_path'); ?>/stats.php?action=graph&object_type=podcast&object_id=<?php echo $podcast->id; ?>"><?php echo Ui::get_icon('statistics', T_('Graphs')); ?></a>
-                <a href="<?php echo AmpConfig::get('web_path'); ?>/stats.php?action=graph&object_type=podcast&object_id=<?php echo $podcast->id; ?>"><?php echo T_('Graphs'); ?></a>
+                <a href="<?php echo AmpConfig::get('web_path'); ?>/stats.php?action=graph&object_type=podcast&object_id=<?php echo $podcast->id; ?>">
+                    <?php echo Ui::get_icon('statistics', T_('Graphs')); ?>
+                    <?php echo T_('Graphs'); ?>
+                </a>
             </li>
         <?php
         } ?>
@@ -96,27 +96,27 @@ Ui::show_box_top($podcast->f_title, 'info-box'); ?>
         <?php
         } ?>
         <li>
-        <?php echo " <a href=\"" . $podcast->website . "\" target=\"_blank\">" . UI::get_icon('link', T_('Website')) . "</a>"; ?>
-        <?php echo " <a href=\"" . $podcast->website . "\" target=\"_blank\">" . T_('Website') . "</a>"; ?>
+            <a href="<?php echo $podcast->website; ?>" target="_blank">
+                <?php echo Ui::get_icon('link', T_('Website')); ?>
+                <?php echo T_('Graphs'); ?>
+            </a>
         </li>
         <li>
             <a id="<?php echo 'edit_podcast_' . $podcast->id ?>" onclick="showEditDialog('podcast_row', '<?php echo $podcast->id ?>', '<?php echo 'edit_podcast_' . $podcast->id ?>', '<?php echo T_('Podcast Edit') ?>', '')">
                 <?php echo Ui::get_icon('edit', T_('Edit')); ?>
-            </a>
-            <a id="<?php echo 'edit_podcast_' . $podcast->id ?>" onclick="showEditDialog('podcast_row', '<?php echo $podcast->id ?>', '<?php echo 'edit_podcast_' . $podcast->id ?>', '<?php echo T_('Podcast Edit') ?>', '')">
                 <?php echo T_('Edit Podcast'); ?>
             </a>
         </li>
         <li>
-            <?php echo Ajax::button('?page=podcast&action=sync&podcast_id=' . $podcast->id, 'file_refresh', T_('Sync'), 'sync_podcast_' . $podcast->id); ?>
-            <?php echo Ajax::text('?page=podcast&action=sync&podcast_id=' . $podcast->id, T_('Sync'), 'sync_podcast_text_' . $podcast->id); ?>
+            <?php echo Ajax::button_with_text('?page=podcast&action=sync&podcast_id=' . $podcast->id, 'file_refresh', T_('Sync'), 'sync_podcast_' . $podcast->id); ?>
         </li>
         <?php
     } ?>
         <?php if (Access::check('interface', 75)) { ?>
         <li>
             <a id="<?php echo 'delete_podcast_' . $podcast->id ?>" href="<?php echo AmpConfig::get('web_path'); ?>/podcast.php?action=delete&podcast_id=<?php echo $podcast->id; ?>">
-                <?php echo Ui::get_icon('delete', T_('Delete')); ?> &nbsp;<?php echo T_('Delete'); ?>
+                <?php echo Ui::get_icon('delete', T_('Delete')); ?>
+                <?php echo T_('Delete'); ?>
             </a>
         </li>
         <?php

--- a/public/templates/show_podcasts.inc.php
+++ b/public/templates/show_podcasts.inc.php
@@ -35,7 +35,10 @@ $thcount  = 5; ?>
     <ul>
         <?php if (Access::check('interface', 75)) { ?>
         <li>
-            <a href="<?php echo AmpConfig::get('web_path'); ?>/podcast.php?action=show_create"><?php echo Ui::get_icon('add', T_('Add')); ?> <?php echo T_('Subscribe to Podcast'); ?></a>
+            <a href="<?php echo AmpConfig::get('web_path'); ?>/podcast.php?action=show_create">
+                <?php echo Ui::get_icon('add', T_('Add')); ?>
+                <?php echo T_('Subscribe to Podcast'); ?>
+            </a>
         </li>
         <?php
 } ?>

--- a/public/templates/show_pvmsg.inc.php
+++ b/public/templates/show_pvmsg.inc.php
@@ -36,7 +36,8 @@ Ui::show_box_top($pvmsg->getSubjectFormatted(), 'info-box'); ?>
     <ul>
         <li>
             <a id="<?php echo 'reply_pvmsg_' . $pvmsg->getId() ?>" href="<?php echo AmpConfig::get('web_path'); ?>/pvmsg.php?action=show_add_message&reply_to=<?php echo $pvmsg->getId(); ?>">
-                <?php echo Ui::get_icon('mail', T_('Reply')); ?> <?php echo T_('Reply'); ?>
+                <?php echo Ui::get_icon('mail', T_('Reply')); ?>
+                <?php echo T_('Reply'); ?>
             </a>
         </li>
     </ul>

--- a/public/templates/show_search.inc.php
+++ b/public/templates/show_search.inc.php
@@ -46,21 +46,22 @@ Ui::show_box_top('<div id="smartplaylist_row_' . $playlist->id . '">' . $title .
         $zipHandler = $dic->get(ZipHandlerInterface::class);
         if (Access::check_function('batch_download') && $zipHandler->isZipable('search')) { ?>
         <li>
-            <a class="nohtml" href="<?php echo AmpConfig::get('web_path'); ?>/batch.php?action=search&amp;id=<?php echo $playlist->id; ?>"><?php echo Ui::get_icon('batch_download', T_('Batch Download')); ?></a>
-            <?php echo T_('Batch Download'); ?>
+            <a class="nohtml" href="<?php echo AmpConfig::get('web_path'); ?>/batch.php?action=search&amp;id=<?php echo $playlist->id; ?>">
+                <?php echo Ui::get_icon('batch_download', T_('Batch Download')); ?>
+                <?php echo T_('Batch Download'); ?>
+            </a>
         </li>
             <?php
 } ?>
         <li>
-            <?php echo Ajax::button('?action=basket&type=search&id=' . $playlist->id, 'add', T_('Add All'), 'play_playlist'); ?>
-            <?php echo T_('Add All'); ?>
+            <?php echo Ajax::button_with_text('?action=basket&type=search&id=' . $playlist->id, 'add', T_('Add All'), 'play_playlist'); ?>
         </li>
         <?php if ($playlist->has_access()) { ?>
         <li>
             <a href="<?php echo AmpConfig::get('web_path'); ?>/smartplaylist.php?action=delete_playlist&playlist_id=<?php echo $playlist->id; ?>">
                 <?php echo Ui::get_icon('delete'); ?>
+                <?php echo T_('Delete'); ?>
             </a>
-            <?php echo T_('Delete'); ?>
         </li>
         <?php
     } ?>

--- a/public/templates/show_search_options.inc.php
+++ b/public/templates/show_search_options.inc.php
@@ -31,8 +31,7 @@ use Ampache\Module\Util\ZipHandlerInterface;
 <div id="information_actions">
 <ul>
 <li>
-    <?php echo Ajax::button('?action=basket&type=browse_set&browse_id=' . $browse->id, 'add', T_('Add Search Results'), 'add_search_results'); ?>
-    <?php echo T_('Add Search Results'); ?>
+    <?php echo Ajax::button_with_text('?action=basket&type=browse_set&browse_id=' . $browse->id, 'add', T_('Add Search Results'), 'add_search_results'); ?>
 </li>
     <?php
     // @todo remove after refactoring
@@ -40,8 +39,10 @@ use Ampache\Module\Util\ZipHandlerInterface;
     $zipHandler = $dic->get(ZipHandlerInterface::class);
     if (Access::check_function('batch_download') && $zipHandler->isZipable((string) filter_input(INPUT_GET, 'type', FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES))) { ?>
 <li>
-    <a class="nohtml" href="<?php echo AmpConfig::get('web_path'); ?>/batch.php?action=browse&amp;type=<?php echo scrub_out((string) filter_input(INPUT_GET, 'type', FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES)); ?>&amp;browse_id=<?php echo $browse->id; ?>"><?php echo Ui::get_icon('batch_download', T_('Batch Download')); ?></a>
-    <?php echo T_('Batch Download'); ?>
+    <a class="nohtml" href="<?php echo AmpConfig::get('web_path'); ?>/batch.php?action=browse&amp;type=<?php echo scrub_out((string) filter_input(INPUT_GET, 'type', FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES)); ?>&amp;browse_id=<?php echo $browse->id; ?>">
+        <?php echo Ui::get_icon('batch_download', T_('Batch Download')); ?>
+        <?php echo T_('Batch Download'); ?>
+    </a>
 </li>
     <?php
 } ?>

--- a/public/templates/show_searches.inc.php
+++ b/public/templates/show_searches.inc.php
@@ -31,7 +31,10 @@ use Ampache\Module\Util\Ui;
     <ul>
         <?php if (Access::check('interface', 25)) { ?>
         <li>
-            <a href="<?php echo AmpConfig::get('web_path'); ?>/search.php?type=song"><?php echo Ui::get_icon('add', T_('Add')); ?> <?php echo T_('Add Smart Playlist'); ?></a>
+            <a href="<?php echo AmpConfig::get('web_path'); ?>/search.php?type=song">
+                <?php echo Ui::get_icon('add', T_('Add')); ?>
+                <?php echo T_('Add Smart Playlist'); ?>
+            </a>
         </li>
         <?php
 } ?>

--- a/public/templates/show_tvshow.inc.php
+++ b/public/templates/show_tvshow.inc.php
@@ -69,15 +69,13 @@ Ui::show_box_top($tvshow->f_name, 'info-box'); ?>
     <ul>
         <?php if (AmpConfig::get('directplay')) { ?>
         <li>
-            <?php echo Ajax::button('?page=stream&action=directplay&object_type=tvshow&object_id=' . $tvshow->id, 'play', T_('Play All'), 'directplay_full_' . $tvshow->id); ?>
-            <?php echo Ajax::text('?page=stream&action=directplay&object_type=tvshow&object_id=' . $tvshow->id, T_('Play All'), 'directplay_full_text_' . $tvshow->id); ?>
+            <?php echo Ajax::button_with_text('?page=stream&action=directplay&object_type=tvshow&object_id=' . $tvshow->id, 'play', T_('Play All'), 'directplay_full_' . $tvshow->id); ?>
         </li>
         <?php
     } ?>
         <?php if (Stream_Playlist::check_autoplay_append()) { ?>
         <li>
-            <?php echo Ajax::button('?page=stream&action=directplay&object_type=tvshow&object_id=' . $tvshow->id . '&append=true', 'play_add', T_('Play All Last'), 'addplay_tvshow_' . $tvshow->id); ?>
-            <?php echo Ajax::text('?page=stream&action=directplay&object_type=tvshow&object_id=' . $tvshow->id . '&append=true', T_('Play All Last'), 'addplay_tvshow_text_' . $tvshow->id); ?>
+            <?php echo Ajax::button_with_text('?page=stream&action=directplay&object_type=tvshow&object_id=' . $tvshow->id . '&append=true', 'play_add', T_('Play All Last'), 'addplay_tvshow_' . $tvshow->id); ?>
         </li>
         <?php
     } ?>
@@ -85,8 +83,6 @@ Ui::show_box_top($tvshow->f_name, 'info-box'); ?>
         <li>
             <a id="<?php echo 'edit_tvshow_' . $tvshow->id ?>" onclick="showEditDialog('tvshow_row', '<?php echo $tvshow->id ?>', '<?php echo 'edit_tvshow_' . $tvshow->id ?>', '<?php echo T_('TV Show Edit') ?>', '')">
                 <?php echo Ui::get_icon('edit', T_('Edit')); ?>
-            </a>
-            <a id="<?php echo 'edit_tvshow_' . $tvshow->id ?>" onclick="showEditDialog('tvshow_row', '<?php echo $tvshow->id ?>', '<?php echo 'edit_tvshow_' . $tvshow->id ?>', '<?php echo T_('TV Show Edit') ?>', '')">
                 <?php echo T_('Edit TV Show'); ?>
             </a>
         </li>
@@ -95,7 +91,8 @@ Ui::show_box_top($tvshow->f_name, 'info-box'); ?>
         <?php if (Catalog::can_remove($tvshow)) { ?>
         <li>
             <a id="<?php echo 'delete_tvshow_' . $tvshow->id ?>" href="<?php echo AmpConfig::get('web_path'); ?>/tvshows.php?action=delete&tvshow_id=<?php echo $tvshow->id; ?>">
-                <?php echo Ui::get_icon('delete', T_('Delete')); ?> <?php echo T_('Delete'); ?>
+                <?php echo Ui::get_icon('delete', T_('Delete')); ?>
+                <?php echo T_('Delete'); ?>
             </a>
         </li>
         <?php

--- a/public/templates/show_tvshow_season.inc.php
+++ b/public/templates/show_tvshow_season.inc.php
@@ -63,15 +63,13 @@ Ui::show_box_top($season->f_name . ' - ' . $season->f_tvshow_link, 'info-box'); 
     <ul>
         <?php if (AmpConfig::get('directplay')) { ?>
         <li>
-            <?php echo Ajax::button('?page=stream&action=directplay&object_type=tvshow_season&object_id=' . $season->id, 'play', T_('Play All'), 'directplay_full_' . $season->id); ?>
-            <?php echo Ajax::text('?page=stream&action=directplay&object_type=tvshow_season&object_id=' . $season->id, T_('Play All'), 'directplay_full_text_' . $season->id); ?>
+            <?php echo Ajax::button_with_text('?page=stream&action=directplay&object_type=tvshow_season&object_id=' . $season->id, 'play', T_('Play All'), 'directplay_full_' . $season->id); ?>
         </li>
         <?php
     } ?>
         <?php if (Stream_Playlist::check_autoplay_append()) { ?>
         <li>
-            <?php echo Ajax::button('?page=stream&action=directplay&object_type=season&object_id=' . $season->id . '&append=true', 'play_add', T_('Play All Last'), 'addplay_season_' . $season->id); ?>
-            <?php echo Ajax::text('?page=stream&action=directplay&object_type=season&object_id=' . $season->id . '&append=true', T_('Play All Last'), 'addplay_season_text_' . $season->id); ?>
+            <?php echo Ajax::button_with_text('?page=stream&action=directplay&object_type=season&object_id=' . $season->id . '&append=true', 'play_add', T_('Play All Last'), 'addplay_season_' . $season->id); ?>
         </li>
         <?php
     } ?>
@@ -79,8 +77,6 @@ Ui::show_box_top($season->f_name . ' - ' . $season->f_tvshow_link, 'info-box'); 
         <li>
             <a id="<?php echo 'edit_tvshow_season_' . $season->id ?>" onclick="showEditDialog('tvshow_season_row', '<?php echo $season->id ?>', '<?php echo 'edit_tvshow_season_' . $season->id ?>', '<?php echo T_('Season Edit') ?>', '')">
                 <?php echo Ui::get_icon('edit', T_('Edit')); ?>
-            </a>
-            <a id="<?php echo 'edit_tvshow_season_' . $season->id ?>" onclick="showEditDialog('tvshow_season_row', '<?php echo $season->id ?>', '<?php echo 'edit_tvshow_season_' . $season->id ?>', '<?php echo T_('Season Edit') ?>', '')">
                 <?php echo T_('Edit Season'); ?>
             </a>
         </li>
@@ -89,7 +85,8 @@ Ui::show_box_top($season->f_name . ' - ' . $season->f_tvshow_link, 'info-box'); 
         <?php if (Catalog::can_remove($season)) { ?>
         <li>
             <a id="<?php echo 'delete_tvshow_season_' . $season->id ?>" href="<?php echo AmpConfig::get('web_path'); ?>/tvshow_seasons.php?action=delete&tvshow_season_id=<?php echo $season->id; ?>">
-                <?php echo Ui::get_icon('delete', T_('Delete')); ?> <?php echo T_('Delete'); ?>
+                <?php echo Ui::get_icon('delete', T_('Delete')); ?>
+                <?php echo T_('Delete'); ?>
             </a>
         </li>
         <?php

--- a/public/themes/reborn/templates/default.css
+++ b/public/themes/reborn/templates/default.css
@@ -1706,6 +1706,7 @@ span.fatalerror {
 }
 
 #information_actions li img {
+    margin-right: 4px;
     vertical-align: top;
 }
 

--- a/src/Module/Api/Ajax.php
+++ b/src/Module/Api/Ajax.php
@@ -166,6 +166,38 @@ class Ajax
     } // button
 
     /**
+     * button_with_text
+     * This prints out an img of the specified icon coupled with
+     * the text string and then sets up the required ajax for it.
+     * @param string $action
+     * @param string $icon
+     * @param string $text
+     * @param string $source
+     * @param string $post
+     * @param string $class
+     * @param string $confirm
+     * @return string
+     */
+    public static function button_with_text($action, $icon, $text, $source = '', $post = '', $class = '', $confirm = '')
+    {
+        // Get the correct action
+        $ajax_string = self::action($action, $source, $post);
+
+        // If they passed a span class
+        if ($class) {
+            $class = ' class="' . $class . '"';
+        }
+
+        $button = Ui::get_icon($icon, $text);
+
+        $string = "<a href=\"javascript:void(0);\" id=\"$source\" $class>" . $button . " " . $text . "</a>\n";
+
+        $string .= self::observe($source, 'click', $ajax_string, $confirm);
+
+        return $string;
+    } // button
+
+    /**
      * text
      * This prints out the specified text as a link and sets up the required
      * ajax for the link so it works correctly


### PR DESCRIPTION
I noticed quite a few action items had separate links for the img and text, or links were missing from either one.

Now all actions (#information_actions) have both img and text inside a single ```<a>```

