### PR TITLE
Give correct MetadataField in Ampache\Repository\Model\Metadata\Model\Metadata

### DIFF
--- a/src/Repository/Model/Metadata/Metadata.php
+++ b/src/Repository/Model/Metadata/Metadata.php
@@ -24,6 +24,7 @@ namespace Ampache\Repository\Model\Metadata;
 use Ampache\Config\AmpConfig;
 use Ampache\Repository\Model\Metadata\Model\MetadataField;
 use ReflectionException;
+use Ampache\Module\Util\ObjectTypeToClassNameMapper;
 
 trait Metadata
 {
@@ -66,7 +67,7 @@ trait Metadata
      */
     public function getMetadata()
     {
-        return $this->metadataRepository->findByObjectIdAndType($this->id, get_class($this));
+        return $this->metadataRepository->findByObjectIdAndType($this->id, ucfirst(ObjectTypeToClassNameMapper::reverseMap(get_class($this))));
     }
 
     /**
@@ -89,7 +90,7 @@ trait Metadata
         $metadata = new Model\Metadata();
         $metadata->setField($field);
         $metadata->setObjectId($this->id);
-        $metadata->setType(get_class($this));
+        $metadata->setType(ucfirst(ObjectTypeToClassNameMapper::reverseMap(get_class($this))));
         $metadata->setData($data);
         $this->metadataRepository->add($metadata);
     }
@@ -102,7 +103,7 @@ trait Metadata
     public function updateOrInsertMetadata(MetadataField $field, $data)
     {
         /* @var Model\Metadata $metadata */
-        $metadata = $this->metadataRepository->findByObjectIdAndFieldAndType($this->id, $field, get_class($this));
+        $metadata = $this->metadataRepository->findByObjectIdAndFieldAndType($this->id, $field, ucfirst(ObjectTypeToClassNameMapper::reverseMap(get_class($this))));
         if ($metadata) {
             $object = reset($metadata);
             $object->setData($data);

--- a/src/Repository/Model/Metadata/Model/Metadata.php
+++ b/src/Repository/Model/Metadata/Model/Metadata.php
@@ -62,7 +62,7 @@ class Metadata extends DatabaseObject implements Model
      * can initialize objects the right way
      */
     protected $fieldClassRelations = array(
-        'field' => MetadataField::class
+        'field' => \Ampache\Repository\Model\Metadata\Repository\MetadataField::class
     );
 
     /**


### PR DESCRIPTION
Fixes issue #2830

Also a correction to write only the classname (e.g. 'Song') into table field `metadata.type`, and not the classname with the full namespace.

This also solves a infinite loop when updating the catalog with custom metadata enabled