### PR TITLE
Fix /improved tag write

### DIFF
--- a/src/Config/ConfigurationKeyEnum.php
+++ b/src/Config/ConfigurationKeyEnum.php
@@ -105,6 +105,7 @@ final class ConfigurationKeyEnum
     public const ALLOW_ZIP_DOWNLOAD            = 'allow_zip_download';
     public const ENABLE_CUSTOM_METADATA        = 'enable_custom_metadata';
     public const WRITE_ID3                     = 'write_id3';
+    public const WRITE_ID3_ART                 = 'write_id3_art';
     public const COMPOSER_BINARY_PATH          = 'composer_binary_path';
     public const ART_ZIP_ADD                   = 'art_zip_add';
     public const FILE_ZIP_COMMENT              = 'file_zip_comment';

--- a/src/Module/Art/Collector/LastFmCollectorModule.php
+++ b/src/Module/Art/Collector/LastFmCollectorModule.php
@@ -115,7 +115,7 @@ final class LastFmCollectorModule implements CollectorModuleInterface
                 );
 
                 // HACK: we shouldn't rely on the extension to determine file type
-                $results  = pathinfo($url[0]);
+                $results  = pathinfo($url);
                 $mime     = 'image/' . $results['extension'];
                 $images[] = ['url' => $url, 'mime' => $mime, 'title' => 'LastFM'];
                 if ($limit && count($images) >= $limit) {

--- a/src/Module/Util/VaInfo.php
+++ b/src/Module/Util/VaInfo.php
@@ -331,8 +331,8 @@ final class VaInfo implements VaInfoInterface
 
                 if ($retval !== 0 || $retval1 !== 0) {
                     $this->logger->debug(
-                       'Metaflac and vorbiscomments must be installed to write tags to flac and oga files',
-                       [LegacyLogger::CONTEXT_TYPE => __CLASS__]
+                        'Metaflac and vorbiscomments must be installed to write tags to flac and oga files',
+                        [LegacyLogger::CONTEXT_TYPE => __CLASS__]
                     );
                     
                     return;

--- a/src/Module/Util/VaInfo.php
+++ b/src/Module/Util/VaInfo.php
@@ -334,14 +334,13 @@ final class VaInfo implements VaInfoInterface
         }
     } // write_id3
 
-
-    /**
-     * prepare_id3_frames
-     * Prepares id3 frames for writing tag to file
+     /**
+     * prepare_metadata_for_writing
+     * Prepares vorbiscomments/id3v2 metadata for writing tag to file
      * @param array $frames
      * @return array
      */
