### PR TITLE
crop images from the centre instead of resizing into a square

### DIFF
--- a/public/templates/show_arts.inc.php
+++ b/public/templates/show_arts.inc.php
@@ -49,7 +49,7 @@ while ($count <= $rows) {
             echo "<td>&nbsp;</td>\n";
         } else { ?>
             <td>
-                <a href="<?php echo $image_url; ?>" title="<?php echo $_SESSION['form']['images'][$key]['title']; ?>" rel="prettyPhoto" target="_blank"><img src="<?php echo $image_url; ?>" alt="<?php echo T_('Art'); ?>" height="175" width="175" /></a>
+                <a href="<?php echo $image_url; ?>" title="<?php echo $_SESSION['form']['images'][$key]['title']; ?>" rel="prettyPhoto" target="_blank"><img src="<?php echo $image_url; ?>" alt="<?php echo T_('Art'); ?>" height="" width="175" /></a>
                 <br />
                 <p>
                 <?php if (is_array($dimensions) && (!(int) $dimensions['width'] == 0 || !(int) $dimensions['height'] == 0)) { ?>

--- a/src/Repository/Model/Art.php
+++ b/src/Repository/Model/Art.php
@@ -818,16 +818,21 @@ class Art extends database_object
         // Create a new blank image of the correct size
         $thumbnail = imagecreatetruecolor((int) $size['width'], (int) $size['height']);
 
-        if ($source_size['width'] > $source_size['height']) {
+        if ($source_size['width'] > $source_size['height']) { // landscape
             $new_height = $size['height'];
             $new_width  = floor($source_size['width'] * ($new_height / $source_size['height']));
             $crop_x     = ceil(($source_size['width'] - $source_size['height']) / 2);
             $crop_y     = 0;
-        } else {
+        } elseif ($source_size['height'] > $source_size['width']) { // portrait
             $new_width  = $size['width'];
             $new_height = floor($source_size['height'] * ($new_width / $source_size['width']));
             $crop_x     = 0;
-            $crop_y     = ceil(($source_size['height'] - $source_size['width']) / 3); // assuming portrait images would have faces closer to the top
+            $crop_y     = ceil(($source_size['height'] - $source_size['width']) / 3); // assuming most portrait images would have faces closer to the top
+        } else { // square
+            $new_width  = $size['width'];
+            $new_height = $size['height'];
+            $crop_x     = 0;
+            $crop_y     = 0;
         }
 
         if (!imagecopyresampled($thumbnail, $source, 0, 0, $crop_x, $crop_y, $new_width, $new_height, $source_size['width'], $source_size['height'])) {

--- a/src/Repository/Model/Art.php
+++ b/src/Repository/Model/Art.php
@@ -818,7 +818,19 @@ class Art extends database_object
         // Create a new blank image of the correct size
         $thumbnail = imagecreatetruecolor((int) $size['width'], (int) $size['height']);
 
-        if (!imagecopyresampled($thumbnail, $source, 0, 0, 0, 0, $size['width'], $size['height'], $source_size['width'], $source_size['height'])) {
+        if ($source_size['width'] > $source_size['height']) {
+            $new_height = $size['height'];
+            $new_width  = floor($source_size['width'] * ($new_height / $source_size['height']));
+            $crop_x     = ceil(($source_size['width'] - $source_size['height']) / 2);
+            $crop_y     = 0;
+        } else {
+            $new_width  = $size['width'];
+            $new_height = floor($source_size['height'] * ($new_width / $source_size['width']));
+            $crop_x     = 0;
+            $crop_y     = ceil(($source_size['height'] - $source_size['width']) / 3); // assuming portrait images would have faces closer to the top
+        }
+
+        if (!imagecopyresampled($thumbnail, $source, 0, 0, $crop_x, $crop_y, $new_width, $new_height, $source_size['width'], $source_size['height'])) {
             debug_event(self::class, 'Unable to create resized image', 1);
             imagedestroy($source);
             imagedestroy($thumbnail);


### PR DESCRIPTION
First change is to keep aspect ratio of original images during art selection

![art-selection](https://user-images.githubusercontent.com/5735900/121337534-fd14b180-c95f-11eb-8c7a-2d9aaf286089.jpg)

Second is to crop non-square images from the centre (or slightly above centre for portrait images making the assumption that faces would most likely be higher), instead of squashing the image into being a square. This does mean there is a possibility of faces being cut off but I feel that is better than distorted images

![before-after](https://user-images.githubusercontent.com/5735900/121337539-fdad4800-c95f-11eb-97b9-f343924e9f9a.jpg)
