### PR TITLE
Display flag/fav alongside star ratings

### DIFF
--- a/public/templates/now-playing.css
+++ b/public/templates/now-playing.css
@@ -52,7 +52,7 @@ label {
 .cel_username,
 .cel_tags,
 .similars,
-.cel_rating,
+.cel_ratings,
 .cel_userflag {
     display: none;
 }

--- a/public/templates/show_album.inc.php
+++ b/public/templates/show_album.inc.php
@@ -84,22 +84,16 @@ if ($directplay_limit > 0) {
         Art::display('album', $album->id, $name, $thumb); ?>
 </div>
 <?php if (User::is_registered()) { ?>
-    <?php if (AmpConfig::get('ratings')) {
-            $rating = new Rating($album->id, 'album'); ?>
-    <div style="display:table-cell;" id="rating_<?php echo $album->id; ?>_album">
-            <?php echo Rating::show($album->id, 'album');
-            $average = $rating->get_average_rating();
-            if ($average > 0) {
-                /* HINT: Average rating. e.g. (average 3.7) */
-                echo '(' . T_('average') . ' ' . $average . ')';
-            } ?>
-    </div></p>
+    <?php if (AmpConfig::get('ratings')) { ?>
+    <span id="rating_<?php echo $album->id; ?>_album">
+        <?php echo Rating::show($album->id, 'album', true); ?>
+    </span>
     <?php
-        } ?>
+    } ?>
     <?php if (AmpConfig::get('userflags')) { ?>
-    <div style="display:table-cell;" id="userflag_<?php echo $album->id; ?>_album">
-            <?php echo Userflag::show($album->id, 'album'); ?>
-    </div>
+    <span id="userflag_<?php echo $album->id; ?>_album">
+        <?php echo Userflag::show($album->id, 'album'); ?>
+    </span>
     <?php
         } ?>
 <?php

--- a/public/templates/show_album_group_disks.inc.php
+++ b/public/templates/show_album_group_disks.inc.php
@@ -81,15 +81,15 @@ $zipHandler = $dic->get(ZipHandlerInterface::class);
 </div>
 <?php if (User::is_registered()) { ?>
     <?php if (AmpConfig::get('ratings')) { ?>
-    <div style="display:table-cell;" id="rating_<?php echo $album->id; ?>_album">
-            <?php echo Rating::show($album->id, 'album'); ?>
-    </div>
+    <span id="rating_<?php echo $album->id; ?>_album">
+        <?php echo Rating::show($album->id, 'album'); ?>
+    </span>
     <?php
         } ?>
     <?php if (AmpConfig::get('userflags')) { ?>
-    <div style="display:table-cell;" id="userflag_<?php echo $album->id; ?>_album">
-            <?php echo Userflag::show($album->id, 'album'); ?>
-    </div>
+    <span id="userflag_<?php echo $album->id; ?>_album">
+        <?php echo Userflag::show($album->id, 'album'); ?>
+    </span>
     <?php
         } ?>
 <?php

--- a/public/templates/show_album_row.inc.php
+++ b/public/templates/show_album_row.inc.php
@@ -26,7 +26,6 @@ use Ampache\Repository\Model\Art;
 use Ampache\Repository\Model\Catalog;
 use Ampache\Repository\Model\Rating;
 use Ampache\Repository\Model\Share;
-use Ampache\Repository\Model\User;
 use Ampache\Repository\Model\Userflag;
 use Ampache\Module\Authorization\Access;
 use Ampache\Module\Api\Ajax;
@@ -91,15 +90,23 @@ if (Art::is_enabled()) {
     } ?>
 <td class="<?php echo $cel_tags; ?> optional"><?php echo $libitem->f_tags; ?></td>
 <?php
-    if (User::is_registered()) {
-        if (AmpConfig::get('ratings')) { ?>
-            <td class="cel_rating" id="rating_<?php echo $libitem->id; ?>_album"><?php echo Rating::show($libitem->id, 'album'); ?></td>
+    if ($show_ratings) { ?>
+        <td class="cel_ratings">
+            <?php if (AmpConfig::get('ratings')) { ?>
+                <span class="cel_rating" id="rating_<?php echo $libitem->id; ?>_album">
+                    <?php echo Rating::show($libitem->id, 'album'); ?>
+                </span>
+            <?php
+            } ?>
+
+            <?php if (AmpConfig::get('userflags')) { ?>
+                <span class="cel_userflag" id="userflag_<?php echo $libitem->id; ?>_album">
+                    <?php echo Userflag::show($libitem->id, 'album'); ?>
+                </span>
+            <?php
+            } ?>
+        </td>
     <?php
-        }
-        if (AmpConfig::get('userflags')) { ?>
-            <td class="<?php echo $cel_flag; ?>" id="userflag_<?php echo $libitem->id; ?>_album"><?php echo Userflag::show($libitem->id, 'album'); ?></td>
-    <?php
-        }
     } ?>
 <td class="cel_action">
     <?php if (!AmpConfig::get('use_auth') || Access::check('interface', 25)) {

--- a/public/templates/show_albums.inc.php
+++ b/public/templates/show_albums.inc.php
@@ -30,15 +30,15 @@ use Ampache\Module\Authorization\Access;
 use Ampache\Module\Api\Ajax;
 use Ampache\Module\Util\Ui;
 
-$web_path = AmpConfig::get('web_path');
-$thcount  = 8;
-$is_table = $browse->is_grid_view();
+$web_path     = AmpConfig::get('web_path');
+$thcount      = 8;
+$show_ratings = User::is_registered() && (AmpConfig::get('ratings') || AmpConfig::get('userflags'));
+$is_table     = $browse->is_grid_view();
 //mashup and grid view need different css
 $cel_cover   = ($is_table) ? "cel_cover" : 'grid_cover';
 $cel_album   = ($is_table) ? "cel_album" : 'grid_album';
 $cel_artist  = ($is_table) ? "cel_artist" : 'grid_artist';
 $cel_tags    = ($is_table) ? "cel_tags" : 'grid_tags';
-$cel_flag    = ($is_table) ? "cel_userflag" : 'grid_userflag';
 $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
 <?php if ($browse->is_show_header()) {
     require Ui::find_template('list_header.inc.php');
@@ -64,18 +64,10 @@ $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
             <?php
     } ?>
             <th class="<?php echo $cel_tags; ?> optional"><?php echo T_('Genres'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) {
+            <?php if ($show_ratings) {
         ++$thcount; ?>
-                    <th class="cel_rating optional"><?php echo T_('Rating'); ?></th>
+                <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
                 <?php
-    } ?>
-                <?php if (AmpConfig::get('userflags')) {
-        ++$thcount; ?>
-                    <th class="<?php echo $cel_flag; ?> optional"><?php echo T_('Fav.'); ?></th>
-                <?php
-    } ?>
-            <?php
     } ?>
             <th class="cel_action essential"><?php echo T_('Actions'); ?></th>
         </tr>
@@ -133,17 +125,10 @@ $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
             <?php
         } ?>
             <th class="<?php echo $cel_tags; ?>"><?php echo T_('Genres'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) { ?>
-                    <th class="cel_rating"><?php echo T_('Rating'); ?></th>
+            <?php if ($show_ratings) { ?>
+                <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
                 <?php
             } ?>
-                <?php if (AmpConfig::get('userflags')) { ?>
-                    <th class="<?php echo $cel_flag; ?>"><?php echo T_('Fav.'); ?></th>
-                <?php
-            } ?>
-            <?php
-        } ?>
             <th class="cel_action"><?php echo T_('Actions'); ?></th>
         </tr>
     <tfoot>

--- a/public/templates/show_artist.inc.php
+++ b/public/templates/show_artist.inc.php
@@ -77,22 +77,16 @@ Ui::show_box_top($artist->f_name, 'info-box'); ?>
 </div>
 
 <?php if (User::is_registered()) { ?>
-    <?php if (AmpConfig::get('ratings')) {
-        $rating = new Rating($artist->id, 'artist'); ?>
-    <div id="rating_<?php echo (int) ($artist->id); ?>_artist" style="display:inline;">
-        <?php echo Rating::show($artist->id, 'artist');
-        $average = $rating->get_average_rating();
-        if ($average > 0) {
-            /* HINT: Average rating. e.g. (average 3.7) */
-            echo '(' . T_('average') . ' ' . $average . ')';
-        } ?>
-    </div>
+    <?php if (AmpConfig::get('ratings')) { ?>
+    <span id="rating_<?php echo (int) ($artist->id); ?>_artist">
+        <?php echo Rating::show($artist->id, 'artist', true); ?>
+    </span>
     <?php
     } ?>
     <?php if (AmpConfig::get('userflags')) { ?>
-    <div style="display:table-cell;" id="userflag_<?php echo $artist->id; ?>_artist">
-            <?php echo Userflag::show($artist->id, 'artist'); ?>
-    </div>
+    <span id="userflag_<?php echo $artist->id; ?>_artist">
+        <?php echo Userflag::show($artist->id, 'artist'); ?>
+    </span>
     <?php
     } ?>
 <?php

--- a/public/templates/show_artist_row.inc.php
+++ b/public/templates/show_artist_row.inc.php
@@ -25,7 +25,6 @@ use Ampache\Repository\Model\Art;
 use Ampache\Repository\Model\Artist;
 use Ampache\Repository\Model\Catalog;
 use Ampache\Repository\Model\Rating;
-use Ampache\Repository\Model\User;
 use Ampache\Repository\Model\Userflag;
 use Ampache\Module\Authorization\Access;
 use Ampache\Module\Api\Ajax;
@@ -86,15 +85,23 @@ if (Art::is_enabled()) {
         } ?>
 <td class="<?php echo $cel_tags; ?>"><?php echo $libitem->f_tags; ?></td>
 <?php
-    if (User::is_registered()) {
-        if (AmpConfig::get('ratings')) { ?>
-            <td class="cel_rating" id="rating_<?php echo $libitem->id; ?>_artist"><?php echo Rating::show($libitem->id, 'artist'); ?></td>
-        <?php
-        }
-        if (AmpConfig::get('userflags')) { ?>
-            <td class="<?php echo $cel_flag; ?>" id="userflag_<?php echo $libitem->id; ?>_artist"><?php echo Userflag::show($libitem->id, 'artist'); ?></td>
-        <?php
-        }
+    if ($show_ratings) { ?>
+        <td class="cel_ratings">
+            <?php if (AmpConfig::get('ratings')) { ?>
+                <span class="cel_rating" id="rating_<?php echo $libitem->id; ?>_artist">
+                    <?php echo Rating::show($libitem->id, 'artist'); ?>
+                </span>
+            <?php
+            } ?>
+
+            <?php if (AmpConfig::get('userflags')) { ?>
+                <span class="cel_userflag" id="userflag_<?php echo $libitem->id; ?>_artist">
+                    <?php echo Userflag::show($libitem->id, 'artist'); ?>
+                </span>
+            <?php
+            } ?>
+        </td>
+    <?php
     } ?>
 <td class="cel_action">
 <?php if (!AmpConfig::get('use_auth') || Access::check('interface', 25)) {

--- a/public/templates/show_artists.inc.php
+++ b/public/templates/show_artists.inc.php
@@ -32,15 +32,15 @@ use Ampache\Module\Util\Ui;
 
 session_start();
 
-$web_path = AmpConfig::get('web_path');
-$thcount  = 8;
-$is_table = $browse->is_grid_view();
+$web_path     = AmpConfig::get('web_path');
+$thcount      = 8;
+$show_ratings = User::is_registered() && (AmpConfig::get('ratings') || AmpConfig::get('userflags'));
+$is_table     = $browse->is_grid_view();
 //mashup and grid view need different css
 $cel_cover   = ($is_table) ? "cel_cover" : 'grid_cover';
 $cel_album   = ($is_table) ? "cel_album" : 'grid_album';
 $cel_artist  = ($is_table) ? "cel_artist" : 'grid_artist';
 $cel_tags    = ($is_table) ? "cel_tags" : 'grid_tags';
-$cel_flag    = ($is_table) ? "cel_userflag" : 'grid_userflag';
 $cel_time    = ($is_table) ? "cel_time" : 'grid_time';
 $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
 <?php if ($browse->is_show_header()) {
@@ -65,17 +65,9 @@ $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
             <?php
     } ?>
             <th class="<?php echo $cel_tags; ?> optional"><?php echo T_('Genres'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) {
+            <?php if ($show_ratings) {
         ++$thcount; ?>
-                    <th class="cel_rating optional"><?php echo T_('Rating'); ?></th>
-                <?php
-    } ?>
-                <?php if (AmpConfig::get('userflags')) {
-        ++$thcount; ?>
-                    <th class="<?php echo $cel_flag; ?> optional"><?php echo T_('Fav.'); ?></th>
-                <?php
-    } ?>
+                <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
             <?php
     } ?>
             <th class="cel_action essential"><?php echo T_('Action'); ?></th>
@@ -135,15 +127,8 @@ $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
             <?php
         } ?>
             <th class="<?php echo $cel_tags; ?> optional"><?php echo T_('Genres'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) { ?>
-                    <th class="cel_rating optional"><?php echo T_('Rating'); ?></th>
-                <?php
-            } ?>
-                <?php if (AmpConfig::get('userflags')) { ?>
-                    <th class="<?php echo $cel_flag; ?> optional"><?php echo T_('Fav.'); ?></th>
-                <?php
-            } ?>
+            <?php if ($show_ratings) { ?>
+                <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
             <?php
         } ?>
             <th class="cel_action essential"> <?php echo T_('Action'); ?> </th>

--- a/public/templates/show_now_playing_row.inc.php
+++ b/public/templates/show_now_playing_row.inc.php
@@ -114,21 +114,15 @@ $(document).ready(function(){
         <div class="np_group" id="np_group_4">
     <?php
         if (AmpConfig::get('ratings')) { ?>
-            <div class="np_cell cel_rating">
-                <label><?php echo T_('Rating'); ?></label>
-                <div id="rating_<?php echo $media->id; ?>_song">
-                    <?php echo Rating::show($media->id, 'song'); ?>
-                </div>
-            </div>
+            <span id="rating_<?php echo $media->id; ?>_song">
+                <?php echo Rating::show($media->id, 'song'); ?>
+            </span>
         <?php
         }
         if (AmpConfig::get('userflags')) { ?>
-            <div class="np_cell cel_userflag">
-                <label><?php echo T_('Fav.'); ?></label>
-                <div id="userflag_<?php echo $media->id; ?>_song">
-                    <?php echo Userflag::show($media->id, 'song'); ?>
-                </div>
-            </div>
+            <span id="userflag_<?php echo $media->id; ?>_song">
+                <?php echo Userflag::show($media->id, 'song'); ?>
+            </span>
         <?php
         } ?>
         </div>

--- a/public/templates/show_now_playing_video_row.inc.php
+++ b/public/templates/show_now_playing_video_row.inc.php
@@ -70,18 +70,12 @@ $media->format(); ?>
 <div class="np_group" id="np_group_4">
 <?php
     if (AmpConfig::get('ratings')) { ?>
-        <div class="np_cell cel_rating">
-            <label><?php echo T_('Rating'); ?></label>
-            <div id="rating_<?php echo $media->id; ?>_video">
-                <?php echo Rating::show($media->id, 'video'); ?>
-            </div>
-        </div>
-        <div class="np_cell cel_userflag">
-            <label><?php echo T_('Fav.'); ?></label>
-            <div id="userflag_<?php echo $media->id; ?>_video">
-                <?php echo Userflag::show($media->id, 'video'); ?>
-            </div>
-        </div>
+        <span id="rating_<?php echo $media->id; ?>_video">
+            <?php echo Rating::show($media->id, 'video'); ?>
+        </span>
+        <span id="userflag_<?php echo $media->id; ?>_video">
+            <?php echo Userflag::show($media->id, 'video'); ?>
+        </span>
     <?php
     } ?>
 </div>

--- a/public/templates/show_playlist.inc.php
+++ b/public/templates/show_playlist.inc.php
@@ -52,15 +52,15 @@ ob_end_clean();
 Ui::show_box_top('<div id="playlist_row_' . $playlist->id . '">' . $title . '</div>', 'info-box'); ?>
 <?php if (User::is_registered()) { ?>
     <?php if (AmpConfig::get('ratings')) { ?>
-    <div style="display:table-cell;" id="rating_<?php echo $playlist->id; ?>_playlist">
-            <?php echo Rating::show($playlist->id, 'playlist'); ?>
-    </div>
+    <span id="rating_<?php echo $playlist->id; ?>_playlist">
+        <?php echo Rating::show($playlist->id, 'playlist'); ?>
+    </span>
     <?php
     } ?>
     <?php if (AmpConfig::get('userflags')) { ?>
-    <div style="display:table-cell;" id="userflag_<?php echo $playlist->id; ?>_playlist">
-            <?php echo Userflag::show($playlist->id, 'playlist'); ?>
-    </div>
+    <span id="userflag_<?php echo $playlist->id; ?>_playlist">
+        <?php echo Userflag::show($playlist->id, 'playlist'); ?>
+    </span>
     <?php
     } ?>
 <?php

--- a/public/templates/show_playlist_media_row.inc.php
+++ b/public/templates/show_playlist_media_row.inc.php
@@ -26,7 +26,6 @@ use Ampache\Repository\Model\Art;
 use Ampache\Repository\Model\Playlist;
 use Ampache\Repository\Model\Rating;
 use Ampache\Repository\Model\Share;
-use Ampache\Repository\Model\User;
 use Ampache\Repository\Model\Userflag;
 use Ampache\Module\Authorization\Access;
 use Ampache\Module\Api\Ajax;
@@ -72,16 +71,24 @@ if (!isset($libitem->enabled) || $libitem->enabled || Access::check('interface',
     </span>
 </td>
 <td class="<?php echo $cel_time; ?>"><?php echo $libitem->f_time ?></td>
-<?php if (User::is_registered()) {
-        if (AmpConfig::get('ratings')) { ?>
-    <td class="cel_rating" id="rating_<?php echo $libitem->id ?>_<?php echo $object_type ?>"><?php echo Rating::show($libitem->id, $object_type) ?></td>
-    <?php
-        }
-        if (AmpConfig::get('userflags')) { ?>
-    <td class="<?php echo $cel_flag; ?>" id="userflag_<?php echo $libitem->id ?>_<?php echo $object_type ?>"><?php echo Userflag::show($libitem->id, $object_type) ?></td>
-    <?php
-        }
-    } ?>
+<?php if ($show_ratings) { ?>
+    <td class="cel_ratings">
+        <?php if (AmpConfig::get('ratings')) { ?>
+            <span class="cel_rating" id="rating_<?php echo $libitem->id ?>_<?php echo $object_type ?>">
+                <?php echo Rating::show($libitem->id, $object_type) ?>
+            </span>
+        <?php
+        } ?>
+
+        <?php if (AmpConfig::get('userflags')) { ?>
+            <span class="cel_userflag" id="userflag_<?php echo $libitem->id ?>_<?php echo $object_type ?>">
+                <?php echo Userflag::show($libitem->id, $object_type) ?>
+            </span>
+        <?php
+        } ?>
+    </td>
+<?php
+} ?>
 <td class="cel_action">
     <?php if (AmpConfig::get('download')) { ?>
     <a class="nohtml" href="<?php echo AmpConfig::get('web_path') ?>/stream.php?action=download&amp;<?php echo $object_type ?>_id=<?php echo $libitem->id ?>">

--- a/public/templates/show_playlist_medias.inc.php
+++ b/public/templates/show_playlist_medias.inc.php
@@ -28,13 +28,13 @@ use Ampache\Module\Util\InterfaceImplementationChecker;
 use Ampache\Module\Util\ObjectTypeToClassNameMapper;
 use Ampache\Module\Util\Ui;
 
-$web_path = AmpConfig::get('web_path');
-$seconds  = $browse->duration;
-$duration = floor($seconds / 3600) . gmdate(":i:s", $seconds % 3600);
-$is_table = $browse->is_grid_view();
+$web_path     = AmpConfig::get('web_path');
+$seconds      = $browse->duration;
+$duration     = floor($seconds / 3600) . gmdate(":i:s", $seconds % 3600);
+$show_ratings = User::is_registered() && (AmpConfig::get('ratings') || AmpConfig::get('userflags'));
+$is_table     = $browse->is_grid_view();
 //mashup and grid view need different css
 $cel_cover = ($is_table) ? "cel_cover" : 'grid_cover';
-$cel_flag  = ($is_table) ? "cel_userflag" : 'grid_userflag';
 $cel_time  = ($is_table) ? "cel_time" : 'grid_time'; ?>
 <?php if ($browse->is_show_header()) {
     require Ui::find_template('list_header.inc.php');
@@ -52,17 +52,10 @@ $cel_time  = ($is_table) ? "cel_time" : 'grid_time'; ?>
                 <th class="cel_title essential persist"><?php echo T_('Title'); ?></th>
                 <th class="cel_add essential"></th>
                 <th class="<?php echo $cel_time; ?> optional"><?php echo T_('Time'); ?></th>
-                <?php if (User::is_registered()) { ?>
-                    <?php if (AmpConfig::get('ratings')) { ?>
-                        <th class="cel_rating optional"><?php echo T_('Rating'); ?></th>
+                <?php if ($show_ratings) { ?>
+                    <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
                     <?php
-} ?>
-                    <?php if (AmpConfig::get('userflags')) { ?>
-                <?php
-        } ?>
-                <th class="<?php echo $cel_flag; ?> optional"><?php echo T_('Fav.'); ?></th>
-            <?php
-    } ?>
+                } ?>
                 <th class="cel_action essential"><?php echo T_('Action'); ?></th>
                 <th class="cel_drag essential"></th>
             </tr>
@@ -91,21 +84,14 @@ $cel_time  = ($is_table) ? "cel_time" : 'grid_time'; ?>
                 <?php if (Art::is_enabled()) { ?>
                 <th class="<?php echo $cel_cover; ?>"><?php echo T_('Art') ?></th>
                 <?php
-    } ?>
+                } ?>
                 <th class="cel_title"><?php echo T_('Title'); ?></th>
                 <th class="cel_add"></th>
                 <th class="<?php echo $cel_time; ?>"><?php echo T_('Time'); ?></th>
-                <?php if (User::is_registered()) { ?>
-                    <?php if (AmpConfig::get('ratings')) { ?>
-                        <th class="cel_rating"><?php echo T_('Rating'); ?></th>
-                    <?php
-        } ?>
-                    <?php if (AmpConfig::get('userflags')) { ?>
-                        <th class="<?php echo $cel_flag; ?>"><?php echo T_('Fav.'); ?></th>
-                    <?php
-        } ?>
+                <?php if ($show_ratings) { ?>
+                    <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
                 <?php
-    } ?>
+                } ?>
                 <th class="cel_action"><?php echo T_('Action'); ?></th>
                 <th class="cel_drag"></th>
             </tr>

--- a/public/templates/show_playlist_row.inc.php
+++ b/public/templates/show_playlist_row.inc.php
@@ -24,7 +24,6 @@ use Ampache\Config\AmpConfig;
 use Ampache\Repository\Model\Playlist;
 use Ampache\Repository\Model\Rating;
 use Ampache\Repository\Model\Share;
-use Ampache\Repository\Model\User;
 use Ampache\Repository\Model\Userflag;
 use Ampache\Module\Authorization\Access;
 use Ampache\Module\Api\Ajax;
@@ -74,15 +73,23 @@ use Ampache\Module\Util\ZipHandlerInterface;
 <td class="cel_medias"><?php echo $libitem->get_media_count(); ?></td>
 <td class="cel_owner"><?php echo scrub_out($libitem->f_user); ?></td>
 <?php
-    if (User::is_registered()) {
-        if (AmpConfig::get('ratings')) { ?>
-    <td class="cel_rating" id="rating_<?php echo $libitem->id; ?>_playlist"><?php echo Rating::show($libitem->id, 'playlist'); ?></td>
+    if ($show_ratings) { ?>
+        <td class="cel_ratings">
+            <?php if (AmpConfig::get('ratings')) { ?>
+                <span class="cel_rating" id="rating_<?php echo $libitem->id; ?>_playlist">
+                    <?php echo Rating::show($libitem->id, 'playlist'); ?>
+                </span>
+            <?php
+            } ?>
+
+            <?php if (AmpConfig::get('userflags')) { ?>
+                <span class="cel_userflag" id="userflag_<?php echo $libitem->id; ?>_playlist">
+                    <?php echo Userflag::show($libitem->id, 'playlist'); ?>
+                </span>
+            <?php
+            } ?>
+        </td>
     <?php
-        }
-        if (AmpConfig::get('userflags')) { ?>
-    <td class="<?php echo $cel_flag; ?>" id="userflag_<?php echo $libitem->id; ?>_playlist"><?php echo Userflag::show($libitem->id, 'playlist'); ?></td>
-    <?php
-        }
     } ?>
 <td class="cel_action">
 <?php

--- a/public/templates/show_playlists.inc.php
+++ b/public/templates/show_playlists.inc.php
@@ -28,10 +28,10 @@ use Ampache\Module\Api\Ajax;
 use Ampache\Module\System\Core;
 use Ampache\Module\Util\Ui;
 
-$is_table = $browse->is_grid_view();
+$is_table     = $browse->is_grid_view();
+$show_ratings = User::is_registered() && (AmpConfig::get('ratings') || AmpConfig::get('userflags'));
 //mashup and grid view need different css
-$cel_cover = ($is_table) ? "cel_cover" : 'grid_cover';
-$cel_flag  = ($is_table) ? "cel_userflag" : 'grid_userflag'; ?>
+$cel_cover = ($is_table) ? "cel_cover" : 'grid_cover';?>
 <?php if ($browse->is_show_header()) {
     require Ui::find_template('list_header.inc.php');
 } ?>
@@ -41,25 +41,17 @@ $cel_flag  = ($is_table) ? "cel_userflag" : 'grid_userflag'; ?>
             <th class="cel_play essential"></th>
             <?php if (AmpConfig::get('playlist_art')) { ?>
             <th class="<?php echo $cel_cover; ?> optional"><?php echo T_('Art') ?></th>
-            <?php
-} ?>
+            <?php } ?>
             <th class="cel_playlist essential persist"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&type=playlist&sort=name', T_('Playlist Name'), 'playlist_sort_name'); ?></th>
             <th class="cel_add essential"></th>
             <th class="cel_last_update optional"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&type=playlist&sort=last_update', T_('Last Update'), 'playlist_sort_last_update'); ?></th>
             <th class="cel_type optional"><?php echo T_('Type'); ?></th>
             <th class="cel_medias optional"><?php /* HINT: Number of items in a playlist */ echo T_('# Items'); ?></th>
             <th class="cel_owner optional"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&type=playlist&sort=user', T_('Owner'), 'playlist_sort_owner'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) { ?>
-                    <th class="cel_rating optional"><?php echo T_('Rating'); ?></th>
-                <?php
-        } ?>
-                <?php if (AmpConfig::get('userflags')) { ?>
-                    <th class="<?php echo $cel_flag; ?> optional"><?php echo T_('Fav.'); ?></th>
-                <?php
-        } ?>
+            <?php if ($show_ratings) { ?>
+            <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
             <?php
-    } ?>
+            } ?>
             <th class="cel_action essential"><?php echo T_('Actions'); ?></th>
         </tr>
     </thead>
@@ -90,24 +82,17 @@ $cel_flag  = ($is_table) ? "cel_userflag" : 'grid_userflag'; ?>
             <?php if (AmpConfig::get('playlist_art')) { ?>
             <th class="<?php echo $cel_cover; ?>"><?php echo T_('Art') ?></th>
             <?php
-        } ?>
+            } ?>
             <th class="cel_playlist essential persist"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&type=playlist&sort=name', T_('Playlist Name'), 'playlist_sort_name'); ?></th>
             <th class="cel_add essential"></th>
             <th class="cel_last_update"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&type=playlist&sort=last_update', T_('Last Update'), 'playlist_sort_last_update_bottom'); ?></th>
             <th class="cel_type optional"><?php echo T_('Type'); ?></th>
             <th class="cel_medias optional"><?php /* HINT: Number of items in a playlist */ echo T_('# Items'); ?></th>
             <th class="cel_owner optional"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&type=playlist&sort=user', T_('Owner'), 'playlist_sort_owner_bottom'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) { ?>
-                    <th class="cel_rating"><?php echo T_('Rating'); ?></th>
-                <?php
-            } ?>
-                <?php if (AmpConfig::get('userflags')) { ?>
-                    <th class="<?php echo $cel_flag; ?>"><?php echo T_('Fav.'); ?></th>
-                <?php
-            } ?>
+            <?php if ($show_ratings) { ?>
+            <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
             <?php
-        } ?>
+            } ?>
             <th class="cel_action essential"><?php echo T_('Actions'); ?></th>
         </tr>
     </tfoot>

--- a/public/templates/show_podcast.inc.php
+++ b/public/templates/show_podcast.inc.php
@@ -47,21 +47,18 @@ Ui::show_box_top($podcast->f_title, 'info-box'); ?>
 </div>
 <?php } ?>
 <?php if (User::is_registered()) { ?>
-    <?php
-    if (AmpConfig::get('ratings')) { ?>
-    <div id="rating_<?php echo (int) ($podcast->id); ?>_podcast" style="display:inline;">
+    <?php if (AmpConfig::get('ratings')) { ?>
+    <span id="rating_<?php echo (int) ($podcast->id); ?>_podcast">
         <?php echo Rating::show($podcast->id, 'podcast'); ?>
-    </div>
-    <?php
-    } ?>
+    </span>
+    <?php } ?>
+
     <?php if (AmpConfig::get('userflags')) { ?>
-    <div style="display:table-cell;" id="userflag_<?php echo $podcast->id; ?>_podcast">
-            <?php echo Userflag::show($podcast->id, 'podcast'); ?>
-    </div>
-    <?php
-    } ?>
-<?php
-    } ?>
+    <span id="userflag_<?php echo $podcast->id; ?>_podcast">
+        <?php echo Userflag::show($podcast->id, 'podcast'); ?>
+    </span>
+    <?php } ?>
+<?php } ?>
 <div id="information_actions">
     <h3><?php echo T_('Actions'); ?>:</h3>
     <ul>

--- a/public/templates/show_podcast_episode.inc.php
+++ b/public/templates/show_podcast_episode.inc.php
@@ -41,24 +41,21 @@ use Ampache\Module\Util\Ui;
     <?php if (AmpConfig::get('ratings')) { ?>
         <dt><?php echo T_('Rating'); ?></dt>
         <dd>
-            <div id="rating_<?php echo $episode->id; ?>_podcast_episode"><?php echo Rating::show($episode->id,
-                    'podcast_episode'); ?>
+            <div id="rating_<?php echo $episode->id; ?>_podcast_episode">
+                <?php echo Rating::show($episode->id, 'podcast_episode'); ?>
             </div>
         </dd>
-    <?php
-    } ?>
+    <?php } ?>
 
     <?php if (AmpConfig::get('userflags')) { ?>
         <dt><?php echo T_('Fav.'); ?></dt>
         <dd>
-            <div id="userflag_<?php echo $episode->id; ?>_podcast_episode"><?php echo Userflag::show($episode->id,
-                    'podcast_episode'); ?>
+            <div id="userflag_<?php echo $episode->id; ?>_podcast_episode">
+                <?php echo Userflag::show($episode->id, 'podcast_episode'); ?>
             </div>
         </dd>
-    <?php
-    } ?>
-<?php
-} ?>
+    <?php } ?>
+<?php } ?>
 <dt><?php echo T_('Action'); ?></dt>
     <dd>
         <?php if (!empty($episode->file)) { ?>

--- a/public/templates/show_podcast_episode_row.inc.php
+++ b/public/templates/show_podcast_episode_row.inc.php
@@ -71,19 +71,23 @@ use Ampache\Module\Util\Ui;
 <td class="cel_pubdate"><?php echo $libitem->f_pubdate; ?></td>
 <td class="cel_state"><?php echo $libitem->f_state; ?></td>
 <?php
-    if (User::is_registered()) {
-        if (AmpConfig::get('ratings')) { ?>
-    <td class="cel_rating" id="rating_<?php echo $libitem->id; ?>_podcast_episode">
-        <?php echo Rating::show($libitem->id, 'podcast_episode'); ?>
-    </td>
+    if ($show_ratings) { ?>
+        <td class="cel_ratings">
+            <?php if (AmpConfig::get('ratings')) { ?>
+                <span class="cel_rating" id="rating_<?php echo $libitem->id; ?>_podcast_episode">
+                    <?php echo Rating::show($libitem->id, 'podcast_episode'); ?>
+                </span>
+            <?php
+            } ?>
+
+            <?php if (AmpConfig::get('userflags')) { ?>
+                <span class="cel_userflag" id="userflag_<?php echo $libitem->id; ?>_podcast_episode">
+                    <?php echo Userflag::show($libitem->id, 'podcast_episode'); ?>
+                </span>
+            <?php
+            } ?>
+        </td>
     <?php
-        }
-        if (AmpConfig::get('userflags')) { ?>
-    <td class="<?php echo $cel_flag; ?>" id="userflag_<?php echo $libitem->id; ?>_podcast_episode">
-        <?php echo Userflag::show($libitem->id, 'podcast_episode'); ?>
-    </td>
-    <?php
-        }
     } ?>
 <td class="cel_action">
     <?php if (Access::check_function('download') && !empty($libitem->file)) { ?>

--- a/public/templates/show_podcast_episodes.inc.php
+++ b/public/templates/show_podcast_episodes.inc.php
@@ -29,11 +29,11 @@ use Ampache\Repository\Model\Userflag;
 use Ampache\Module\Api\Ajax;
 use Ampache\Module\Util\Ui;
 
-$thcount  = 7;
-$is_table = $browse->is_grid_view();
+$thcount      = 7;
+$show_ratings = User::is_registered() && (AmpConfig::get('ratings') || AmpConfig::get('userflags'));
+$is_table     = $browse->is_grid_view();
 //mashup and grid view need different css
 $cel_cover   = ($is_table) ? "cel_cover" : 'grid_cover';
-$cel_flag    = ($is_table) ? "cel_userflag" : 'grid_userflag';
 $cel_time    = ($is_table) ? "cel_time" : 'grid_time';
 $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
 <?php if ($browse->is_show_header()) {
@@ -48,22 +48,13 @@ $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
             <th class="cel_podcast optional"><?php echo T_('Podcast'); ?></th>
             <th class="<?php echo $cel_time; ?> optional"><?php echo T_('Time'); ?></th>
             <?php if (AmpConfig::get('show_played_times')) { ?>
-                <th class="<?php echo $cel_counter; ?> optional"><?php echo T_('# Played'); ?></th>
-                <?php
-            } ?>
+            <th class="<?php echo $cel_counter; ?> optional"><?php echo T_('# Played'); ?></th>
+            <?php } ?>
             <th class="cel_pubdate optional"><?php echo T_('Publication Date'); ?></th>
             <th class="cel_state optional"><?php echo T_('State'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) {
-                ++$thcount; ?>
-                    <th class="cel_rating optional"><?php echo T_('Rating'); ?></th>
-                <?php
-            } ?>
-                <?php if (AmpConfig::get('userflags')) {
-                ++$thcount; ?>
-                    <th class="<?php echo $cel_flag; ?> optional"><?php echo T_('Fav.'); ?></th>
-                <?php
-            } ?>
+            <?php if ($show_ratings) {
+    ++$thcount; ?>
+            <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
             <?php
 } ?>
             <th class="cel_action essential"><?php echo T_('Actions'); ?></th>
@@ -105,27 +96,20 @@ $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
             <th class="cel_podcast"><?php echo T_('Podcast'); ?></th>
             <th class="<?php echo $cel_time; ?>"><?php echo T_('Time'); ?></th>
             <?php if (AmpConfig::get('show_played_times')) { ?>
-                <th class="<?php echo $cel_counter; ?> optional"><?php echo T_('# Played'); ?></th>
-                <?php
+            <th class="<?php echo $cel_counter; ?> optional"><?php echo T_('# Played'); ?></th>
+            <?php
             } ?>
             <th class="cel_pubdate"><?php echo T_('Publication Date'); ?></th>
             <th class="cel_state"><?php echo T_('State'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) { ?>
-                    <th class="cel_rating"><?php echo T_('Rating'); ?></th>
-                <?php
-            } ?>
-                <?php if (AmpConfig::get('userflags')) { ?>
-                    <th class="<?php echo $cel_flag; ?>"><?php echo T_('Fav.'); ?></th>
-                <?php
-            } ?>
+            <?php if ($show_ratings) { ?>
+            <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
             <?php
-        } ?>
+            } ?>
             <th class="cel_action"><?php echo T_('Actions'); ?></th>
         </tr>
     <tfoot>
 </table>
 <?php show_table_render(); ?>
 <?php if ($browse->is_show_header()) {
-            require Ui::find_template('list_header.inc.php');
-        } ?>
+                require Ui::find_template('list_header.inc.php');
+            } ?>

--- a/public/templates/show_podcast_row.inc.php
+++ b/public/templates/show_podcast_row.inc.php
@@ -24,7 +24,6 @@ use Ampache\Config\AmpConfig;
 use Ampache\Repository\Model\Art;
 use Ampache\Repository\Model\Podcast;
 use Ampache\Repository\Model\Rating;
-use Ampache\Repository\Model\User;
 use Ampache\Repository\Model\Userflag;
 use Ampache\Module\Authorization\Access;
 use Ampache\Module\Api\Ajax;
@@ -57,19 +56,19 @@ use Ampache\Module\Util\Ui;
 <td class="cel_title"><?php echo $libitem->f_link; ?></td>
 <td class="cel_episodes"><?php echo $libitem->episodes; ?></td>
 <?php
-    if (User::is_registered()) {
-        if (AmpConfig::get('ratings')) { ?>
-    <td class="cel_rating" id="rating_<?php echo $libitem->id; ?>_podcast">
-        <?php echo Rating::show($libitem->id, 'podcast'); ?>
-    </td>
+    if ($show_ratings) { ?>
+        <td class="cel_ratings">
+            <?php if (AmpConfig::get('ratings')) { ?>
+                <span class="cel_rating" id="rating_<?php echo $libitem->id; ?>_podcast"><?php echo Rating::show($libitem->id, 'podcast'); ?></span>
+            <?php
+            } ?>
+
+            <?php if (AmpConfig::get('userflags')) { ?>
+                <span class="cel_userflag" id="userflag_<?php echo $libitem->id; ?>_podcast"><?php echo Userflag::show($libitem->id, 'podcast'); ?></span>
+            <?php
+            } ?>
+        </td>
     <?php
-        }
-        if (AmpConfig::get('userflags')) { ?>
-    <td class="<?php echo $cel_flag; ?>" id="userflag_<?php echo $libitem->id; ?>_podcast">
-        <?php echo Userflag::show($libitem->id, 'podcast'); ?>
-    </td>
-    <?php
-        }
     } ?>
 <td class="cel_action">
 <?php

--- a/public/templates/show_podcasts.inc.php
+++ b/public/templates/show_podcasts.inc.php
@@ -30,11 +30,11 @@ use Ampache\Module\Authorization\Access;
 use Ampache\Module\Api\Ajax;
 use Ampache\Module\Util\Ui;
 
-$thcount  = 5;
-$is_table = $browse->is_grid_view();
+$thcount      = 5;
+$show_ratings = User::is_registered() && (AmpConfig::get('ratings') || AmpConfig::get('userflags'));
+$is_table     = $browse->is_grid_view();
 //mashup and grid view need different css
-$cel_cover = ($is_table) ? "cel_cover" : 'grid_cover';
-$cel_flag  = ($is_table) ? "cel_userflag" : 'grid_userflag'; ?>
+$cel_cover = ($is_table) ? "cel_cover" : 'grid_cover';?>
 <div id="information_actions">
     <ul>
         <?php if (Access::check('interface', 75)) { ?>
@@ -62,17 +62,9 @@ $cel_flag  = ($is_table) ? "cel_userflag" : 'grid_userflag'; ?>
 } ?>
             <th class="cel_title essential persist"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&sort=title', T_('Title'), 'podcast_sort_title'); ?></th>
             <th class="cel_episodes optional"><?php echo T_('Episodes'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) {
+            <?php if ($show_ratings) {
         ++$thcount; ?>
-                    <th class="cel_rating optional"><?php echo T_('Rating'); ?></th>
-                <?php
-    } ?>
-                <?php if (AmpConfig::get('userflags')) {
-        ++$thcount; ?>
-                    <th class="<?php echo $cel_flag; ?> optional"><?php echo T_('Fav.'); ?></th>
-                <?php
-    } ?>
+            <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
             <?php
     } ?>
             <th class="cel_action essential"><?php echo T_('Actions'); ?></th>
@@ -105,28 +97,21 @@ $cel_flag  = ($is_table) ? "cel_userflag" : 'grid_userflag'; ?>
     <tfoot>
         <tr class="th-bottom">
             <th class="cel_play"></th>
-        <?php if (Art::is_enabled()) { ?>
+            <?php if (Art::is_enabled()) { ?>
             <th class="<?php echo $cel_cover; ?>"><?php echo T_('Art'); ?></th>
-        <?php
-        } ?>
+            <?php
+            } ?>
             <th class="cel_title"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&sort=title', T_('Title'), 'podcast_sort_title_bottom'); ?></th>
             <th class="cel_episodes"><?php echo T_('Episodes'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) { ?>
-                    <th class="cel_rating"><?php echo T_('Rating'); ?></th>
-                <?php
-            } ?>
-                <?php if (AmpConfig::get('userflags')) { ?>
-                    <th class="<?php echo $cel_flag; ?>"><?php echo T_('Fav.'); ?></th>
-                <?php
-            } ?>
+            <?php if ($show_ratings) { ?>
+            <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
             <?php
-        } ?>
+            } ?>
             <th class="cel_action"><?php echo T_('Actions'); ?></th>
         </tr>
     <tfoot>
 </table>
 <?php show_table_render(); ?>
 <?php if ($browse->is_show_header()) {
-            require Ui::find_template('list_header.inc.php');
-        } ?>
+                require Ui::find_template('list_header.inc.php');
+            } ?>

--- a/public/templates/show_random_albums.inc.php
+++ b/public/templates/show_random_albums.inc.php
@@ -24,6 +24,7 @@ use Ampache\Config\AmpConfig;
 use Ampache\Repository\Model\Album;
 use Ampache\Repository\Model\Art;
 use Ampache\Repository\Model\Rating;
+use Ampache\Repository\Model\Userflag;
 use Ampache\Module\Authorization\Access;
 use Ampache\Module\Api\Ajax;
 use Ampache\Module\Playback\Stream_Playlist;
@@ -74,11 +75,15 @@ if ($albums) {
         <?php
             } ?>
         <?php
-        if (AmpConfig::get('ratings') && Access::check('interface', 25)) {
-            echo "<div id=\"rating_" . $album->id . "_album\">";
-            echo Rating::show($album->id, 'album');
-            echo "</div>";
-        } ?>
+        if (Access::check('interface', 25)) { ?>
+            <?php if (AmpConfig::get('ratings')) { ?>
+                <span class="cel_rating" id="rating_<?php echo $album->id; ?>_album"><?php echo Rating::show($album->id, 'album'); ?></span>
+            <?php } ?>
+
+            <?php if (AmpConfig::get('userflags')) { ?>
+                <span class="cel_rating" id="userflag_<?php echo $album->id; ?>_album"><?php echo Userflag::show($album->id, 'album'); ?></span>
+            <?php } ?>
+        <?php } ?>
     </div>
     <?php
     } ?>

--- a/public/templates/show_random_videos.inc.php
+++ b/public/templates/show_random_videos.inc.php
@@ -23,6 +23,7 @@
 use Ampache\Config\AmpConfig;
 use Ampache\Repository\Model\Art;
 use Ampache\Repository\Model\Rating;
+use Ampache\Repository\Model\Userflag;
 use Ampache\Repository\Model\Video;
 use Ampache\Module\Authorization\Access;
 use Ampache\Module\Api\Ajax;
@@ -68,11 +69,15 @@ if ($videos) {
         } ?>
         </div>
         <?php
-        if (AmpConfig::get('ratings') && Access::check('interface', 25)) {
-            echo "<div id=\"rating_" . $video->id . "_video\">";
-            echo Rating::show($video->id, 'video');
-            echo "</div>";
-        } ?>
+        if (Access::check('interface', 25)) { ?>
+            <?php if (AmpConfig::get('ratings')) { ?>
+                <span class="cel_rating" id="rating_<?php echo $video->id; ?>_video"><?php echo Rating::show($video->id, 'video'); ?></span>
+            <?php } ?>
+
+            <?php if (AmpConfig::get('userflags')) { ?>
+                <span class="cel_rating" id="userflag_<?php echo $video->id; ?>_video"><?php echo Userflag::show($video->id, 'video'); ?></span>
+            <?php } ?>
+        <?php } ?>
     </div>
     <?php
     } ?>

