### PR TITLE
Add catalog id parameter in sql for querying with count filter

### DIFF
--- a/src/Repository/Model/Catalog.php
+++ b/src/Repository/Model/Catalog.php
@@ -1103,7 +1103,7 @@ abstract class Catalog extends database_object
         }
         if ($filter === 'count') {
             // Update for things added in the last run or empty ones
-            $sql = "SELECT DISTINCT(`artist`.`id`) AS `artist` FROM `artist`" . "WHERE `artist`.`id` IN (SELECT DISTINCT `song`.`artist` FROM `song` WHERE `addition_time` > " . $this->last_add . ") OR (`album_count` = 0 AND `song_count` = 0) ";
+            $sql = "SELECT DISTINCT(`artist`.`id`) AS `artist` FROM `artist`" . "WHERE `artist`.`id` IN (SELECT DISTINCT `song`.`artist` FROM `song` WHERE `song`.`catalog` = ? AND `addition_time` > " . $this->last_add . ") OR (`album_count` = 0 AND `song_count` = 0) ";
         }
         $db_results = Dba::read($sql, array($this->id));
 


### PR DESCRIPTION
This fix following error while executing `bin/cli run:updateCatalog -a`
```
PDOException SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens
(thrown in /srv/http/ampache/src/Module/System/Dba.php:85)

Stack Trace:

  0) PDOStatement->execute()
     at /srv/http/ampache/src/Module/System/Dba.php:85
  1) Ampache\Module\System\Dba::_query()
     at /srv/http/ampache/src/Module/System/Dba.php:61
  2) Ampache\Module\System\Dba::query()
     at /srv/http/ampache/src/Module/System/Dba.php:122
  3) Ampache\Module\System\Dba::read()
     at /srv/http/ampache/src/Repository/Model/Catalog.php:1108
  4) Ampache\Repository\Model\Catalog->get_artist_ids()
     at /srv/http/ampache/src/Module/Catalog/Update/UpdateCatalog.php:133
  5) Ampache\Module\Catalog\Update\UpdateCatalog->update()
     at /srv/http/ampache/src/Module/Cli/UpdateCatalogCommand.php:62
  6) Ampache\Module\Cli\UpdateCatalogCommand->execute()
     at /srv/http/ampache/vendor/adhocore/cli/src/Application.php:366
  7) Ahc\Cli\Application->doAction()
     at /srv/http/ampache/vendor/adhocore/cli/src/Application.php:280
  8) Ahc\Cli\Application->handle()
     at /srv/http/ampache/bin/cli:72
```