### PR TITLE
replaygain not read in ogg files.

### DIFF
--- a/src/Module/Util/VaInfo.php
+++ b/src/Module/Util/VaInfo.php
@@ -1089,7 +1089,6 @@ final class VaInfo implements VaInfoInterface
                     break;
             }
         }
-        
         // Replaygain stored by getID3
         if (isset($this->_raw['replay_gain'])) {
             if (isset($this->_raw['replay_gain']['track']['adjustment'])) {

--- a/src/Module/Util/VaInfo.php
+++ b/src/Module/Util/VaInfo.php
@@ -1089,6 +1089,22 @@ final class VaInfo implements VaInfoInterface
                     break;
             }
         }
+        
+        // Replaygain stored by getID3
+        if (isset($this->_raw['replay_gain'])) {
+            if (isset($this->_raw['replay_gain']['track']['adjustment'])) {
+                $parsed['replaygain_track_gain'] = (float) $this->_raw['replay_gain']['track']['adjustment'];
+            }
+            if (isset($this->_raw['replay_gain']['track']['peak'])) {
+                $parsed['replaygain_track_peak'] = (float) $this->_raw['replay_gain']['track']['peak'];
+            }
+            if (isset($this->_raw['replay_gain']['album']['adjustment'])) {
+                $parsed['replaygain_album_gain'] = (float) $this->_raw['replay_gain']['album']['adjustment'];
+            }
+            if (isset($this->_raw['replay_gain']['album']['peak'])) {
+                $parsed['replaygain_album_peak'] = (float) $this->_raw['replay_gain']['album']['peak'];
+            }
+        }
 
         return $parsed;
     }


### PR DESCRIPTION
It seems that the replaygain tags put in OGG files by foobar2000 for example are processed by getId3 but not by vainfo.php. As a result, no replay gain is seen during playback of OGG files. This patch should process these tags from OGG files:
- replaygain_track_gain
- replaygain_track_peak
- replaygain_album_gain
- replaygain_album_peak