--- a/public/templates/show_recommended_artists.inc.php
+++ b/public/templates/show_recommended_artists.inc.php
@@ -24,10 +24,12 @@ use Ampache\Config\AmpConfig;
 use Ampache\Repository\Model\Art;
 use Ampache\Repository\Model\Artist;
 use Ampache\Repository\Model\Rating;
+use Ampache\Repository\Model\User;
 use Ampache\Repository\Model\Userflag;
 use Ampache\Module\Util\Ui;
 
-$thcount  = 8; ?>
+$show_ratings = User::is_registered() && (AmpConfig::get('ratings') || AmpConfig::get('userflags'));
+$thcount      = 8; ?>
 <?php UI::show_box_top(T_('Similar Artists'), 'info-box'); ?>
 <?php Ui::show_box_top(T_('Similar Artists'), 'info-box'); ?>
 <table class="tabledata striped-rows">
@@ -45,15 +47,10 @@ $thcount  = 8; ?>
             <th class="cel_albums"><?php echo T_('Albums'); ?></th>
             <th class="cel_time"><?php echo T_('Time'); ?></th>
             <th class="cel_tags"><?php echo T_('Genres'); ?></th>
-        <?php if (AmpConfig::get('ratings')) {
+            <?php if ($show_ratings) {
         ++$thcount; ?>
-            <th class="cel_rating"><?php echo T_('Rating'); ?></th>
-        <?php
-    } ?>
-        <?php if (AmpConfig::get('userflags')) {
-        ++$thcount; ?>
-            <th class="cel_userflag"><?php echo T_('Fav.'); ?></th>
-        <?php
+                <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
+                <?php
     } ?>
             <th class="cel_action"> <?php echo T_('Action'); ?> </th>
         </tr>
@@ -98,23 +95,19 @@ $thcount  = 8; ?>
         <tr class="th-bottom">
             <th class="cel_play"></th>
             <?php if (Art::is_enabled()) { ?>
-                <th class="cel_cover"><?php echo T_('Art'); ?></th>
+            <th class="cel_cover"><?php echo T_('Art'); ?></th>
             <?php
-        } ?>
+            } ?>
             <th class="cel_artist"><?php echo T_('Artist'); ?></th>
             <th class="cel_add"></th>
             <th class="cel_songs"> <?php echo T_('Songs');  ?> </th>
             <th class="cel_albums"> <?php echo T_('Albums'); ?> </th>
             <th class="cel_time"> <?php echo T_('Time'); ?> </th>
             <th class="cel_tags"><?php echo T_('Genres'); ?></th>