-    public function prepare_id3_frames($frames)
+    public function prepare_metadata_for_writing($frames)
     {
         $ndata = array();
         foreach ($frames as $key => $text) {

--- a/src/Module/Util/VaInfo.php
+++ b/src/Module/Util/VaInfo.php
@@ -365,11 +365,11 @@ final class VaInfo implements VaInfoInterface
     } // write_id3
 
     /**
-    * prepare_metadata_for_writing
-    * Prepares vorbiscomments/id3v2 metadata for writing tag to file
-    * @param array $frames
-    * @return array
-    */
+     * prepare_metadata_for_writing
+     * Prepares vorbiscomments/id3v2 metadata for writing tag to file
+     * @param array $frames
+     * @return array
+     */
     public function prepare_metadata_for_writing($frames)
     {
         $ndata = array();
@@ -391,7 +391,7 @@ final class VaInfo implements VaInfoInterface
 
     /**
      * read_id3
-
+     * 
      * This function runs the various steps to gathering the metadata
      * @return array
      */

--- a/src/Module/Util/VaInfoInterface.php
+++ b/src/Module/Util/VaInfoInterface.php
@@ -47,12 +47,12 @@ interface VaInfoInterface
      */
     public function write_id3($tagData);
     
-     /**
-     * prepare_metadata_for_writing
-     * Prepares vorbiscomments/id3v2 metadata for writing tag to file
-     * @param array $frames
-     * @return array
-     */
+    /**
+    * prepare_metadata_for_writing
+    * Prepares vorbiscomments/id3v2 metadata for writing tag to file
+    * @param array $frames
+    * @return array
+    */
     public function prepare_metadata_for_writing($frames);
 
     /**

--- a/src/Module/Util/VaInfoInterface.php
+++ b/src/Module/Util/VaInfoInterface.php
@@ -46,14 +46,14 @@ interface VaInfoInterface
      * @throws Exception
      */
     public function write_id3($tagData);
-
-    /**
-     * prepare_id3_frames
-     * Prepares id3 frames for writing tag to file
+    
+     /**
+     * prepare_metadata_for_writing
+     * Prepares vorbiscomments/id3v2 metadata for writing tag to file
      * @param array $frames
      * @return array
      */
-    public function prepare_id3_frames($frames);
+    public function prepare_metadata_for_writing($frames);
 
     /**
      * read_id3

--- a/src/Module/Util/VaInfoInterface.php
+++ b/src/Module/Util/VaInfoInterface.php
@@ -48,16 +48,16 @@ interface VaInfoInterface
     public function write_id3($tagData);
     
     /**
-    * prepare_metadata_for_writing
-    * Prepares vorbiscomments/id3v2 metadata for writing tag to file
-    * @param array $frames
-    * @return array
-    */
+     * prepare_metadata_for_writing
+     * Prepares vorbiscomments/id3v2 metadata for writing tag to file
+     * @param array $frames
+     * @return array
+     */
     public function prepare_metadata_for_writing($frames);
 
     /**
      * read_id3
-
+     *
      * This function runs the various steps to gathering the metadata
      * @return array
      */

--- a/src/Repository/Model/Art.php
+++ b/src/Repository/Model/Art.php
@@ -399,7 +399,6 @@ class Art extends database_object
                     'picturetypeid' => $current_picturetypeid, 'description' => $description);
 
                 if (is_null($apics)) {
-                    //       $ndata['attached_picture'][]    = $apics[0];
                     $ndata['attached_picture'][]    = $new_pic;
                 } else {
                     switch (count($apics)) {
@@ -420,9 +419,9 @@ class Art extends database_object
                             if (is_null($idx)) {
                                 $ndata['attached_picture'][0] = $new_pic;
                             } else {
-                                $id                              = ($idx == 0) ? 1 : 0;
-                                $ndata['attached_picture'][$id]  = array('data' => $apics[$id]['data'], 'mime' => $apics[$id][$apic_mimetype],
-                    'picturetypeid' => $apics[$id][$apic_typeid], 'description' => $apics[$id]['description']);
+                                $apicsId                              = ($idx == 0) ? 1 : 0;
+                                $ndata['attached_picture'][$apicsId]  = array('data' => $apics[$apicsId]['data'], 'mime' => $apics[$apicsId][$apic_mimetype],
+                                'picturetypeid' => $apics[$apicsId][$apic_typeid], 'description' => $apics[$apicsId]['description']);
                                 ;
                             }
                             
@@ -452,8 +451,7 @@ class Art extends database_object
         $idx = null;
         for ($i=0; $i < count($apics); $i++) {
             if ($new_pic['picturetypeid'] == $apics[$i][$apic_typeid]) {
-                $ndata['attached_picture'][$i]['description']       = $new_pic['descr
-                iption'];
+                $ndata['attached_picture'][$i]['description']       = $new_pic['description'];
                 $ndata['attached_picture'][$i]['data']              = $new_pic['data'];
                 $ndata['attached_picture'][$i]['mime']              = $new_pic['mime'];
                 $ndata['attached_picture'][$i]['picturetypeid']     = $new_pic['picturetypeid'];

--- a/src/Repository/Model/Art.php
+++ b/src/Repository/Model/Art.php
@@ -404,7 +404,7 @@ class Art extends database_object
                 } else {
                     switch (count($apics)) {
                         case 1:
-                            $idx = $this->check_for_duplicate($apics, $ndata, $new_pic, $apic_typeid, $apic_mimetype);
+                            $idx = $this->check_for_duplicate($apics, $ndata, $new_pic, $apic_typeid);
                             if (is_null($idx)) {
                                 $ndata['attached_picture'][] = $new_pic;
                                 $ndata['attached_picture'][] = array('data' => $apics[0]['data'], 'description' => $apics[0]['description'],
@@ -412,7 +412,7 @@ class Art extends database_object
                             }
                             break;
                         case 2:
-                            $idx = $this->check_for_duplicate($apics, $ndata, $new_pic, $apic_typeid, $apic_mimetype);
+                            $idx = $this->check_for_duplicate($apics, $ndata, $new_pic, $apic_typeid);
                             /* If $idx is null, it means both images are of opposite types
                              * of the new image. Either image could be replaced to have
                              * one cover and one artist image.
@@ -435,7 +435,7 @@ class Art extends database_object
                 $vainfo->write_id3($ndata);
             } // foreach song
         } // write_id3
-//        $this->write_tag_to_file($source, $mime);
+
         if (AmpConfig::get('album_art_store_disk')) {
             self::write_to_dir($source, $sizetext, $this->type, $this->uid, $this->kind);
             $source = null;
@@ -446,93 +446,14 @@ class Art extends database_object
 
         return true;
     } // insert
-    
-    /* Tag here means the concantonation of all the metadata frames
-     *  which overwrites the existing Tag.
-     */
-    public function write_tag_to_file($source, $mime)
-    {
-        $current_picturetypeid = ($this->type == 'album') ? 3 : 8;
-        global $dic;
-        $utilityFactory = $dic->get(UtilityFactoryInterface::class);
 
-        if (AmpConfig::get('write_id3_art', false)) {
-            $class_name = ObjectTypeToClassNameMapper::map($this->type);
-            $object     = new $class_name($this->uid);
-            debug_event(__CLASS__, 'Inserting ' . $this->type . ' image' . $object->name . ' for song files.', 5);
-            if ($this->type === 'album') {
-                /** Use special treatment for albums */
-                $songs = $this->getSongRepository()->getByAlbum($object->id);
-            } elseif ($this->type === 'artist') {
-                /** Use special treatment for artists */
-                $songs = $this->getSongRepository()->getByArtist($object);
-            }
-            foreach ($songs as $song_id) {
-                $song   = new Song($song_id);
-                $song->format();
-                $description = ($this->type == 'artist') ? $song->f_artist_full : $object->full_name;
-                $vainfo      = $utilityFactory->createVaInfo(
-                    $song->file
-                );
-                $ndata      = array();
-                $fileformat = '';
-                $data       = $vainfo->read_id3();
-                $fileformat = $data['fileformat'];
-                if ($fileformat == 'flac') {
-                    $apics = $data['flac']['PICTURE'];
-                } else {
-                    $apics = $data['id3v2']['APIC'];
-                }
-                /* is the file flac or mp3? */
-                $apic_typeid   = ($fileformat == 'flac') ? 'typeid' : 'picturetypeid';
-                $apic_mimetype = ($fileformat == 'flac') ? 'mime_type' : 'picturetypeid';
-                
-                if (is_null($apics)) {
-                    $ndata['attached_picture'][0]['description']   = $description;
-                    $ndata['attached_picture'][0]['data']          = $source;
-                    $ndata['attached_picture'][0]['mime']          = $mime;
-                    $ndata['attached_picture'][0]['picturetypeid'] = $current_picturetypeid;
-                } else {
-                    $new_pic = array('data' => $source, 'mime' => $mime,
-                    'picturetypeid' => $current_picturetypeid, 'description' => $description);
-                    switch (count($apics)) {
-                        case 1:
-                            $idx = $this->check_for_duplicate($apics, $ndata, $new_pic, $apic_typeid, $apic_mimetype);
-                            if (is_null($idx)) {
-                                $ndata['attached_picture'][] = $new_pic;
-                            }
-                            $ndata['attached_picture'][] = $apics[0];
-                            break;
-                        case 2:
-                            $idx = $this->check_for_duplicate($apics, $ndata, $new_pic, $apic_typeid, $apic_mimetype);
-                            /* If $idx is null, it means both images are of opposite types
-                             * of the new image. Either image could be replaced to have
-                             * one cover and one artist image.
-                             */
-                            if (is_null($idx)) {
-                                $ndata['attached_picture'][0] = $new_pic;
-                            } else {
-                                $id                           = ($idx == 0) ? 1 : 0;
-                                $ndata['attached_picture'][]  = $apics[$id];
-                            }
-                            
-                            break;
-                    }
-                }
-                unset($apics);
-                $tags    = ($fileformat == 'flac') ? 'vorbiscomment' : 'id3v2';
-                $ndata   = array_merge($ndata, $vainfo->prepare_metadata_for_writing($data['tags'][$tags]));
-                $vainfo->write_id3($ndata);
-            } // foreach song
-        } // write_id3
-    }
-    
-    private function check_for_duplicate($apics, &$ndata, $new_pic, $apic_typeid, $apic_mimetype)
+    private function check_for_duplicate($apics, &$ndata, $new_pic, $apic_typeid)
     {
         $idx = null;
         for ($i=0; $i < count($apics); $i++) {
             if ($new_pic['picturetypeid'] == $apics[$i][$apic_typeid]) {
-                $ndata['attached_picture'][$i]['description']       = $new_pic['description'];
+                $ndata['attached_picture'][$i]['description']       = $new_pic['descr
+                iption'];
                 $ndata['attached_picture'][$i]['data']              = $new_pic['data'];
                 $ndata['attached_picture'][$i]['mime']              = $new_pic['mime'];
                 $ndata['attached_picture'][$i]['picturetypeid']     = $new_pic['picturetypeid'];

--- a/src/Repository/Model/Artist.php
+++ b/src/Repository/Model/Artist.php
@@ -347,6 +347,25 @@ class Artist extends database_object implements library_item, GarbageCollectible
     }
 
     /**
+     * get_album_ids
+     *
+     * Get each album id for the artist
+     * @return int[]
+     */
+    public function get_album_ids()
+    {
+        $sql        = "SELECT  DISTINCT `album`.`id` FROM `song` LEFT JOIN `catalog` ON `catalog`.`id` = `song`.`catalog` LEFT JOIN `album` ON `album`.`id` = `song`.`album` WHERE `album`.`album_artist` = ? AND `catalog`.`enabled` = '1'";
+        $db_results = Dba::read($sql, array($this->id));
+        $results    = array();
+
+        while ($row = Dba::fetch_assoc($db_results, false)) {
+            $results[] = (int)$row['id'];
+        }
+
+        return $results;
+    }
+
+    /**
      * get_album_count
      *
      * Get count for an artist's albums.
@@ -362,6 +381,7 @@ class Artist extends database_object implements library_item, GarbageCollectible
 
         return (int) $results['album_count'];
     }
+
     /**
      * get_album_group_count
      *

--- a/src/Repository/Model/Catalog.php
+++ b/src/Repository/Model/Catalog.php
@@ -2933,7 +2933,7 @@ abstract class Catalog extends database_object
                 $catalogs = self::get_catalogs();
                 // Intentional break fall-through
             case 'update_file_tags':
-                $write_id3 = AmpConfig::get('write_id3', false);
+                $write_id3     = AmpConfig::get('write_id3', false);
                 $write_id3_art = AmpConfig::get('write_id3_art', false);
                 AmpConfig::set_by_array(['write_id3' => 'true'], true);
                 AmpConfig::set_by_array(['write_id3_art' => 'true'], true);

--- a/src/Repository/Model/Catalog.php
+++ b/src/Repository/Model/Catalog.php
@@ -2934,9 +2934,9 @@ abstract class Catalog extends database_object
                 // Intentional break fall-through
             case 'update_file_tags':
                 $write_id3 = AmpConfig::get('write_id3', false);
-                AmpConfig::set('write_id3', 'true', true);
                 $write_id3_art = AmpConfig::get('write_id3_art', false);
-                AmpConfig::set('write_id3_art', 'true', true);
+                AmpConfig::set_by_array(['write_id3' => 'true'], true);
+                AmpConfig::set_by_array(['write_id3_art' => 'true'], true);
 
                 $id3Writer = static::getSongId3TagWriter();
                 set_time_limit(0);
@@ -2952,8 +2952,8 @@ abstract class Catalog extends database_object
                         }
                     }
                 }
-                AmpConfig::set('write_id3', $write_id3, true);
-                AmpConfig::set('write_id3', $write_id3_art, true);
+                AmpConfig::set_by_array(['write_id3' => $write_id3], true);
+                AmpConfig::set_by_array(['write_id3' => $write_id3_art], true);
         }
 
         // Remove any orphaned artists/albums/etc.

--- a/src/Repository/Model/Catalog.php
+++ b/src/Repository/Model/Catalog.php
@@ -1732,6 +1732,10 @@ abstract class Catalog extends database_object
                 static::getAlbumRepository()->updateTime($libitem);
                 break;
             case 'artist':
+                foreach ($libitem->get_album_ids() as $album_id) {
+                    $album_tags = self::getSongTags('album', $album_id);
+                    Tag::update_tag_list(implode(',', $album_tags), 'album', $album_id, false);
+                }
                 $tags = self::getSongTags('artist', $libitem->id);
                 Tag::update_tag_list(implode(',', $tags), 'artist', $libitem->id, false);
                 $libitem->update_album_count();


### PR DESCRIPTION
1. Added check for existance of metaflac and vorbiscomments before writing flac or oga tags.
2. getID3 library doesn't remove pictures, only vorbiscomments.  Added work-around to replace existing file images in flac or oga files.
3.  Added missing constant `WRITE_ID3_ART` to `src/Config/ConfigurationKeyEnum.php`

This PR hasn't been tested on Windows: Specifically the Windows code in Vainfo.php.  **Hopefully someone can test PR in Windows environment before merging**.