### PR TITLE
Allow the object id to be used as a list of ids

### DIFF
--- a/resources/templates/playlist/new_dialog.xhtml
+++ b/resources/templates/playlist/new_dialog.xhtml
@@ -4,7 +4,7 @@
         <a
             href="javascript:void(0);"
             id="rb_append_dplaylist_new"
-            onclick="createNewPlaylist('${ADAPTER/getNewPlaylistTitle}', '${ADAPTER/getAjaxUri}?page=playlist&action=append_item&item_type=${ADAPTER/getObjectType}&item_id=${ADAPTER/getObjectId}', 'rb_append_dplaylist_new');"
+            onclick="createNewPlaylist('${ADAPTER/getNewPlaylistTitle}', '${ADAPTER/getAjaxUri}?page=playlist&action=append_item&item_type=${ADAPTER/getObjectType}&item_id=${ADAPTER/getObjectIds}', 'rb_append_dplaylist_new');"
             tal:content="ADAPTER/getNewPlaylistTitle"
         >TITLE</a>
     </li>
@@ -12,7 +12,7 @@
         <a
             href="javascript:void(0);"
             id="rb_append_dplaylist_${playlist/id}"
-            onclick="handlePlaylistAction('${ADAPTER/getAjaxUri}?page=playlist&action=append_item&playlist_id=${playlist/id}&item_type=${ADAPTER/getObjectType}&item_id=${ADAPTER/getObjectId}', 'rb_append_dplaylist_${playlist/id}');"
+            onclick="handlePlaylistAction('${ADAPTER/getAjaxUri}?page=playlist&action=append_item&playlist_id=${playlist/id}&item_type=${ADAPTER/getObjectType}&item_id=${ADAPTER/getObjectIds}', 'rb_append_dplaylist_${playlist/id}');"
             tal:content="playlist/name"
         >NAME</a>
     </li>

--- a/src/Gui/GuiFactory.php
+++ b/src/Gui/GuiFactory.php
@@ -125,7 +125,7 @@ final class GuiFactory implements GuiFactoryInterface
     public function createNewPlaylistDialogAdapter(
         GuiGatekeeperInterface $gatekeeper,
         string $object_type,
-        int $object_id
+        string $object_id
     ): NewPlaylistDialogAdapterInterface {
         return new NewPlaylistDialogAdapter(
             $this->playlistLoader,

--- a/src/Gui/GuiFactoryInterface.php
+++ b/src/Gui/GuiFactoryInterface.php
@@ -55,6 +55,6 @@ interface GuiFactoryInterface
     public function createNewPlaylistDialogAdapter(
         GuiGatekeeperInterface $gatekeeper,
         string $object_type,
-        int $object_id
+        string $object_id
     ): NewPlaylistDialogAdapterInterface;
 }

--- a/src/Gui/Playlist/NewPlaylistDialogAdapter.php
+++ b/src/Gui/Playlist/NewPlaylistDialogAdapter.php
@@ -38,20 +38,20 @@ final class NewPlaylistDialogAdapter implements NewPlaylistDialogAdapterInterfac
 
     private string $object_type;
 
-    private int $object_id;
+    private string $object_ids;
 
     public function __construct(
         PlaylistLoaderInterface $playlistLoader,
         AjaxUriRetrieverInterface $ajaxUriRetriever,
         GuiGatekeeperInterface $gatekeeper,
         string $object_type,
-        int $object_id
+        string $object_id
     ) {
         $this->playlistLoader   = $playlistLoader;
         $this->ajaxUriRetriever = $ajaxUriRetriever;
         $this->gatekeeper       = $gatekeeper;
         $this->object_type      = $object_type;
-        $this->object_id        = $object_id;
+        $this->object_ids       = $object_id;
     }
 
     /**
@@ -79,9 +79,9 @@ final class NewPlaylistDialogAdapter implements NewPlaylistDialogAdapterInterfac
         return $this->object_type;
     }
 
-    public function getObjectId(): int
+    public function getObjectIds(): string
     {
-        return $this->object_id;
+        return $this->object_ids;
     }
 
     public function getNewPlaylistTitle(): string

--- a/src/Gui/Playlist/NewPlaylistDialogAdapterInterface.php
+++ b/src/Gui/Playlist/NewPlaylistDialogAdapterInterface.php
@@ -29,7 +29,7 @@ interface NewPlaylistDialogAdapterInterface
 
     public function getObjectType(): string;
 
-    public function getObjectId(): int;
+    public function getObjectIds(): string;
 
     public function getNewPlaylistTitle(): string;
 }

--- a/src/Module/Api/Edit/ShowEditPlaylistAction.php
+++ b/src/Module/Api/Edit/ShowEditPlaylistAction.php
@@ -79,6 +79,12 @@ final class ShowEditPlaylistAction extends AbstractEditAction
         database_object $libitem,
         int $object_id
     ): ?ResponseInterface {
+        /**
+         * Actually, object_id is not used - this is a design flaw.
+         * This action allows to submit multiple ids but the abstract app
+         * uses just one for internal checks. So we have to retrieve the object_ids here again
+         * @todo FIXME Replace by some smart solution
+         */
         $result = $this->talFactory
             ->createTalView()
             ->setTemplate('playlist/new_dialog.xhtml')
@@ -87,7 +93,7 @@ final class ShowEditPlaylistAction extends AbstractEditAction
                 $this->guiFactory->createNewPlaylistDialogAdapter(
                     $gatekeeper,
                     $object_type,
-                    $object_id
+                    $request->getQueryParams()['id']
                 )
             )
             ->render();