-        <?php if (AmpConfig::get('ratings')) { ?>
-            <th class="cel_rating"><?php echo T_('Rating'); ?></th>
-        <?php
-        } ?>
-        <?php if (AmpConfig::get('userflags')) { ?>
-            <th class="cel_userflag"><?php echo T_('Fav.'); ?></th>
-        <?php
-        } ?>
+            <?php if ($show_ratings) { ?>
+            <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
+            <?php
+            } ?>
             <th class="cel_action"> <?php echo T_('Action'); ?> </th>
         </tr>
     </tfoot>

--- a/public/templates/show_songs.inc.php
+++ b/public/templates/show_songs.inc.php
@@ -32,15 +32,15 @@ use Ampache\Module\Authorization\Access;
 use Ampache\Module\Authorization\GatekeeperFactoryInterface;
 use Ampache\Module\Util\Ui;
 
-$web_path = AmpConfig::get('web_path');
-$thcount  = 8;
-$is_table = $browse->is_grid_view();
+$web_path     = AmpConfig::get('web_path');
+$show_ratings = User::is_registered() && (AmpConfig::get('ratings') || AmpConfig::get('userflags'));
+$thcount      = 8;
+$is_table     = $browse->is_grid_view();
 //mashup and grid view need different css
 $cel_song    = ($is_table) ? "cel_song" : 'grid_song';
 $cel_album   = ($is_table) ? "cel_album" : 'grid_album';
 $cel_artist  = ($is_table) ? "cel_artist" : 'grid_artist';
 $cel_tags    = ($is_table) ? "cel_tags" : 'grid_tags';
