### PR TITLE
Specify SameSite on all cookies (use php 7.3 array parameter)

### DIFF
--- a/public/templates/header.inc.php
+++ b/public/templates/header.inc.php
@@ -497,7 +497,7 @@ $ajaxUriRetriever = $dic->get(AjaxUriRetrieverInterface::class);
                     $('#sidebar').show(500);
                 });
 
-                Cookies.set('sidebar_state', newstate, { expires: 30, path: '/; samesite=strict'});
+                Cookies.set('sidebar_state', newstate, { expires: 30, path: '/', samesite: 'Strict'});
             });
             </script>
             <div id="rightbar" class="rightbar-fixed">

--- a/public/templates/show_html5_player.inc.php
+++ b/public/templates/show_html5_player.inc.php
@@ -258,7 +258,7 @@ if (AmpConfig::get('song_page_title') && !$is_share) {
     });
 
     $("#jquery_jplayer_1").bind($.jPlayer.event.volumechange, function(event) {
-        Cookies.set('jp_volume', event.jPlayer.options.volume, { expires: 7, path: '/; samesite=strict'});
+        Cookies.set('jp_volume', event.jPlayer.options.volume, { expires: 7, path: '/', samesite: 'Strict'});
     });
 
     $("#jquery_jplayer_1").bind($.jPlayer.event.resize, function (event) {

--- a/public/templates/show_html5_player_headers.inc.php
+++ b/public/templates/show_html5_player_headers.inc.php
@@ -304,7 +304,7 @@ function ToggleReplayGain()
 
     if (replaygainNode != null) {
         replaygainEnabled = !replaygainEnabled;
-        document.cookie = 'replaygain=' + replaygainEnabled + ';samesite=lax';
+        Cookies.set('replaygain', replaygainEnabled, {path: '/', samesite: 'Strict'});
         ApplyReplayGain();
 
         if (replaygainEnabled) {

--- a/public/templates/sidebar.inc.php
+++ b/public/templates/sidebar.inc.php
@@ -94,7 +94,7 @@ $(function() {
             if ($header.children(".header-img").hasClass("collapsed")) {
                 sbstate = "collapsed";
             }
-            Cookies.set('sb_' + $header.children(".header-img").attr('id'), sbstate, { expires: 30, path: '/; samesite=strict'});
+            Cookies.set('sb_' + $header.children(".header-img").attr('id'), sbstate, { expires: 30, path: '/', samesite: 'Strict'});
         });
 
     });

--- a/src/Module/Application/Logout/LogoutAction.php
+++ b/src/Module/Application/Logout/LogoutAction.php
@@ -48,7 +48,7 @@ final class LogoutAction implements ApplicationActionInterface
     public function run(ServerRequestInterface $request, GuiGatekeeperInterface $gatekeeper): ?ResponseInterface
     {
         // To end a legitimate session, just call logout.
-        setcookie($this->configContainer->getSessionName() . '_remember', null, -1);
+        setcookie($this->configContainer->getSessionName() . '_remember', null, ['expires' => -1, 'samesite' => 'Strict']);
 
         $this->authenticationManager->logout('', false);
 

--- a/src/Module/System/InstallationHelper.php
+++ b/src/Module/System/InstallationHelper.php
@@ -556,10 +556,16 @@ final class InstallationHelper implements InstallationHelperInterface
                 $dbconfig['download']    = '0';
                 $dbconfig['allow_video'] = '0';
 
+                $cookie_options = [
+                    'expires' => time() + (30 * 24 * 60 * 60),
+                    'path' => '/',
+                    'samesite' => 'Strict'
+                ];
+
                 // Default local UI preferences to have a better 'minimalist first look'.
-                setcookie('sidebar_state', 'collapsed', time() + (30 * 24 * 60 * 60), '/');
-                setcookie('browse_album_grid_view', 'false', time() + (30 * 24 * 60 * 60), '/');
-                setcookie('browse_artist_grid_view', 'false', time() + (30 * 24 * 60 * 60), '/');
+                setcookie('sidebar_state', 'collapsed', $cookie_options);
+                setcookie('browse_album_grid_view', 'false', $cookie_options);
+                setcookie('browse_artist_grid_view', 'false', $cookie_options);
                 break;
             case 'community':
                 $trconfig['use_auth']                                = 'false';

--- a/src/Module/System/Session.php
+++ b/src/Module/System/Session.php
@@ -178,15 +178,19 @@ final class Session implements SessionInterface
 
         debug_event(self::class, 'Deleting Session with key:' . $key, 6);
 
-        $session_name  = AmpConfig::get('session_name');
-        $cookie_path   = AmpConfig::get('cookie_path');
-        $cookie_domain = '';
-        $cookie_secure = make_bool(AmpConfig::get('cookie_secure'));
+        $session_name   = AmpConfig::get('session_name');
+        $cookie_options = [
+            'expires' => -1,
+            'path' => AmpConfig::get('cookie_path'),
+            'domain' => AmpConfig::get('cookie_domain'),
+            'secure' => make_bool(AmpConfig::get('cookie_secure')),
+            'samesite' => 'Strict'
+        ];
 
         // Destroy our cookie!
-        setcookie($session_name, '', -1, $cookie_path, $cookie_domain, $cookie_secure);
-        setcookie($session_name . '_user', '', -1, $cookie_path, $cookie_domain, $cookie_secure);
-        setcookie($session_name . '_lang', '', -1, $cookie_path, $cookie_domain, $cookie_secure);
+        setcookie($session_name, '', $cookie_options);
+        setcookie($session_name . '_user', '', $cookie_options);
+        setcookie($session_name . '_lang', '', $cookie_options);
 
         return true;
     }
@@ -366,10 +370,17 @@ final class Session implements SessionInterface
             return false;
         }
 
+        $cookie_options = [
+            'expires' => (int)AmpConfig::get('cookie_life'),
+            'path' => (string)AmpConfig::get('cookie_path'),
+            'domain' => (string)AmpConfig::get('cookie_domain'),
+            'secure' => make_bool(AmpConfig::get('cookie_secure')),
+            'samesite' => 'Strict'
+        ];
+
         // Set up the cookie params before we start the session.
         // This is vital
-        session_set_cookie_params((int)AmpConfig::get('cookie_life'), (string)AmpConfig::get('cookie_path'),
-            (string)AmpConfig::get('cookie_domain'), make_bool(AmpConfig::get('cookie_secure')));
+        session_set_cookie_params($cookie_options);
         session_write_close();
 
         // Set name
@@ -549,15 +560,18 @@ final class Session implements SessionInterface
     public static function create_cookie()
     {
         // Set up the cookie prefs before we throw down, this is very important
-        $cookie_life   = (int)AmpConfig::get('cookie_life');
-        $cookie_path   = (string)AmpConfig::get('cookie_path');
-        $cookie_domain = '';
-        $cookie_secure = make_bool(AmpConfig::get('cookie_secure'));
+        $cookie_options = [
+            'expires' => (int)AmpConfig::get('cookie_life'),
+            'path' => (string)AmpConfig::get('cookie_path'),
+            'domain' => (string)AmpConfig::get('cookie_domain'),
+            'secure' => make_bool(AmpConfig::get('cookie_secure')),
+            'samesite' => 'Strict'
+        ];
 
         if (isset($_SESSION)) {
-            setcookie(session_name(), session_id(), $cookie_life, $cookie_path, $cookie_domain, $cookie_secure);
+            setcookie(session_name(), session_id(), $cookie_options);
         } else {
-            session_set_cookie_params($cookie_life, $cookie_path, $cookie_domain, $cookie_secure);
+            session_set_cookie_params($cookie_options);
         }
         session_write_close();
         session_name(AmpConfig::get('session_name'));
@@ -578,15 +592,17 @@ final class Session implements SessionInterface
      */
     public static function create_user_cookie($username)
     {
-        $cookie_life   = AmpConfig::get('cookie_life');
-        $session_name  = AmpConfig::get('session_name');
-        $cookie_path   = AmpConfig::get('cookie_path');
-        $cookie_domain = '';
-        $cookie_secure = make_bool(AmpConfig::get('cookie_secure'));
+        $session_name   = AmpConfig::get('session_name');
+        $cookie_options = [
+            'expires' => AmpConfig::get('cookie_life'),
+            'path' => AmpConfig::get('cookie_path'),
+            'domain' => AmpConfig::get('cookie_domain'),
+            'secure' => make_bool(AmpConfig::get('cookie_secure')),
+            'samesite' => 'Strict'
+        ];
 
-        setcookie($session_name . '_user', $username, $cookie_life, $cookie_path, $cookie_domain, $cookie_secure);
-        setcookie($session_name . '_lang', AmpConfig::get('lang'), $cookie_life, $cookie_path, $cookie_domain,
-            $cookie_secure);
+        setcookie($session_name . '_user', $username, $cookie_options);
+        setcookie($session_name . '_lang', AmpConfig::get('lang'), $cookie_options);
     }
 
     /**
@@ -597,11 +613,15 @@ final class Session implements SessionInterface
      */
     public static function create_remember_cookie($username)
     {
-        $remember_length = AmpConfig::get('remember_length');
         $session_name    = AmpConfig::get('session_name');
-        $cookie_path     = AmpConfig::get('cookie_path');
-        $cookie_domain   = '';
-        $cookie_secure   = make_bool(AmpConfig::get('cookie_secure'));
+        $remember_length = time() + AmpConfig::get('remember_length');
+        $cookie_options  = [
+            'expires' => $remember_length,
+            'path' => AmpConfig::get('cookie_path'),
+            'domain' => AmpConfig::get('cookie_domain'),
+            'secure' => make_bool(AmpConfig::get('cookie_secure')),
+            'samesite' => 'Strict'
+        ];
 
         $token = self::generateRandomToken(); // generate a token, should be 128 - 256 bit
         self::storeTokenForUser($username, $token, $remember_length);
@@ -609,7 +629,7 @@ final class Session implements SessionInterface
         $mac    = hash_hmac('sha256', $cookie, AmpConfig::get('secret_key'));
         $cookie .= ':' . $mac;
 
-        setcookie($session_name . '_remember', $cookie, time() + $remember_length, $cookie_path, $cookie_domain, $cookie_secure);
+        setcookie($session_name . '_remember', $cookie, $cookie_options);
     }
 
     /**

--- a/src/Module/Util/Captcha/easy_captcha_persistent_grant.php
+++ b/src/Module/Util/Captcha/easy_captcha_persistent_grant.php
@@ -52,7 +52,7 @@ class easy_captcha_persistent_grant extends easy_captcha
     public function grant()
     {
         if (!headers_sent()) {
-            setcookie($this->cookie(), $this->validity_token(), time() + 175 * CAPTCHA_TIMEOUT);
+            setcookie($this->cookie(), $this->validity_token(), ['expires' => time() + 175 * CAPTCHA_TIMEOUT, 'samesite' => 'Strict']);
             //} else {
             //    // $this->log("::grant", "COOKIES", "too late for cookies");
         }

--- a/src/Repository/Model/Browse.php
+++ b/src/Repository/Model/Browse.php
@@ -445,7 +445,7 @@ class Browse extends Query
     public function save_cookie_params($option, $value)
     {
         if ($this->get_type()) {
-            setcookie('browse_' . $this->get_type() . '_' . $option, $value, time() + 31536000, "/");
+            setcookie('browse_' . $this->get_type() . '_' . $option, $value, ['expires' => time() + 31536000, 'path' => "/", 'samesite' => 'Strict']);
         }
     }
 


### PR DESCRIPTION
Fixes #2910

- Use the PHP7.3 array parameter for setting cookies, which lets you specify a ```samesite``` value.
- Amends the JS cookies which were using an old workaround to set samesite.

One problem remains though, I haven't been able to get the ```ampache``` (session_name) cookie to accept a samesite value, and I don't fully understand why that is as according to the PHP docs it should happily accept the samesite value. 

Assuming its to do with it being a session cookie (session-set-cookie-params), the furthest I could get was changing the PHP setting ```session.cookie_samesite = "Strict"```...