### PR TITLE
Cache bust some frequently updated assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ public/develop
 public/master
 public/foam
 public/ample
+public/cached_assets/
 storage/
 tmp/
 /vendor/
@@ -48,4 +49,4 @@ web.config
 *.swp
 *.v11.suo
 *~
-public/cached_assets/
+config/ampache.cfg.php.backup

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ web.config
 *.swp
 *.v11.suo
 *~
+public/cached_assets/

--- a/public/templates/header.inc.php
+++ b/public/templates/header.inc.php
@@ -28,6 +28,7 @@ use Ampache\Module\Api\Ajax;
 use Ampache\Module\System\AutoUpdate;
 use Ampache\Module\System\Core;
 use Ampache\Module\Util\AjaxUriRetrieverInterface;
+use Ampache\Module\Util\AssetCache;
 use Ampache\Module\Util\Mailer;
 use Ampache\Module\Util\Ui;
 use Ampache\Repository\PrivateMessageRepositoryInterface;
@@ -99,9 +100,9 @@ $ajaxUriRetriever = $dic->get(AjaxUriRetrieverInterface::class);
         <script src="<?php echo $web_path; ?>/lib/components/jQuery-File-Upload/js/jquery.iframe-transport.js" defer></script>
         <script src="<?php echo $web_path; ?>/lib/components/jQuery-File-Upload/js/jquery.fileupload.js" defer></script>
         <script src="<?php echo $web_path; ?>/lib/components/jQuery-contextMenu/dist/jquery.contextMenu.js"></script>
