### PR TITLE
Add missing parameter for Upnp_Api::createDIDL call

### DIFF
--- a/modules/localplay/upnp/upnpplayer.class.php
+++ b/modules/localplay/upnp/upnpplayer.class.php
@@ -223,7 +223,7 @@ class UPnPPlayer
         $song = new song($songId);
         $song->format();
         $songItem = Upnp_Api::_itemSong($song, '');
-        $domDIDL  = Upnp_Api::createDIDL($songItem);
+        $domDIDL  = Upnp_Api::createDIDL($songItem, '');
         $xmlDIDL  = $domDIDL->saveXML();
 
         return array(


### PR DESCRIPTION
Introduced by ffacc2285f3450c6725d547a1226927874db6a49, backported from
source-changes