### PR TITLE
Make gravatar urls https-only

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -84,6 +84,7 @@ All API code that used 'Tag' now references 'Genre' instead
 * Don't transcode podcast_episodes
 * localplay
   * added 'track' parameter used by 'skip' commands to go to the playlist track (playlist starts at 1)
+* Plugins: Use only https for building gravatar urls
 
 ## Ampache 4.4.0-release
 

--- a/src/Plugin/AmpacheGravatar.php
+++ b/src/Plugin/AmpacheGravatar.php
@@ -23,16 +23,14 @@ declare(strict_types=0);
 
 namespace Ampache\Plugin;
 
-use Ampache\Config\AmpConfig;
 use Ampache\Repository\Model\User;
-use Ampache\Module\System\Core;
 
 class AmpacheGravatar
 {
     public $name        = 'Gravatar';
     public $categories  = 'avatar';
     public $description = 'User\'s avatars with Gravatar';
-    public $url         = 'http://gravatar.com';
+    public $url         = 'https://gravatar.com';
     public $version     = '000001';
     public $min_ampache = '360040';
     public $max_ampache = '999999';
@@ -84,18 +82,14 @@ class AmpacheGravatar
      */
     public function get_avatar_url($user, $size = 80)
     {
-        $url = "";
+        $url = '';
         if (!empty($user->email)) {
-            if (!empty(AmpConfig::get('force_ssl')) || (filter_has_var(INPUT_SERVER,
-                        'HTTPS') && Core::get_server('HTTPS') !== 'off')) {
-                $url = "https://secure.gravatar.com";
-            } else {
-                $url = "http://www.gravatar.com";
-            }
-            $url .= "/avatar/";
-            $url .= md5(strtolower(trim($user->email)));
-            $url .= "?s=" . $size . "&r=g";
-            $url .= "&d=identicon";
+            $url = sprintf(
+                '%s/avatar/%s?s=%d&r=g&d=identicon',
+                $this->url,
+                md5(strtolower(trim($user->email))),
+                $size
+            );
         }
 
         return $url;


### PR DESCRIPTION
As the browser vendors tend to drop http in near future (or at least add
warnings, etc...) and _every_ client out there is capable of modern TLS
versions, it's time to enforce https - at least when building the
gravatar-urls.

Related #2366

Fixes #1797