### PR TITLE
fix user access for API method PodcastEpisodeDelete

### DIFF
--- a/src/Module/Api/Method/PodcastEpisodeDeleteMethod.php
+++ b/src/Module/Api/Method/PodcastEpisodeDeleteMethod.php
@@ -70,9 +70,7 @@ final class PodcastEpisodeDeleteMethod
             return false;
         }
         $user = User::get_from_username(Session::username($input['auth']));
-        if (!Catalog::can_remove($episode, $user->id)) {
-            Api::error(T_('Require: 75'), '4742', self::ACTION, 'account', $input['api_format']);
-
+        if (!Api::check_access('interface', 75, $user->id, self::ACTION, $input['api_format'])) {
             return false;
         }
 


### PR DESCRIPTION
Regardless of the access rights, the user was not able to delete a podcast_episode via the Ampache API method 'PodcastEpisodeDelete' (error: 'Require: 75'). I tested it with admin rights. Via the subsonic API the action performed without errors.

With this pull request the Ampache API method 'PodcastEpisodeDelete' behaves as the subsonic counterpart 'deletePodcastEpisode':
https://github.com/ampache/ampache/blob/a93fe6a4bff4b003c98f3da7016183d03dc7e57c/src/Module/Api/Subsonic_Api.php#L2361

The same check is performed here in the Ampache API method 'PodcastDelete': https://github.com/ampache/ampache/blob/a93fe6a4bff4b003c98f3da7016183d03dc7e57c/src/Module/Api/Method/PodcastDeleteMethod.php#L61