### PR TITLE
Search bar improvements

### DIFF
--- a/public/templates/header.inc.php
+++ b/public/templates/header.inc.php
@@ -228,9 +228,14 @@ $ajaxUriRetriever = $dic->get(AjaxUriRetrieverInterface::class);
                             return false;
                         },
                         select: function( event, ui ) {
-                            if (ui.item != null) {
+                            if (ui.item !== null) {
                                 $(this).val(ui.item.value);
                             }
+
+                            if (event.keyCode === $.ui.keyCode.ENTER) {
+                                NavigateTo(ui.item.link);
+                            }
+
                             return false;
                         }
                     });

--- a/public/templates/header.inc.php
+++ b/public/templates/header.inc.php
@@ -165,22 +165,26 @@ $ajaxUriRetriever = $dic->get(AjaxUriRetrieverInterface::class);
                         } else {
                             itemhtml += "<a>";
                         }
-                        if (item.image != '') {
-                            itemhtml += "<img src='" + item.image + "' class='searchart' />";
+                        if (item.image !== '') {
+                            itemhtml += "<img src='" + item.image + "' class='searchart' alt='' />";
                         }
-                        itemhtml += "<span class='searchitemtxt'>" + item.label + ((item.rels == '') ? "" : " - " + item.rels)  + "</span>";
+                        itemhtml += "<span class='searchitemtxt'>" + item.label + ((item.rels === '') ? "" : " - " + item.rels)  + "</span>";
                         itemhtml += "</a>";
 
                         return $( "<li class='ui-menu-item'>" )
                             .data("ui-autocomplete-item", item)
-                            .append( itemhtml )
+                            .append( itemhtml + "</li>")
                             .appendTo( ul );
                 },
                 _renderMenu: function( ul, items ) {
                     var that = this, currentType = "";
                     $.each( items, function( index, item ) {
-                        if (item.type != currentType) {
-                            ul.append( "<li class='ui-autocomplete-category'>" + item.type + "</li>" );
+                        if (item.type !== currentType) {
+                            $( "<li class='ui-autocomplete-category'>")
+                                .data("ui-autocomplete-item", item)
+                                .append( item.type + "</li>" )
+                                .appendTo( ul );
+
                             currentType = item.type;
                         }
                         that._renderItem( ul, item );

--- a/public/templates/header.inc.php
+++ b/public/templates/header.inc.php
@@ -202,7 +202,7 @@ $ajaxUriRetriever = $dic->get(AjaxUriRetrieverInterface::class);
                         }
                     })
                     // reopen previous search results
-                    .bind( "focus click", function( event ) {
+                    .bind( "click", function( event ) {
                         if ($( this )[0].value.length >= minSearchChars) {
                             $( this ).data( "custom-catcomplete" ).search();
                         }
@@ -228,10 +228,6 @@ $ajaxUriRetriever = $dic->get(AjaxUriRetrieverInterface::class);
                             return false;
                         },
                         select: function( event, ui ) {
-                            if (ui.item !== null) {
-                                $(this).val(ui.item.value);
-                            }
-
                             if (event.keyCode === $.ui.keyCode.ENTER) {
                                 NavigateTo(ui.item.link);
                             }

--- a/public/templates/header.inc.php
+++ b/public/templates/header.inc.php
@@ -196,7 +196,7 @@ $ajaxUriRetriever = $dic->get(AjaxUriRetrieverInterface::class);
                 $( "#searchString" )
                 // don't navigate away from the field on tab when selecting an item
                     .bind( "keydown", function( event ) {
-                        if ( event.keyCode === $.ui.keyCode.TAB && $( this ).data( "ui-autocomplete" ).menu.active ) {
+                        if ( event.keyCode === $.ui.keyCode.TAB && $( this ).data( "custom-catcomplete" ).widget().is(":visible") ) {
                             event.preventDefault();
                         }
                     })

--- a/public/templates/header.inc.php
+++ b/public/templates/header.inc.php
@@ -203,7 +203,7 @@ $ajaxUriRetriever = $dic->get(AjaxUriRetrieverInterface::class);
                     })
                     // reopen previous search results
                     .bind( "click", function( event ) {
-                        if ($( this )[0].value.length >= minSearchChars) {
+                        if ($( this ).val().length >= minSearchChars) {
                             $( this ).data( "custom-catcomplete" ).search();
                         }
                     })
@@ -219,7 +219,7 @@ $ajaxUriRetriever = $dic->get(AjaxUriRetrieverInterface::class);
                         },
                         search: function() {
                             // custom minLength
-                            if (this.value.length < minSearchChars) {
+                            if ($( this ).val().length < minSearchChars) {
                                 return false;
                             }
                         },

--- a/public/templates/header.inc.php
+++ b/public/templates/header.inc.php
@@ -193,11 +193,18 @@ $ajaxUriRetriever = $dic->get(AjaxUriRetrieverInterface::class);
             });
 
             $(function() {
+                var minSearchChars = 2;
                 $( "#searchString" )
-                // don't navigate away from the field on tab when selecting an item
+                    // don't navigate away from the field on tab when selecting an item
                     .bind( "keydown", function( event ) {
                         if ( event.keyCode === $.ui.keyCode.TAB && $( this ).data( "custom-catcomplete" ).widget().is(":visible") ) {
                             event.preventDefault();
+                        }
+                    })
+                    // reopen previous search results
+                    .bind( "focus", function( event ) {
+                        if ($( this )[0].value.length >= minSearchChars) {
+                            $( this ).data( "custom-catcomplete" ).search();
                         }
                     })
                     .catcomplete({
@@ -212,7 +219,7 @@ $ajaxUriRetriever = $dic->get(AjaxUriRetrieverInterface::class);
                         },
                         search: function() {
                             // custom minLength
-                            if (this.value.length < 2) {
+                            if (this.value.length < minSearchChars) {
                                 return false;
                             }
                         },

--- a/public/templates/header.inc.php
+++ b/public/templates/header.inc.php
@@ -236,6 +236,9 @@ $ajaxUriRetriever = $dic->get(AjaxUriRetrieverInterface::class);
                                 NavigateTo(ui.item.link);
                             }
 
+                            // remove focus from search after selection
+                            $(this).blur();
+
                             return false;
                         }
                     });

--- a/public/templates/header.inc.php
+++ b/public/templates/header.inc.php
@@ -202,7 +202,7 @@ $ajaxUriRetriever = $dic->get(AjaxUriRetrieverInterface::class);
                         }
                     })
                     // reopen previous search results
-                    .bind( "focus", function( event ) {
+                    .bind( "focus click", function( event ) {
                         if ($( this )[0].value.length >= minSearchChars) {
                             $( this ).data( "custom-catcomplete" ).search();
                         }
@@ -235,9 +235,6 @@ $ajaxUriRetriever = $dic->get(AjaxUriRetrieverInterface::class);
                             if (event.keyCode === $.ui.keyCode.ENTER) {
                                 NavigateTo(ui.item.link);
                             }
-
-                            // remove focus from search after selection
-                            $(this).blur();
 
                             return false;
                         }


### PR DESCRIPTION
- Fixes ```Uncaught TypeError: n is undefined``` when result rows are hovered on, due to the autocomplete widget expecting .data()
- Fixes #371, pressing [Enter] now navigates to the selected item
- Clicking into search field with existing value will reopen results (having to add/remove characters just to trigger previous results is annoying)
- Preserve the search string instead of replacing it with the selected item
- Fixes the [Tab] key bind