### PR TITLE
only glue with comma if more than 1 item

### DIFF
--- a/public/templates/show_artist_info.inc.php
+++ b/public/templates/show_artist_info.inc.php
@@ -42,9 +42,8 @@ use Ampache\Module\Util\Ui;
         if (array_key_exists('yearformed', $biography)) {
             $dcol[] = $biography['yearformed'];
         }
-        if (count($dcol) > 0) {
-            echo implode(',', $dcol);
-        } ?>
+        $glue = (count(array_filter($dcol)) > 1) ? ',' : '';
+        echo implode($glue, $dcol) ?>
     </div>
 </div>
 <div id="item_summary">


### PR DESCRIPTION
![firefox_YTkLDrYzWP](https://user-images.githubusercontent.com/5735900/137325912-ed7fdc77-3d27-46e8-8f09-fe97fc05b332.png)

Prevents comma being added when array is empty, or when it has just one of the items