-$cel_flag    = ($is_table) ? "cel_userflag" : 'grid_userflag';
 $cel_time    = ($is_table) ? "cel_time" : 'grid_time';
 $cel_license = ($is_table) ? "cel_license" : 'grid_license';
 $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
@@ -69,22 +69,19 @@ $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
             <th class="<?php echo $cel_counter; ?> optional"><?php echo T_('# Skipped'); ?></th>
             <?php
     } ?>
-            <?php if (User::is_registered()) { ?>
+            <?php if ($show_ratings) {
+        ++$thcount; ?>
+            <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
                 <?php if (AmpConfig::get('ratings')) {
-        ++$thcount;
-        Rating::build_cache('song', $object_ids); ?>
-                    <th class="cel_rating optional"><?php echo T_('Rating'); ?></th>
-                <?php
-    } ?>
+            Rating::build_cache('song', $object_ids);
+        } ?>
                 <?php if (AmpConfig::get('userflags')) {
-        ++$thcount;
-        Userflag::build_cache('song', $object_ids); ?>
-                <th class="<?php echo $cel_flag; ?> optional"><?php echo T_('Fav.'); ?></th>
-            <?php
-    } ?>
+            Userflag::build_cache('song', $object_ids);
+        } ?>
                 <?php
     } ?>