-        <script src="<?php echo $web_path; ?>/lib/javascript/base.js" defer></script>
-        <script src="<?php echo $web_path; ?>/lib/javascript/ajax.js" defer></script>
-        <script src="<?php echo $web_path; ?>/lib/javascript/tools.js" defer></script>
+        <script src="<?php echo AssetCache::get_url($web_path . '/lib/javascript/base.js'); ?>" defer></script>
+        <script src="<?php echo AssetCache::get_url($web_path . '/lib/javascript/ajax.js'); ?>" defer></script>
+        <script src="<?php echo AssetCache::get_url($web_path . '/lib/javascript/tools.js'); ?>" defer></script>
 
         <script>
             $(document).ready(function(){

--- a/public/templates/install_footer.inc.php
+++ b/public/templates/install_footer.inc.php
@@ -4,7 +4,7 @@
     ================================================== -->
     <script src="<?php echo $web_path; ?>/lib/components/jquery/jquery.min.js"></script>
     <script src="<?php echo $web_path; ?>/lib/components/bootstrap/js/bootstrap.min.js"></script>
-    <script src="<?php echo $web_path; ?>/lib/javascript/base.js"></script>
+    <script src="<?php echo AssetCache::asset_url($web_path . '/lib/javascript/base.js'); ?>"></script>
     <?php
         if (isset($jsEnd) && !empty($jsEnd) && is_array($jsEnd)) {
             foreach ($jsEnd as $js) {

--- a/public/templates/show_debug.inc.php
+++ b/public/templates/show_debug.inc.php
@@ -52,6 +52,9 @@ $web_path    = AmpConfig::get('web_path'); ?>
             <li>
                 <a href="<?php echo $web_path; ?>/admin/system.php?action=clear_cache&type=album"><?php echo Ui::get_icon('cog', T_('Clear Albums Cache')) . ' ' . T_('Clear Albums Cache'); ?></a>
             </li>
+            <li>
+                <a href="<?php echo $web_path; ?>/admin/system.php?action=clear_cache&type=asset"><?php echo Ui::get_icon('cog', T_('Clear Assets Cache')) . ' ' . T_('Clear Assets Cache'); ?></a>
+            </li>
         </ul>
     </div>
 

--- a/public/templates/show_html5_player_headers.inc.php
+++ b/public/templates/show_html5_player_headers.inc.php
@@ -4,6 +4,7 @@ use Ampache\Config\AmpConfig;
 use Ampache\Module\Broadcast\Broadcast_Server;
 use Ampache\Module\Playback\Stream;
 use Ampache\Module\Util\AjaxUriRetrieverInterface;
+use Ampache\Module\Util\AssetCache;
 use Ampache\Module\Util\Ui;
 
 global $dic;
@@ -29,9 +30,9 @@ if (!$iframed) {
 <script src="<?php echo $web_path; ?>/lib/components/jquery/jquery.min.js"></script>
 <script src="<?php echo $web_path; ?>/lib/components/jquery-ui/jquery-ui.min.js"></script>
 <script src="<?php echo $web_path; ?>/lib/components/js-cookie/js-cookie-built.js"></script>
-<script src="<?php echo $web_path; ?>/lib/javascript/base.js"></script>
-<script src="<?php echo $web_path; ?>/lib/javascript/ajax.js"></script>
-<script src="<?php echo $web_path; ?>/lib/javascript/tools.js"></script>
+<script src="<?php echo AssetCache::get_url($web_path . '/lib/javascript/base.js'); ?>"></script>
+<script src="<?php echo AssetCache::get_url($web_path . '/lib/javascript/ajax.js'); ?>"></script>
+<script src="<?php echo AssetCache::get_url($web_path . '/lib/javascript/tools.js'); ?>"></script>
 <script>
 var jsAjaxServer = "<?php echo $ajaxUriRetriever->getAjaxServerUri(); ?>";
 var jsAjaxUrl = "<?php echo $ajaxUriRetriever->getAjaxUri(); ?>";

--- a/public/templates/show_registration_confirmation.inc.php
+++ b/public/templates/show_registration_confirmation.inc.php
@@ -21,6 +21,7 @@
  */
 
 use Ampache\Config\AmpConfig;
+use Ampache\Module\Util\AssetCache;
 use Ampache\Module\Util\Ui;
 
 $htmllang = str_replace("_", "-", AmpConfig::get('lang'));
@@ -42,8 +43,8 @@ $_SESSION['login'] = true; ?>
                 <a href="<?php echo $web_path; ?>"><h1 id="headerlogo"></h1></a>
             </div>
             <script src="<?php echo $web_path; ?>/lib/components/jquery/jquery.min.js"></script>
-            <script src="<?php echo $web_path; ?>/lib/javascript/base.js"></script>
-            <script src="<?php echo $web_path; ?>/lib/javascript/ajax.js"></script>
+            <script src="<?php echo AssetCache::get_url($web_path . '/lib/javascript/base.js'); ?>"></script>
+            <script src="<?php echo AssetCache::get_url($web_path . '/lib/javascript/ajax.js'); ?>"></script>
             <div id="content">
                 <div id="guts">
                     <?php

--- a/public/templates/show_user_activate.inc.php
+++ b/public/templates/show_user_activate.inc.php
@@ -21,6 +21,7 @@
  */
 
 use Ampache\Config\AmpConfig;
+use Ampache\Module\Util\AssetCache;
 use Ampache\Module\Util\Ui;
 
 $htmllang = str_replace("_", "-", AmpConfig::get('lang'));
@@ -41,8 +42,8 @@ $web_path = AmpConfig::get('web_path'); ?>
                 <span><?php echo T_('Registration Validation'); ?>.</span>
             </div>
             <script src="<?php echo $web_path; ?>/lib/components/jquery/jquery.min.js"></script>
-            <script src="<?php echo $web_path; ?>/lib/javascript/base.js"></script>
-            <script src="<?php echo $web_path; ?>/lib/javascript/ajax.js"></script>
+            <script src="<?php echo AssetCache::get_url($web_path . '/lib/javascript/base.js'); ?>"></script>
+            <script src="<?php echo AssetCache::get_url($web_path . '/lib/javascript/ajax.js'); ?>"></script>
             <div>
 <?php
     if ($validationResult) {

--- a/public/templates/show_user_registration.inc.php
+++ b/public/templates/show_user_registration.inc.php
@@ -25,6 +25,7 @@ use Ampache\Config\AmpConfig;
 use Ampache\Module\System\AmpError;
 use Ampache\Module\System\Core;
 use Ampache\Module\User\Registration;
+use Ampache\Module\Util\AssetCache;
 use Ampache\Module\Util\Captcha\captcha;
 use Ampache\Module\Util\Ui;
 
@@ -49,8 +50,8 @@ $_SESSION['login'] = true; ?>
 
 <body id="registerPage">
     <script src="<?php echo $web_path; ?>/lib/components/jquery/jquery.min.js"></script>
-    <script src="<?php echo $web_path; ?>/lib/javascript/base.js"></script>
-    <script src="<?php echo $web_path; ?>/lib/javascript/ajax.js"></script>
+    <script src="<?php echo AssetCache::get_url($web_path . '/lib/javascript/base.js'); ?>"></script>
+    <script src="<?php echo AssetCache::get_url($web_path . '/lib/javascript/ajax.js'); ?>"></script>
 
     <div id="maincontainer">
         <div id="header">

--- a/public/templates/stylesheets.inc.php
+++ b/public/templates/stylesheets.inc.php
@@ -21,6 +21,7 @@
  */
 
 use Ampache\Config\AmpConfig;
+use Ampache\Module\Util\AssetCache;
 use Ampache\Module\Util\Ui;
 
 $web_path       = AmpConfig::get('web_path');
@@ -31,16 +32,16 @@ if (!is_array($theme_css_base)) {
     $theme_css_base = array($theme_css_base);
 }
 foreach ($theme_css_base as $css_base) { ?>
-    <link rel="stylesheet" href="<?php echo $web_path . $theme_path . '/' . $css_base[0]; ?>" type="text/css" media="<?php echo $css_base[1]; ?>" />
+    <link rel="stylesheet" href="<?php echo AssetCache::get_url($web_path . $theme_path . '/' . $css_base[0]); ?>" type="text/css" media="<?php echo $css_base[1]; ?>" />
 <?php
 } ?>
-<link rel="stylesheet" href="<?php echo $web_path . '/templates/base.css'; ?>" type="text/css" media="screen" />
-<link rel="stylesheet" href="<?php echo $web_path . $theme_path . '/' . $theme_color . '.css'; ?>" type="text/css" media="screen" />
-<link rel="stylesheet" href="<?php echo $web_path . '/templates/print.css'; ?>" type="text/css" media="print" />
+<link rel="stylesheet" href="<?php echo AssetCache::get_url($web_path . '/templates/base.css'); ?>" type="text/css" media="screen" />
+<link rel="stylesheet" href="<?php echo AssetCache::get_url($web_path . $theme_path . '/' . $theme_color . '.css'); ?>" type="text/css" media="screen" />
+<link rel="stylesheet" href="<?php echo AssetCache::get_url($web_path . '/templates/print.css'); ?>" type="text/css" media="print" />
 <?php
 if (is_rtl(AmpConfig::get('lang'))
     && is_file(__DIR__ . '/../../public/' . $theme_path . '/rtl.css')) { ?>
-<link rel="stylesheet" href="<?php echo $web_path . $theme_path; ?>/rtl.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="<?php echo AssetCache::get_url($web_path . $theme_path . '/rtl.css'); ?>" type="text/css" media="screen" />
 <?php } ?>
 <link rel="stylesheet" href="<?php echo $web_path; ?>/lib/components/prettyphoto/css/prettyPhoto.css" type="text/css" media="screen" />
 <link rel="stylesheet" href="<?php echo $web_path . '/templates/jquery-ui.custom.css'; ?>" type="text/css" media="screen" />

--- a/public/themes/reborn/templates/dark.css
+++ b/public/themes/reborn/templates/dark.css
@@ -128,7 +128,7 @@ input[type=submit]:focus:active {
    -------------------------- */
 #ajax-loading {
     color: #ff9d00;
-    background-image: url(../images/ajax-loader.gif);
+    background-image: url(/themes/reborn/images/ajax-loader.gif);
 }
 
 /* --------------------------
@@ -173,7 +173,7 @@ input[type=submit]:focus:active {
 
 #loginPage #headerlogo,
 #registerPage #headerlogo {
-    background-image: url('../images/ampache-dark.png');
+    background-image: url('/themes/reborn/images/ampache-dark.png');
 }
 
 #loginPage #loginbox {
@@ -452,7 +452,7 @@ input:invalid {
 }
 
 #content .missing {
-    background-image: url('../images/missing.png');
+    background-image: url('/themes/reborn/images/missing.png');
 }
 
 /* --------------------------
@@ -497,7 +497,7 @@ span.fatalerror {
 }
 
 .item_art .item_art_play .item_art_play_icon {
-    background-image: url('../images/videoplay.png');
+    background-image: url('/themes/reborn/images/videoplay.png');
 }
 
 .item_art .item_art_actions {
@@ -532,12 +532,12 @@ span.fatalerror {
 
 .userflag a.userflag_true,
 .userflag a:hover.userflag_false {
-    background: url(../../../images/icon_flag.png) left top;
+    background: url(/images/icon_flag.png) left top;
 }
 
 .userflag a:hover.userflag_true,
 .userflag a.userflag_false {
-    background: url(../../../images/icon_flag_off.png) left top;
+    background: url(/images/icon_flag_off.png) left top;
 }
 
 /* --------------------------
@@ -659,7 +659,7 @@ a.option-list:hover {
 }
 
 .editdialogstyle.ui-dialog {
-    background-image: url("../../../images/background.png") !important;
+    background-image: url("/images/background.png") !important;
 }
 
 #tabs li a {

--- a/public/themes/reborn/templates/default.css
+++ b/public/themes/reborn/templates/default.css
@@ -22,7 +22,7 @@
 
 @font-face {
     font-family: 'DejaVuSansCondensed';
-    src: url('fonts/dejavusanscondensed.eot?') format('embedded-opentype'), url('fonts/dejavusanscondensed.woff') format('woff'), url('fonts/dejavusanscondensed.ttf') format('truetype'), url('fonts/dejavusanscondensed.svg#DejaVuSansCondensed') format('svg');
+    src: url('/themes/reborn/templates/fonts/dejavusanscondensed.eot?') format('embedded-opentype'), url('/themes/reborn/templates/fonts/dejavusanscondensed.woff') format('woff'), url('/themes/reborn/templates/fonts/dejavusanscondensed.ttf') format('truetype'), url('/themes/reborn/templates/fonts/dejavusanscondensed.svg#DejaVuSansCondensed') format('svg');
 }
 
 /* --------------------------
@@ -1768,7 +1768,7 @@ span.fatalerror {
 .star-rating ul,
 .star-rating a:hover,
 .star-rating .current-rating {
-    background: url(../images/ratings/star_rating.png) left -1000px repeat-x;
+    background: url(/themes/reborn/images/ratings/star_rating.png) left -1000px repeat-x;
 }
 
 .star-rating ul {
@@ -1817,7 +1817,7 @@ span.fatalerror {
 .star-rating a.star0 {
     left: 0;
     width: 16px;
-    background: url(../../../images/ratings/x_off.gif) left top;
+    background: url(/images/ratings/x_off.gif) left top;
 }
 
 .dynamic-star-rating a:hover {
@@ -1825,7 +1825,7 @@ span.fatalerror {
 }
 
 .dynamic-star-rating a:hover.star0 {
-    background: url(../../../images/ratings/x.gif) left top;
+    background: url(/images/ratings/x.gif) left top;
 }
 
 .dynamic-star-rating ul {

--- a/public/themes/reborn/templates/light.css
+++ b/public/themes/reborn/templates/light.css
@@ -126,7 +126,7 @@ input[type=submit]:focus:active {
    ------------------------ */
 #ajax-loading {
     color: #1990db;
-    background-image: url(../images/ajax-loader-light.gif);
+    background-image: url(/themes/reborn/images/ajax-loader-light.gif);
 }
 
 /* ------------------------
@@ -171,7 +171,7 @@ input[type=submit]:focus:active {
 
 #loginPage #headerlogo,
 #registerPage #headerlogo {
-    background-image: url('../images/ampache-light.png');
+    background-image: url('/themes/reborn/images/ampache-light.png');
 }
 
 #loginPage #loginbox {
@@ -454,7 +454,7 @@ input:invalid {
 }
 
 #content .missing {
-    background-image: url('../images/missing.png');
+    background-image: url('/themes/reborn/images/missing.png');
 }
 
 /* ------------------------
@@ -499,7 +499,7 @@ span.fatalerror {
 }
 
 .item_art .item_art_play .item_art_play_icon {
-    background-image: url('../images/videoplay.png');
+    background-image: url('/themes/reborn/images/videoplay.png');
 }
 
 .item_art .item_art_actions {
@@ -533,19 +533,19 @@ span.fatalerror {
 }
 
 .userflag a.userflag_true {
-    background: url(../../../images/icon_flag.png) left top;
+    background: url(/images/icon_flag.png) left top;
 }
 
 .userflag a:hover.userflag_true {
-    background: url(../../../images/icon_flag_off.png) left top;
+    background: url(/images/icon_flag_off.png) left top;
 }
 
 .userflag a.userflag_false {
-    background: url(../../../images/icon_flag_off.png) left top;
+    background: url(/images/icon_flag_off.png) left top;
 }
 
 .userflag a:hover.userflag_false {
-    background: url(../../../images/icon_flag.png) left top;
+    background: url(/images/icon_flag.png) left top;
 }
 
 /* ------------------------
@@ -669,7 +669,7 @@ a.option-list:hover {
 }
 
 .editdialogstyle.ui-dialog {
-    background-image: url("../../../images/background.light.png") !important;
+    background-image: url("/images/background.light.png") !important;
 }
 
 #tabs li a {

--- a/src/Module/Application/Admin/System/ClearCacheAction.php
+++ b/src/Module/Application/Admin/System/ClearCacheAction.php
@@ -33,6 +33,7 @@ use Ampache\Module\Application\ApplicationActionInterface;
 use Ampache\Module\Application\Exception\AccessDeniedException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
+use Ampache\Module\Util\AssetCache;
 use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -78,6 +79,9 @@ final class ClearCacheAction implements ApplicationActionInterface
                 break;
             case 'album':
                 Album::clear_cache();
+                break;
+            case 'asset':
+                AssetCache::clear_cache();
                 break;
         }
 

--- a/src/Module/System/AutoUpdate.php
+++ b/src/Module/System/AutoUpdate.php
@@ -26,6 +26,7 @@ namespace Ampache\Module\System;
 
 use Ampache\Config\AmpConfig;
 use Ampache\Config\ConfigContainerInterface;
+use Ampache\Module\Util\AssetCache;
 use Exception;
 use Ampache\Repository\Model\Preference;
 use Requests;
@@ -314,6 +315,7 @@ class AutoUpdate
         if (!$api) {
             echo T_('Done') . '<br />';
         }
+        AssetCache::clear_cache();
         ob_flush();
         self::get_latest_version(true);
     }

--- a/src/Module/Util/AssetCache.php
+++ b/src/Module/Util/AssetCache.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright 2001 - 2020 Ampache.org
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=0);
+
+namespace Ampache\Module\Util;
+
+use Ampache\Config\AmpConfig;
+use Ampache\Module\System\Core;
+
+/**
+ * A collection of methods related to cache-busting assets
+ */
+class AssetCache
+{
+    private static string $cacheDir = '/cached_assets/';
+    private static string $cacheDirURL;
+    private static string $cacheDirPath;
+
+    private static function set_cache_dir()
+    {
+        self::$cacheDirURL  = AmpConfig::get('web_path') . self::$cacheDir;
+        self::$cacheDirPath = Core::get_server('DOCUMENT_ROOT') . self::$cacheDir;
+    }
+
+    public static function get_url(string $path)
+    {
+        self::set_cache_dir();
+
+        $originalFileURL       = $path;
+        $originalFilePath      = Core::get_server('DOCUMENT_ROOT') . str_replace(AmpConfig::get('web_path'), '', $path);
+        $originalFilePathArray = pathinfo($path);
+
+        $cachedFileURL  = self::$cacheDirURL . $originalFilePathArray['filename'] . '-' . md5_file($originalFilePath) . '.' . $originalFilePathArray['extension'];
+        $cachedFilePath = self::$cacheDirPath . $originalFilePathArray['filename'] . '-' . md5_file($originalFilePath) . '.' . $originalFilePathArray['extension'];
+
+        if (!file_exists($cachedFilePath)) {
+            self::copy_file($originalFilePath);
+        }
+
+        if (file_exists($cachedFilePath)) {
+            return $cachedFileURL;
+        }
+
+        // if all else fails return original file
+        return $originalFileURL;
+    }
+
+    private static function copy_file(string $path)
+    {
+        self::create_cache_dir();
+
+        $filePath      = str_replace(AmpConfig::get('web_path'), Core::get_server('DOCUMENT_ROOT'), $path);
+        $filepathArray = pathinfo($path);
+
+        if (file_exists($filePath)) {
+            $cachedVersion = self::$cacheDirPath . $filepathArray['filename'] . '-' . md5_file($filePath) . '.' . $filepathArray['extension'];
+            copy($filePath, $cachedVersion);
+        }
+    }
+
+    private static function create_cache_dir()
+    {
+        if (!file_exists(self::$cacheDirPath)) {
+            mkdir(self::$cacheDirPath, 0755);
+        }
+    }
+
+    public static function clear_cache()
+    {
+        self::set_cache_dir();
+
+        $files = glob(self::$cacheDirPath . '*');
+
+        foreach ($files as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This uses the MD5 hash of a file to create a unique cached version, to avoid 'just clear your browser cache' issues

- Reference a cached version of asset if it exists, otherwise create cached version and reference it, or fallback to original file
- Added 'Clear Assets Cache' option to Ampache Debug page
- Change paths in CSS to be web root relative to account for different physical locations of original and cached CSS file

Not sure if I should also clear the asset cache during clean_catalog() just so its periodically cleared?