--- a/tests/Gui/GuiFactoryTest.php
+++ b/tests/Gui/GuiFactoryTest.php
@@ -139,7 +139,7 @@ class GuiFactoryTest extends MockeryTestCase
             $this->subject->createNewPlaylistDialogAdapter(
                 $this->mock(GuiGatekeeperInterface::class),
                 'some-type',
-                666
+                '666'
             )
         );
     }

--- a/tests/Gui/Playlist/NewPlaylistDialogAdapterTest.php
+++ b/tests/Gui/Playlist/NewPlaylistDialogAdapterTest.php
@@ -41,9 +41,9 @@ class NewPlaylistDialogAdapterTest extends MockeryTestCase
     /** @var MockInterface|GuiGatekeeperInterface|null */
     private MockInterface $gatekeeper;
 
-    private string $object_type = 'some-object-type';
+    private string $objectType = 'some-object-type';
 
-    private int $object_id = 666;
+    private string $objectIds = '666';
 
     private ?NewPlaylistDialogAdapter $subject;
 
@@ -57,8 +57,8 @@ class NewPlaylistDialogAdapterTest extends MockeryTestCase
             $this->playlistLoader,
             $this->ajaxUriRetriever,
             $this->gatekeeper,
-            $this->object_type,
-            $this->object_id
+            $this->objectType,
+            $this->objectIds
         );
     }
 
@@ -102,16 +102,16 @@ class NewPlaylistDialogAdapterTest extends MockeryTestCase
     public function testGetObjectTypeReturnsValue(): void
     {
         $this->assertSame(
-            $this->object_type,
+            $this->objectType,
             $this->subject->getObjectType()
         );
     }
 
-    public function testGetObjectIdReturnsValue(): void
+    public function testGetObjectIdsReturnsValue(): void
     {
         $this->assertSame(
-            $this->object_id,
-            $this->subject->getObjectId()
+            $this->objectIds,
+            $this->subject->getObjectIds()
         );
     }
 


### PR DESCRIPTION
This is a serious flaw. The playlist-edit actions allows the object-id
to be int[] instead of int - but the app performs an int-cast on the
list to use it for some checks beforehand.