-                <th class="cel_action essential"><?php echo T_('Action'); ?></th>
+            <th class="cel_action essential"><?php echo T_('Action'); ?></th>
+
             <?php if (isset($argument) && $argument) {
         ++$thcount; ?>
                 <th class="cel_drag essential"></th>
@@ -108,6 +105,7 @@ $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
                     $content = $talFactory->createTalView()
                         ->setContext('BROWSE_ARGUMENT', isset($argument) ? $argument : '')
                         ->setContext('USER_IS_REGISTERED', User::is_registered())
+                        ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings') || AmpConfig::get('userflags')))
                         ->setContext('SONG', $guiFactory->createSongViewAdapter($gatekeeper, $libitem))
                         ->setContext('CONFIG', $guiFactory->createConfigViewAdapter())
                         ->setContext('IS_TABLE_VIEW', $is_table)
@@ -142,24 +140,19 @@ $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
             } ?>
             <?php if (AmpConfig::get('show_played_times')) { ?>
             <th class="<?php echo $cel_counter; ?> optional"><?php echo T_('# Played'); ?></th>
-            <?php } ?>
-            <?php if (AmpConfig::get('show_skipped_times')) { ?>
-            <th class="<?php echo $cel_counter; ?> optional"><?php echo T_('# Skipped'); ?></th>
-            <?php } ?>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) { ?>
-                    <th class="cel_rating"><?php echo T_('Rating'); ?></th>
-                <?php
-                } ?>
-                <?php if (AmpConfig::get('userflags')) { ?>
-                    <th class="<?php echo $cel_flag; ?>"></th>
-                <?php
-                } ?>
             <?php
             } ?>
-                <th class="cel_action"></th>
+            <?php if (AmpConfig::get('show_skipped_times')) { ?>
+            <th class="<?php echo $cel_counter; ?> optional"><?php echo T_('# Skipped'); ?></th>
+            <?php
+            } ?>
+            <?php if ($show_ratings) { ?>
+            <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
+            <?php
+            } ?>
+            <th class="cel_action"></th>
             <?php if (isset($argument) && $argument) { ?>
-                <th class="cel_drag"></th>
+            <th class="cel_drag"></th>
             <?php
             } ?>
         </tr>

--- a/public/templates/show_tvshow.inc.php
+++ b/public/templates/show_tvshow.inc.php
@@ -51,15 +51,15 @@ Ui::show_box_top($tvshow->f_name, 'info-box'); ?>
 <?php if (User::is_registered()) { ?>
     <?php
     if (AmpConfig::get('ratings')) { ?>
-    <div id="rating_<?php echo (int) ($tvshow->id); ?>_tvshow" style="display:inline;">
+    <span id="rating_<?php echo (int) ($tvshow->id); ?>_tvshow">
         <?php echo Rating::show($tvshow->id, 'tvshow'); ?>
-    </div>
+    </span>
     <?php
     } ?>
     <?php if (AmpConfig::get('userflags')) { ?>
-    <div style="display:table-cell;" id="userflag_<?php echo $tvshow->id; ?>_tvshow">
-            <?php echo Userflag::show($tvshow->id, 'tvshow'); ?>
-    </div>
+    <span id="userflag_<?php echo $tvshow->id; ?>_tvshow">
+        <?php echo Userflag::show($tvshow->id, 'tvshow'); ?>
+    </span>
     <?php
     } ?>
 <?php

--- a/public/templates/show_tvshow_row.inc.php
+++ b/public/templates/show_tvshow_row.inc.php
@@ -25,7 +25,6 @@ use Ampache\Repository\Model\Art;
 use Ampache\Repository\Model\Catalog;
 use Ampache\Repository\Model\Rating;
 use Ampache\Repository\Model\TvShow;
-use Ampache\Repository\Model\User;
 use Ampache\Repository\Model\Userflag;
 use Ampache\Module\Authorization\Access;
 use Ampache\Module\Api\Ajax;
@@ -62,15 +61,19 @@ use Ampache\Module\Util\Ui;
 <td class="cel_seasons"><?php echo $libitem->seasons; ?></td>
 <td class="<?php echo $cel_tags; ?>"><?php echo $libitem->f_tags; ?></td>
 <?php
-    if (User::is_registered()) {
-        if (AmpConfig::get('ratings')) { ?>
-    <td class="cel_rating" id="rating_<?php echo $libitem->id; ?>_tvshow"><?php echo Rating::show($libitem->id, 'tvshow'); ?></td>
+    if ($show_ratings) { ?>
+        <td class="cel_ratings">
+            <?php if (AmpConfig::get('ratings')) { ?>
+                <span class="cel_rating" id="rating_<?php echo $libitem->id; ?>_tvshow"><?php echo Rating::show($libitem->id, 'tvshow'); ?></span>
+            <?php
+            } ?>
+
+            <?php if (AmpConfig::get('userflags')) { ?>
+                <span class="cel_userflag" id="userflag_<?php echo $libitem->id; ?>_tvshow"><?php echo Userflag::show($libitem->id, 'tvshow'); ?></span>
+            <?php
+            } ?>
+        </td>
     <?php
-        }
-        if (AmpConfig::get('userflags')) { ?>
-        <td class="<?php echo $cel_flag; ?>" id="userflag_<?php echo $libitem->id; ?>_tvshow"><?php echo Userflag::show($libitem->id, 'tvshow'); ?></td>
-    <?php
-        }
     } ?>
 <td class="cel_action">
 <?php

--- a/public/templates/show_tvshow_season.inc.php
+++ b/public/templates/show_tvshow_season.inc.php
@@ -43,21 +43,21 @@ Ui::show_box_top($season->f_name . ' - ' . $season->f_tvshow_link, 'info-box'); 
     Art::display('tvshow_season', $season->id, $season->f_name, 6); ?>
 </div>
 <?php if (User::is_registered()) { ?>
-    <?php
-    if (AmpConfig::get('ratings')) { ?>
-    <div id="rating_<?php echo (int) ($season->id); ?>_tvshow_season" style="display:inline;">
+    <?php if (AmpConfig::get('ratings')) { ?>
+    <span id="rating_<?php echo (int) ($season->id); ?>_tvshow_season">
         <?php echo Rating::show($season->id, 'tvshow_season'); ?>
-    </div>
+    </span>
     <?php
     } ?>
+
     <?php if (AmpConfig::get('userflags')) { ?>
-    <div style="display:table-cell;" id="userflag_<?php echo $season->id; ?>_tvshow_season">
-            <?php echo Userflag::show($season->id, 'tvshow_season'); ?>
-    </div>
+    <span id="userflag_<?php echo $season->id; ?>_tvshow_season">
+        <?php echo Userflag::show($season->id, 'tvshow_season'); ?>
+    </span>
     <?php
     } ?>
 <?php
-    } ?>
+} ?>
 <div id="information_actions">
     <h3><?php echo T_('Actions'); ?>:</h3>
     <ul>

--- a/public/templates/show_tvshow_season_row.inc.php
+++ b/public/templates/show_tvshow_season_row.inc.php
@@ -25,7 +25,6 @@ use Ampache\Repository\Model\Art;
 use Ampache\Repository\Model\Catalog;
 use Ampache\Repository\Model\Rating;
 use Ampache\Repository\Model\TvShow;
-use Ampache\Repository\Model\User;
 use Ampache\Repository\Model\Userflag;
 use Ampache\Module\Authorization\Access;
 use Ampache\Module\Api\Ajax;
@@ -60,19 +59,23 @@ use Ampache\Module\Util\Ui;
 <td class="cel_tvshow"><?php echo $libitem->f_tvshow_link; ?></td>
 <td class="cel_episodes"><?php echo $libitem->episodes; ?></td>
 <?php
-    if (User::is_registered()) {
-        if (AmpConfig::get('ratings')) { ?>
-    <td class="cel_rating" id="rating_<?php echo $libitem->id; ?>_tvshow_season">
-        <?php echo Rating::show($libitem->id, 'tvshow_season'); ?>
-    </td>
+    if ($show_ratings) { ?>
+        <td class="cel_ratings">
+            <?php if (AmpConfig::get('ratings')) { ?>
+                <span class="cel_rating" id="rating_<?php echo $libitem->id; ?>_tvshow_season">
+                    <?php echo Rating::show($libitem->id, 'tvshow_season'); ?>
+                </span>
+            <?php
+            } ?>
+
+            <?php if (AmpConfig::get('userflags')) { ?>
+                <span class="cel_userflag" id="userflag_<?php echo $libitem->id; ?>_tvshow_season">
+                    <?php echo Userflag::show($libitem->id, 'tvshow_season'); ?>
+                </span>
+            <?php
+            } ?>
+        </td>
     <?php
-        }
-        if (AmpConfig::get('userflags')) { ?>
-    <td class="<?php echo $cel_flag; ?>" id="userflag_<?php echo $libitem->id; ?>_tvshow_season">
-        <?php echo Userflag::show($libitem->id, 'tvshow_season'); ?>
-    </td>
-    <?php
-        }
     } ?>
 <td class="cel_action">
 <?php

--- a/public/templates/show_tvshow_seasons.inc.php
+++ b/public/templates/show_tvshow_seasons.inc.php
@@ -33,8 +33,7 @@ $web_path = AmpConfig::get('web_path');
 $thcount  = 6;
 $is_table = $browse->is_grid_view();
 //mashup and grid view need different css
-$cel_cover = ($is_table) ? "cel_cover" : 'grid_cover';
-$cel_flag  = ($is_table) ? "cel_userflag" : 'grid_userflag'; ?>
+$cel_cover = ($is_table) ? "cel_cover" : 'grid_cover';?>
 <?php if ($browse->is_show_header()) {
     require Ui::find_template('list_header.inc.php');
 } ?>
@@ -50,17 +49,9 @@ $cel_flag  = ($is_table) ? "cel_userflag" : 'grid_userflag'; ?>
             <th class="cel_season essential persist"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&sort=season', T_('Season'), 'season_sort_season'); ?></th>
             <th class="cel_tvshow essential"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&sort=tvshow', T_('TV Show'), 'season_sort_tvshow'); ?></th>
             <th class="cel_episodes optional"><?php echo T_('Episodes'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) {
+            <?php if ($show_ratings) {
         ++$thcount; ?>
-                    <th class="cel_rating optional"><?php echo T_('Rating'); ?></th>
-                <?php
-    } ?>
-                <?php if (AmpConfig::get('userflags')) {
-        ++$thcount; ?>
-                    <th class="<?php echo $cel_flag; ?> optional"><?php echo T_('Fav.'); ?></th>
-                <?php
-    } ?>
+            <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
             <?php
     } ?>
             <th class="cel_action essential"><?php echo T_('Actions'); ?></th>
@@ -100,22 +91,15 @@ $cel_flag  = ($is_table) ? "cel_userflag" : 'grid_userflag'; ?>
             <th class="cel_season"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&sort=season', T_('Season'), 'season_sort_name_bottom'); ?></th>
             <th class="cel_tvshow"><?php echo Ajax::text('?page=browse&action=set_sort&browse_id=' . $browse->id . '&sort=tvshow', T_('TV Show'), 'season_sort_artist_bottom'); ?></th>
             <th class="cel_episodes"><?php echo T_('Episodes'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) { ?>
-                    <th class="cel_rating"><?php echo T_('Rating'); ?></th>
+            <?php if ($show_ratings) { ?>
+                <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
                 <?php
             } ?>
-                <?php if (AmpConfig::get('userflags')) { ?>
-                    <th class="<?php echo $cel_flag; ?>"><?php echo T_('Fav.'); ?></th>
-                <?php
-            } ?>
-            <?php
-        } ?>
             <th class="cel_action"><?php echo T_('Actions'); ?></th>
         </tr>
     <tfoot>
 </table>
 <?php show_table_render(); ?>
 <?php if ($browse->is_show_header()) {
-            require Ui::find_template('list_header.inc.php');
-        } ?>
+                require Ui::find_template('list_header.inc.php');
+            } ?>

--- a/public/templates/show_tvshows.inc.php
+++ b/public/templates/show_tvshows.inc.php
@@ -36,8 +36,7 @@ $thcount  = 8;
 $is_table = $browse->is_grid_view();
 //mashup and grid view need different css
 $cel_cover = ($is_table) ? "cel_cover" : 'grid_cover';
-$cel_tags  = ($is_table) ? "cel_tags" : 'grid_tags';
-$cel_flag  = ($is_table) ? "cel_userflag" : 'grid_userflag'; ?>
+$cel_tags  = ($is_table) ? "cel_tags" : 'grid_tags';?>
 <?php if ($browse->is_show_header()) {
     require Ui::find_template('list_header.inc.php');
 } ?>
@@ -54,19 +53,11 @@ $cel_flag  = ($is_table) ? "cel_userflag" : 'grid_userflag'; ?>
             <th class="cel_episodes optional"><?php echo T_('Episodes');  ?></th>
             <th class="cel_seasons optional"><?php echo T_('Seasons'); ?></th>
             <th class="<?php echo $cel_tags; ?> optional"><?php echo T_('Genres'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) {
-        ++$thcount; ?>
-                    <th class="cel_rating optional"><?php echo T_('Rating'); ?></th>
+            <?php if ($show_ratings) {
+                ++$thcount; ?>
+                <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
                 <?php
-    } ?>
-                <?php if (AmpConfig::get('userflags')) {
-        ++$thcount; ?>
-                    <th class="<?php echo $cel_flag; ?> optional"><?php echo T_('Fav.'); ?></th>
-                <?php
-    } ?>
-            <?php
-    } ?>
+            } ?>
             <th class="cel_action essential"><?php echo T_('Action'); ?></th>
         </tr>
     </thead>
@@ -107,17 +98,10 @@ $cel_flag  = ($is_table) ? "cel_userflag" : 'grid_userflag'; ?>
             <th class="cel_episodes optional"><?php echo T_('Episodes');  ?></th>
             <th class="cel_seasons optional"><?php echo T_('Seasons'); ?></th>
             <th class="<?php echo $cel_tags; ?> optional"><?php echo T_('Genres'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) { ?>
-                    <th class="cel_rating optional"><?php echo T_('Rating'); ?></th>
+            <?php if ($show_ratings) { ?>
+                <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
                 <?php
             } ?>
-                <?php if (AmpConfig::get('userflags')) { ?>
-                    <th class="<?php echo $cel_flag; ?> optional"><?php echo T_('Fav.'); ?></th>
-                <?php
-            } ?>
-            <?php
-        } ?>
             <th class="cel_action essential"> <?php echo T_('Action'); ?> </th>
         </tr>
     </tfoot>

--- a/public/templates/show_video.inc.php
+++ b/public/templates/show_video.inc.php
@@ -71,7 +71,8 @@ $subtitles = $video->get_subtitles();
     <?php if (AmpConfig::get('ratings')) { ?>
         <dt><?php echo T_('Rating'); ?></dt>
         <dd>
-            <div id="rating_<?php echo $video->id; ?>_video"><?php echo Rating::show($video->id, 'video'); ?>
+            <div id="rating_<?php echo $video->id; ?>_video">
+                <?php echo Rating::show($video->id, 'video'); ?>
             </div>
         </dd>
     <?php
@@ -80,7 +81,8 @@ $subtitles = $video->get_subtitles();
     <?php if (AmpConfig::get('userflags')) { ?>
         <dt><?php echo T_('Fav.'); ?></dt>
         <dd>
-            <div id="userflag_<?php echo $video->id; ?>_video"><?php echo Userflag::show($video->id, 'video'); ?>
+            <div id="userflag_<?php echo $video->id; ?>_video">
+                <?php echo Userflag::show($video->id, 'video'); ?>
             </div>
         </dd>
     <?php

--- a/public/templates/show_video_row.inc.php
+++ b/public/templates/show_video_row.inc.php
@@ -96,15 +96,23 @@ if ($video_type != 'video') {
 } ?>
 <td class="<?php echo $cel_tags; ?>"><?php echo $libitem->f_tags; ?></td>
 <?php
-    if (User::is_registered()) {
-        if (AmpConfig::get('ratings')) { ?>
-    <td class="cel_rating" id="rating_<?php echo $libitem->id ?>_video"><?php echo Rating::show($libitem->id, 'video') ?></td>
+    if ($show_ratings) { ?>
+        <td class="cel_ratings">
+            <?php if (AmpConfig::get('ratings')) { ?>
+                <span class="cel_rating" id="rating_<?php echo $libitem->id ?>_video">
+                    <?php echo Rating::show($libitem->id, 'video') ?>
+                </span>
+            <?php
+            } ?>
+
+            <?php if (AmpConfig::get('userflags')) { ?>
+                <span class="cel_userflag" id="userflag_<?php echo $libitem->id ?>_video">
+                    <?php echo Userflag::show($libitem->id, 'video') ?>
+                </span>
+            <?php
+            } ?>
+        </td>
     <?php
-        }
-        if (AmpConfig::get('userflags')) { ?>
-    <td class="<?php echo $cel_flag; ?>" id="userflag_<?php echo $libitem->id ?>_video"><?php echo Userflag::show($libitem->id, 'video') ?></td>
-    <?php
-        }
     } ?>
 <td class="cel_action">
 <a href="<?php echo $libitem->link; ?>"><?php echo Ui::get_icon('preferences', T_('Video Information')); ?></a>

--- a/public/templates/show_videos.inc.php
+++ b/public/templates/show_videos.inc.php
@@ -28,12 +28,12 @@ use Ampache\Module\Api\Ajax;
 use Ampache\Module\Util\ObjectTypeToClassNameMapper;
 use Ampache\Module\Util\Ui;
 
-$web_path = AmpConfig::get('web_path');
-$is_table = $browse->is_grid_view();
+$web_path     = AmpConfig::get('web_path');
+$show_ratings = User::is_registered() && (AmpConfig::get('ratings') || AmpConfig::get('userflags'));
+$is_table     = $browse->is_grid_view();
 //mashup and grid view need different css
 $cel_cover   = ($is_table) ? "cel_cover" : 'grid_cover';
 $cel_tags    = ($is_table) ? "cel_tags" : 'grid_tags';
-$cel_flag    = ($is_table) ? "cel_userflag" : 'grid_userflag';
 $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
 <?php if ($browse->is_show_header()) {
     require Ui::find_template('list_header.inc.php');
@@ -59,19 +59,12 @@ if (isset($video_type) && $video_type != 'video') {
             <?php if (AmpConfig::get('show_played_times')) { ?>
             <th class="<?php echo $cel_counter; ?> optional"><?php echo T_('# Played'); ?></th>
             <?php
-} ?>
+            } ?>
             <th class="<?php echo $cel_tags; ?> optional"><?php echo T_('Genres'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) { ?>
-                    <th class="cel_rating optional"><?php echo T_('Rating'); ?></th>
-                <?php
-        } ?>
-                <?php if (AmpConfig::get('userflags')) { ?>
-                    <th class="<?php echo $cel_flag; ?> optional"><?php echo T_('Fav.'); ?></th>
-                <?php
-        } ?>
+            <?php if ($show_ratings) { ?>
+            <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
             <?php
-    } ?>
+            } ?>
             <th class="cel_action essential"><?php echo T_('Action'); ?></th>
         </tr>
     </thead>
@@ -118,24 +111,17 @@ if (isset($video_type) && $video_type != 'video') {
             <?php if (AmpConfig::get('show_played_times')) { ?>
             <th class="<?php echo $cel_counter; ?> optional"><?php echo T_('# Played'); ?></th>
             <?php
-} ?>
+            } ?>
             <th class="<?php echo $cel_tags; ?>"><?php echo T_('Genres'); ?></th>
-            <?php if (User::is_registered()) { ?>
-                <?php if (AmpConfig::get('ratings')) { ?>
-                    <th class="cel_rating"><?php echo T_('Rating'); ?></th>
-                <?php
-        } ?>
-                <?php if (AmpConfig::get('userflags')) { ?>
-                    <th class="<?php echo $cel_flag; ?>"><?php echo T_('Fav.'); ?></th>
-                <?php
-        } ?>
+            <?php if ($show_ratings) { ?>
+            <th class="cel_ratings optional"><?php echo T_('Rating'); ?></th>
             <?php
-    } ?>
+            } ?>
             <th class="cel_action"><?php echo T_('Action'); ?></th>
         </tr>
     </tfoot>
 </table>
 <?php show_table_render(); ?>
 <?php if ($browse->is_show_header()) {
-        require Ui::find_template('list_header.inc.php');
-    } ?>
+                require Ui::find_template('list_header.inc.php');
+            } ?>

--- a/public/themes/reborn/templates/dark.css
+++ b/public/themes/reborn/templates/dark.css
@@ -523,8 +523,12 @@ span.fatalerror {
 }
 
 /* ------------------------
-    Styles for user flags
+    Styles for ratings / user flags
    ------------------------ */
+.star-rating .global-rating {
+    color: #999;
+}
+
 .userflag a.userflag_true,
 .userflag a:hover.userflag_false {
     background: url(../../../images/icon_flag.png) left top;

--- a/public/themes/reborn/templates/default.css
+++ b/public/themes/reborn/templates/default.css
@@ -1776,7 +1776,6 @@ span.fatalerror {
 
 .star-rating .global-rating {
     font-size: 0.8em;
-    color: #999; /* TODO move to dark.css and light.css */ 
     position: relative;
     bottom: 2px;
 }

--- a/public/themes/reborn/templates/default.css
+++ b/public/themes/reborn/templates/default.css
@@ -1025,7 +1025,7 @@ table.tabledata thead .th-top {
     border-bottom: 1px solid;
 }
 
-table.tabledata thead th.cel_rating {
+table.tabledata thead th.cel_ratings {
     padding-left: 7px;
 }
 
@@ -1119,14 +1119,9 @@ table.tabledata tbody td.cel_counter {
     text-align: center;
 }
 
-table.tabledata tbody td.cel_rating {
-    width: 100px !important;
-    max-width: 100px;
-}
-
-table.tabledata tbody td.cel_userflag {
-    width: 40px !important;
-    max-width: 40px;
+table.tabledata tbody td.cel_ratings {
+    width: 130px !important;
+    max-width: 130px;
 }
 
 table.tabledata tbody .cel_cover {
@@ -1144,10 +1139,6 @@ table.tabledata tbody .cel_license {
 table.tabledata tbody td.grid_cover {
     height: auto;
     overflow: visible;
-}
-
-table.tabledata tbody td.grid_userflag {
-    margin-left: 41%;
 }
 
 table.tabledata tbody .grid_cover img,
@@ -1202,7 +1193,7 @@ table.gatherart thead .th-top {
     border-bottom: 1px solid;
 }
 
-table.gatherart thead th.cel_rating {
+table.gatherart thead th.cel_ratings {
     padding-left: 7px;
 }
 
@@ -1301,7 +1292,7 @@ table.disablegv td.cel_drag {
     display: none !important;
 }
 
-table.disablegv td.cel_rating {
+table.disablegv td.cel_ratings {
     display: inline-block !important;
 }
 
@@ -1449,7 +1440,7 @@ div.box.box_rules {
     font-size: 13px;
 }
 
-#now_playing .cel_rating label {
+#now_playing .cel_ratings label {
     display: none;
 }
 
@@ -1760,10 +1751,6 @@ span.fatalerror {
     position: relative;
 }
 
-.dynamic-star-rating {
-    width: 95px;
-}
-
 .star-rating ul,
 .star-rating a:hover,
 .star-rating .current-rating {
@@ -1779,14 +1766,22 @@ span.fatalerror {
     margin: 0;
     padding: 0;
     background-position: left top;
+    display: inline-block;
+    vertical-align: text-top;
 }
 
 .star-rating li {
     display: inline;
 }
 
+.star-rating .global-rating {
+    font-size: 0.8em;
+    color: #999; /* TODO move to dark.css and light.css */ 
+    position: relative;
+    bottom: 2px;
+}
+
 .star-rating a,
-.star-rating span,
 .star-rating .current-rating {
     position: absolute;
     top: 0;
@@ -1821,7 +1816,11 @@ span.fatalerror {
 }
 
 .dynamic-star-rating ul {
-    left: 16px;
+    margin-left: 16px;
+}
+
+[id^=rating_] + [id^=userflag_] {
+    margin-left: 5px;
 }
 
 /* ------------------------
@@ -1831,11 +1830,12 @@ span.fatalerror {
     position: relative;
     width: 16px;
     height: 16px;
+    display: inline-block;
 }
 
 .userflag a {
-    position: absolute;
-    display: inline;
+    display: inline-block;
+    vertical-align: text-top;
 }
 
 .userflag a.userflag_true {

--- a/public/themes/reborn/templates/light.css
+++ b/public/themes/reborn/templates/light.css
@@ -521,8 +521,12 @@ span.fatalerror {
 }
 
 /* ------------------------
-    Styles for user flags
+    Styles for ratings / user flags
    ------------------------ */
+.star-rating .global-rating {
+    color: #777;
+}
+
 .userflag a.userflag_true {
     background: url(../../../images/icon_flag.png) left top;
 }

--- a/resources/templates/song_row.xhtml
+++ b/resources/templates/song_row.xhtml
@@ -49,12 +49,11 @@
         <td tal:condition="CONFIG/isShowPlayedTimesEnabled" class="mash_counter" tal:content="SONG/getNumberPlayed">NUMBER PLAYED</td>
         <td tal:condition="CONFIG/isShowSkippedTimesEnabled" class="mash_counter" tal:content="SONG/getNumberSkipped">NUMBER SKIPPED</td>
     </tal:block>
-    <tal:block tal:condition="USER_IS_REGISTERED">
-        <td tal:condition="CONFIG/isRatingEnabled" class="cel_rating" id="rating_${SONG/getId}_song" tal:content="structure SONG/getRating">RATING</td>
-        <tal:block tal:condition="CONFIG/isUserflagsEnabled">
-            <td tal:condition="IS_TABLE_VIEW" class="cel_userflag" id="userflag_${SONG/getId}_song" tal:content="structure SONG/getUserFlags">USERFLAGS</td>
-            <td tal:condition="not:IS_TABLE_VIEW" class="mash_userflag" id="userflag_${SONG/getId}_song" tal:content="structure SONG/getUserFlags">USERFLAGS</td>
-        </tal:block>
+    <tal:block tal:condition="USING_RATINGS">
+        <td class="cel_ratings">
+            <span tal:condition="CONFIG/isRatingEnabled" class="cel_rating" id="rating_${SONG/getId}_song" tal:content="structure SONG/getRating">RATING</span>
+            <span tal:condition="CONFIG/isUserflagsEnabled" class="cel_userflag" id="userflag_${SONG/getId}_song" tal:content="structure SONG/getUserFlags">USERFLAGS</span>
+        </td>
     </tal:block>
     <td class="cel_action">
         <a tal:attributes="href SONG/getSongUrl" tal:content="structure SONG/getPreferencesIcon">PREFERENCES</a>

--- a/src/Application/Api/Ajax/Handler/DefaultAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/DefaultAjaxHandler.php
@@ -165,14 +165,14 @@ final class DefaultAjaxHandler implements AjaxHandlerInterface
             case 'action_buttons':
                 ob_start();
                 if (AmpConfig::get('ratings')) {
-                    echo " <div id='rating_" . filter_input(INPUT_GET, 'object_id', FILTER_SANITIZE_NUMBER_INT) . "_" . filter_input(INPUT_GET, 'object_type', FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES) . "'>";
+                    echo " <span id='rating_" . filter_input(INPUT_GET, 'object_id', FILTER_SANITIZE_NUMBER_INT) . "_" . filter_input(INPUT_GET, 'object_type', FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES) . "'>";
                     echo Rating::show(filter_input(INPUT_GET, 'object_id', FILTER_SANITIZE_NUMBER_INT), filter_input(INPUT_GET, 'object_type', FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES));
-                    echo "</div> |";
+                    echo "</span>";
                 }
                 if (AmpConfig::get('userflags')) {
-                    echo " <div id='userflag_" . filter_input(INPUT_GET, 'object_id', FILTER_SANITIZE_NUMBER_INT) . "_" . filter_input(INPUT_GET, 'object_type', FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES) . "'>";
+                    echo " <span id='userflag_" . filter_input(INPUT_GET, 'object_id', FILTER_SANITIZE_NUMBER_INT) . "_" . filter_input(INPUT_GET, 'object_type', FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES) . "'>";
                     echo Userflag::show(filter_input(INPUT_GET, 'object_id', FILTER_SANITIZE_NUMBER_INT), filter_input(INPUT_GET, 'object_type', FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES));
-                    echo "</div>";
+                    echo "</span>";
                 }
                 $results['action_buttons'] = ob_get_contents();
                 ob_end_clean();

--- a/src/Repository/Model/Userflag.php
+++ b/src/Repository/Model/Userflag.php
@@ -386,7 +386,7 @@ class Userflag extends database_object
             );
         }
 
-        return sprintf('<div class="userflag">%s</div>', $text);
+        return sprintf('<span class="userflag">%s</span>', $text);
     } // show
 
     /**


### PR DESCRIPTION
Fixes #2797 

So many edits for such a small change... in most places the flag/fav now appears next to the star ratings (didn't bother changing definition lists)

- Rating::show method has been edited slightly to optionally output global/average ratings
- Condensed the average rating display to accommodate the heart icon being adjacent

![firefox_KSU2UwemwN](https://user-images.githubusercontent.com/5735900/117152497-6a7f7080-adfd-11eb-9f87-52396bf4dfc4.png)

![firefox_dmQ4qvF3rV](https://user-images.githubusercontent.com/5735900/117152524-6fdcbb00-adfd-11eb-8949-a31960314794.png)

![firefox_bUoPKUeCWJ](https://user-images.githubusercontent.com/5735900/117152785-b29e9300-adfd-11eb-9710-5bc6e817433b.png)


