### PR TITLE
Use redis for caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/
+.github/
+.tx/
+vendor
+public/lib/components

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 .tx/
 vendor
 public/lib/components
+docker/volumes/media

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ config/ampache.cfg.php.backup
 
 # Devs should be able to customize their docker-compose env without unintentionally committing it
 docker-compose.override.yml
+
+docker/volumes/media/*

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ web.config
 *.v11.suo
 *~
 config/ampache.cfg.php.backup
+
+# Devs should be able to customize their docker-compose env without unintentionally committing it
+docker-compose.override.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,11 @@ docker-compose up -d
 
 You can then open http://localhost:8080 and use the username `ampache` and password `ampache` to connect as the admin.
 
+**Making a catalog**
+
+By default `/media` is available in the `ampache` service to create a catalog.
+You can put your media in `docker/volumes/media` on your machine to make them available in the service.
+
 **Debugging**
 
 !!!This has only been tested on Linux!!!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,36 @@ submitting bug reports and feature requests or writing code which can be incorpo
 Anyone can take part in our community and it there are no rules or requirements stopping you from joining.
 Hopefully this document will help you make the jump!
 
-Please read [Development section](https://github.com/ampache/ampache/wiki#development).
+## Local development environment
+
+### Docker env
+
+**Requirements**
+
+ - [docker](https://docs.docker.com/engine/install/)
+ - [docker-compose](https://docs.docker.com/compose/install/)
+
+**Getting started**
+
+After installing the requirements, just run
+```shell
+docker-compose up -d
+```
+
+You can then open http://localhost:8080 and use the username `ampache` and password `ampache` to connect as the admin.
+
+**Debugging**
+
+!!!This has only been tested on Linux!!!
+
+Create `docker-compose.override.yml` from `docker-compose.override-template.yml`.
+Then start a debugger on your local machine that listens to port `9003`.
+
+Finally, recreate the `ampache` service with `docker-compose up -d ampache`.
+
+**More information**
+
+Additional information can be found on [Development section](https://github.com/ampache/ampache/wiki#development).
 
 ## Bug report
 

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "ext-pdo": "*",
+        "ext-redis": "*",
         "ext-simplexml": "*",
         "ext-xml": "*",
         "adhocore/cli": "^0.9.0",

--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -521,6 +521,12 @@ sociable = "true"
 ; DEFAULT: "false"
 ;memory_cache = "true"
 
+; The memory cache is handled by redis
+; You will need to point to the redis instance you want to use
+; DEFAULT: "127.0.0.1"
+redis_host = "127.0.0.1"
+redis_port = 6379
+
 ; Memory Limit
 ; This defines the "Min" memory limit for PHP if your php.ini
 ; has a lower value set Ampache will set it up to this. If you

--- a/docker-compose.override-template.yml
+++ b/docker-compose.override-template.yml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+  ampache:
+    environment:
+       # Enable XDebug
+       XDEBUG_SESSION: "1"
+
+       # Uncomment to change the default port
+       # XDEBUG_PORT: 9003
+
+       # This host works on linux to YOUR local machine (yours is the host, the service is the guest)
+       # XDEBUG_HOST: host.docker.internal

--- a/docker-compose.override-template.yml
+++ b/docker-compose.override-template.yml
@@ -11,3 +11,15 @@ services:
 
        # This host works on linux to YOUR local machine (yours is the host, the service is the guest)
        # XDEBUG_HOST: host.docker.internal
+
+  # Enable this to run tools like PHP Stan et al
+  # You will probably have xdebug activated on the ampache service and don't want the debugger
+  #  to be called just because you're executing a linting process
+  # Run them with this service instead
+  php:
+    build:
+      context: .
+      dockerfile: docker/php.Dockerfile
+    command: echo "Use this to execute tools"
+    volumes:
+      - ./:/var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
       - ./:/var/www/html
       - ./docker/nginx.conf:/etc/nginx/conf.d/default.conf
+
   ampache:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,14 @@ services:
     command: /cmd.sh
     depends_on:
       - db
-    environment:
+    #environment:
       # Enable XDEBUG by setting to "1"
-      XDEBUG_SESSION: "0"
+      # XDEBUG_SESSION: "1"
+      # Uncomment to change the default port
+      # XDEBUG_PORT: 9003
+      # Uncomment to change the default host
+      # This host works on linux to YOUR local machine (yours is the host, the service is the guest)
+      # XDEBUG_HOST: host.docker.internal
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,6 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: 'secret'
       MYSQL_USER: 'ampache'
-      MYSQL_PASSWORD: 'ampache'
-      MYSQL_DATABASE: 'ampache'
     volumes:
       - mysqldata:/var/lib/mysql
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - ./:/var/www/html
       - ./docker/php/cmd.sh:/cmd.sh
       - ./docker/php/fpm.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
+      - ./docker/volumes/media:/media
 
   db:
     image: mariadb:10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3'
+
+services:
+  nginx:
+    image: nginx:latest
+    depends_on:
+      - ampache
+    ports:
+      - "127.0.0.1:8080:80"
+    volumes:
+      - ./:/var/www/html
+      - ./docker/nginx.conf:/etc/nginx/conf.d/default.conf
+  ampache:
+    build:
+      context: .
+      dockerfile: docker/php.Dockerfile
+    command: /cmd.sh
+    depends_on:
+      - db
+    environment:
+      # Enable XDEBUG by setting to "1"
+      XDEBUG_SESSION: "0"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./:/var/www/html
+      - ./docker/php/cmd.sh:/cmd.sh
+      - ./docker/php/fpm.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
+
+  db:
+    image: mariadb:10
+    environment:
+      MYSQL_ROOT_PASSWORD: 'secret'
+      MYSQL_USER: 'ampache'
+      MYSQL_PASSWORD: 'ampache'
+      MYSQL_DATABASE: 'ampache'
+    volumes:
+      - mysqldata:/var/lib/mysql
+    ports:
+      - "127.0.0.1:13306:3306"
+
+volumes:
+  mysqldata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,5 +44,8 @@ services:
     ports:
       - "127.0.0.1:13306:3306"
 
+  redis:
+    image: redis:latest
+
 volumes:
   mysqldata:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,130 @@
+server {
+    # listen to
+    listen  [::]:80; #ssl; ipv6 optional with ssl enabled
+    listen       80; #ssl; ipv4 optional with ssl enabled
+    server_name localhost:8080;
+
+    resolver 127.0.0.11 valid=10s;
+
+    charset utf-8;
+
+    # Logging, error_log mode [notice] is necessary for rewrite_log on,
+    # (very usefull if rewrite rules do not work as expected)
+
+    #          error_log       /var/log/ampache/error.log; # notice;
+       # access_log      /var/log/ampache/access.log;
+       # rewrite_log     on;
+
+    # Use secure headers to avoid XSS and many other things
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Robots-Tag none;
+    add_header X-Download-Options noopen;
+    add_header X-Permitted-Cross-Domain-Policies none;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "no-referrer";
+    add_header Content-Security-Policy "script-src 'self' 'unsafe-inline' 'unsafe-eval'; frame-src 'self'; object-src 'self'";
+
+    # Avoid information leak
+    server_tokens off;
+    fastcgi_hide_header X-Powered-By;
+
+    root /var/www/html;
+    index index.php;
+
+    # Somebody said this helps, in my setup it doesn't prevent temporary saving in files
+    proxy_max_temp_file_size 0;
+
+    # Rewrite rule for Subsonic backend
+    if ( !-d $request_filename ) {
+        rewrite ^/rest/(.*).view$ /rest/index.php?action=$1 last;
+        rewrite ^/rest/fake/(.+)$ /play/$1 last;
+    }
+
+    # Rewrite rule for Channels
+    if (!-d $request_filename){
+        rewrite ^/channel/([0-9]+)/(.*)$ /channel/index.php?channel=$1&target=$2 last;
+    }
+
+    # Beautiful URL Rewriting
+    rewrite ^/play/ssid/(\w+)/type/(\w+)/oid/([0-9]+)/uid/([0-9]+)/name/(.*)$ /play/index.php?ssid=$1&type=$2&oid=$3&uid=$4&name=$5 last;
+    rewrite ^/play/ssid/(\w+)/type/(\w+)/oid/([0-9]+)/uid/([0-9]+)/client/(.*)/name/(.*)$ /play/index.php?ssid=$1&type=$2&oid=$3&uid=$4&client=$5&name=$6 last;
+    rewrite ^/play/ssid/(\w+)/type/(\w+)/oid/([0-9]+)/uid/([0-9]+)/client/(.*)/player/(.*)/name/(.*)$ /play/index.php?ssid=$1&type=$2&oid=$3&uid=$4&client=$5&player=$6&name=$7 last;
+    rewrite ^/play/ssid/(\w+)/type/(\w+)/oid/([0-9]+)/uid/([0-9]+)/client/(.*)/bitrate/([0-9]+)/player/(.*)/name/(.*)$ /play/index.php?ssid=$1&type=$2&oid=$3&uid=$4&client=$5&bitrate=$6player=$7&name=$8 last;
+    rewrite ^/play/ssid/(\w+)/type/(\w+)/oid/([0-9]+)/uid/([0-9]+)/client/(.*)/transcode_to/(w+)/bitrate/([0-9]+)/player/(.*)/name/(.*)$ /play/index.php?ssid=$1&type=$2&oid=$3&uid=$4&client=$5&transcode_to=$6&bitrate=$7&player=$8&name=$9 last;
+    rewrite ^/play/ssid/(\w+)/type/(\w+)/oid/([0-9]+)/uid/([0-9]+)/client/(.*)/noscrobble/([0-1])/name/(.*)$ /play/index.php?ssid=$1&type=$2&oid=$3&uid=$4&client=$5&noscrobble=$6&name=$7 last;
+    rewrite ^/play/ssid/(\w+)/type/(\w+)/oid/([0-9]+)/uid/([0-9]+)/client/(.*)/noscrobble/([0-1])/player/(.*)/name/(.*)$ /play/index.php?ssid=$1&type=$2&oid=$3&uid=$4&client=$5&noscrobble=$6&player=$7&name=$8 last;
+    rewrite ^/play/ssid/(\w+)/type/(\w+)/oid/([0-9]+)/uid/([0-9]+)/client/(.*)/noscrobble/([0-1])/bitrate/([0-9]+)/player/(.*)/name/(.*)$ /play/index.php?ssid=$1&type=$2&oid=$3&uid=$4&client=$5&noscrobble=$6&bitrate=$7player=$8&name=$9 last;
+    rewrite ^/play/ssid/(\w+)/type/(\w+)/oid/([0-9]+)/uid/([0-9]+)/client/(.*)/noscrobble/([0-1])/transcode_to/(w+)/bitrate/([0-9]+)/player/(.*)/name/(.*)$ /play/index.php?ssid=$1&type=$2&oid=$3&uid=$4&client=$5&noscrobble=$6&transcode_to=$7&bitrate=$8&player=$9&name=$10 last;
+
+    # the following line was needed for me to get downloads of single songs to work
+    rewrite ^/play/ssid/(.*)/type/(.*)/oid/([0-9]+)/uid/([0-9]+)/action/(.*)/name/(.*)$ /play/index.php?ssid=$1&type=$2&oid=$3&uid=$4action=$5&name=$6 last;
+    location /play {
+        if (!-e $request_filename) {
+            rewrite ^/play/art/([^/]+)/([^/]+)/([0-9]+)/thumb([0-9]*)\.([a-z]+)$ /image.php?object_type=$2&object_id=$3&auth=$1 last;
+        }
+
+        rewrite ^/([^/]+)/([^/]+)(/.*)?$ /play/$3?$1=$2;
+        rewrite ^/(/[^/]+|[^/]+/|/?)$ /play/index.php last;
+        break;
+    }
+
+    location /rest {
+        limit_except GET POST {
+            deny all;
+        }
+    }
+
+    location ^~ /bin/ {
+        deny all;
+        return 403;
+    }
+
+    location ^~ /config/ {
+        deny all;
+        return 403;
+    }
+
+    location / {
+        limit_except GET POST HEAD{
+            deny all;
+        }
+    }
+
+    location = / {
+        return http://localhost:8080/public/;
+    }
+
+    location ~ ^/.*.php {
+        fastcgi_index index.php;
+
+        # sets the timeout for requests in [s] , 60s are normally enough
+        fastcgi_read_timeout 60s;
+
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+        # Mitigate HTTPROXY https://httpoxy.org/
+        fastcgi_param HTTP_PROXY "";
+
+        # has to be set to on if encryption (https) is used:
+        # fastcgi_param HTTPS on;
+
+        fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+
+        # chose as your php-fpm is configured to listen on
+        set $upstream_host ampache;
+        fastcgi_pass $upstream_host:9000;
+#         fastcgi_pass ampache:9000;
+    }
+
+    # Rewrite rule for WebSocket
+#     location /ws {
+#         rewrite ^/ws/(.*) /$1 break;
+#         proxy_http_version 1.1;
+#         proxy_set_header Upgrade $http_upgrade;
+#         proxy_set_header Connection "upgrade";
+#         proxy_set_header Host $host;
+#         proxy_pass http://127.0.0.1:8100/;
+#     }
+}

--- a/docker/php.Dockerfile
+++ b/docker/php.Dockerfile
@@ -27,6 +27,7 @@ COPY composer.json $COMPOSER_HOME/
 COPY resources/ ./resources
 RUN composer global install --no-dev --no-autoloader
 
+VOLUME /media
 
 FROM base as dev
 

--- a/docker/php.Dockerfile
+++ b/docker/php.Dockerfile
@@ -8,10 +8,12 @@ RUN apt-get update -qq \
         p7zip-full \
     && rm -rf /var/lib/apt/lists/*
 # Install required PHP extensions
-RUN docker-php-ext-install \
+RUN pecl install redis \
+    && docker-php-ext-install \
       intl \
       gettext \
-      pdo_mysql
+      pdo_mysql \
+    && docker-php-ext-enable redis.so
 
 # Install composer 2.1.14
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \

--- a/docker/php.Dockerfile
+++ b/docker/php.Dockerfile
@@ -21,6 +21,8 @@ RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
     && mv composer.phar /usr/local/bin/composer \
     && mkdir -p $COMPOSER_HOME
 
+# Install composer deps globally \
+# It'll be useful for the production image sometime and acts as a cache for the dev env
 COPY composer.json $COMPOSER_HOME/
 COPY resources/ ./resources
 RUN composer global install --no-dev --no-autoloader

--- a/docker/php.Dockerfile
+++ b/docker/php.Dockerfile
@@ -1,0 +1,33 @@
+FROM php:7-fpm as base
+ENV COMPOSER_HOME /opt/composer
+
+RUN apt-get update -qq \
+    && apt-get install -y  \
+        git \
+        libicu-dev \
+        p7zip-full \
+    && rm -rf /var/lib/apt/lists/*
+# Install required PHP extensions
+RUN docker-php-ext-install \
+      intl \
+      gettext \
+      pdo_mysql
+
+# Install composer 2.1.14
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php -r "if (hash_file('sha384', 'composer-setup.php') === '906a84df04cea2aa72f40b5f787e49f22d4c2f19492ac310e8cba5b96ac8b64115ac402c8cd292b8a03482574915d1a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+    && php composer-setup.php \
+    && php -r "unlink('composer-setup.php');" \
+    && mv composer.phar /usr/local/bin/composer \
+    && mkdir -p $COMPOSER_HOME
+
+COPY composer.json $COMPOSER_HOME/
+COPY resources/ ./resources
+RUN composer global install --no-dev --no-autoloader
+
+
+FROM base as dev
+
+RUN pecl install xdebug \
+    && docker-php-ext-enable xdebug \
+    && composer global install --no-autoloader

--- a/docker/php/cmd.sh
+++ b/docker/php/cmd.sh
@@ -44,4 +44,17 @@ if [[ "${XDEBUG_SESSION:-}" = "1" ]] ; then
     " > /usr/local/etc/php/conf.d/xdebug.ini
 fi
 
-exec php-fpm
+# Enable logging ampache debug output
+# Still have to modify config and set debug = "true"
+sed -i -e 's|log_path = "/var/log/.+"|log_path = "/var/log/"|g' config/ampache.cfg.php
+sed -i -e 's|log_filename = "%name.%Y%m%d.log"|log_filename = "ampache.log"|g' config/ampache.cfg.php
+
+touch /var/log/ampache.log
+chmod a+rw /var/log/ampache.log
+php-fpm &> /var/log/php.log &
+
+# Output the debug logs and the php-fpm process
+tail --lines=1 --follow --retry /var/log/php.log /var/log/ampache.log
+
+# Kill the php-fpm process
+kill %1

--- a/docker/php/cmd.sh
+++ b/docker/php/cmd.sh
@@ -28,10 +28,9 @@ bin/cli admin:addUser \
 
 # https://xdebug.org/docs/step_debug#configure
 # https://stackoverflow.com/questions/48026670/configure-xdebug-in-php-fpm-docker-container#48243590
-# configure xdebug to connect to port 9000 on the host by default
+# configure xdebug to connect to port 9003 on the host by default
 
-case "${XDEBUG_SESSION}" in
-  "true"|"1"|"one"|"yes")
+if [[ "${XDEBUG_SESSION:-}" = "1" ]] ; then
     echo "Enabling XDEBUG remote session"
     echo "
     xdebug.mode=debug
@@ -39,7 +38,6 @@ case "${XDEBUG_SESSION}" in
     xdebug.client_port=${XDEBUG_PORT:-9003}
     xdebug.client_host=${XDEBUG_HOST:-host.docker.internal}
     " > /usr/local/etc/php/conf.d/xdebug.ini
-    ;;
-esac
+fi
 
 exec php-fpm

--- a/docker/php/cmd.sh
+++ b/docker/php/cmd.sh
@@ -21,6 +21,10 @@ bin/installer install \
     --ampachedbuser ampache \
     --ampachedbpassword ampache\
     --webpath "/public"
+# Point to redis container
+sed -i -e 's/.*memory_cache =.*/memory_cache = "true"/g' config/ampache.cfg.php
+sed -i -e 's/.*redis_host =.*/redis_host = "redis"/g' config/ampache.cfg.php
+sed -i -e 's/.*redis_port =.*/redis_port = 6379/g' config/ampache.cfg.php
 chmod a+rw config/ampache.cfg.php
 
 # Add admin user if necessary

--- a/docker/php/cmd.sh
+++ b/docker/php/cmd.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 set -xeuo pipefail
+# Execute commands without XDEBUG
+rm -f /usr/local/etc/php/conf.d/xdebug.ini
+
 composer install
 
 # Give access to all dirs
 find -type d -exec chmod +rx '{}' \;
 # Give read access to all files
 chmod -R +r .
-
-# Execute commands without XDEBUG
-rm -f /usr/local/etc/php/conf.d/xdebug.ini
+# Ensure /media can be written to
+chmod 777 /media/
 
 # Install ampache (install db and write config)
 bin/installer install \

--- a/docker/php/cmd.sh
+++ b/docker/php/cmd.sh
@@ -16,8 +16,10 @@ chmod 777 /media/
 bin/installer install \
     --dbhost db \
     --dbname ampache \
-    --dbuser ampache \
-    --dbpassword ampache \
+    --dbuser root \
+    --dbpassword secret \
+    --ampachedbuser ampache \
+    --ampachedbpassword ampache\
     --webpath "/public"
 chmod a+rw config/ampache.cfg.php
 

--- a/docker/php/fpm.conf
+++ b/docker/php/fpm.conf
@@ -1,0 +1,5 @@
+[global]
+daemonize = no
+
+[www]
+listen = 0.0.0.0:9000

--- a/docker/volumes/media/README.md
+++ b/docker/volumes/media/README.md
@@ -1,0 +1,3 @@
+Add you media files in here to be available in the `ampache` service.
+
+They are ignored by git, so you don't run the danger of committing them.

--- a/src/Module/Cli/AdminAddUserCommand.php
+++ b/src/Module/Cli/AdminAddUserCommand.php
@@ -55,11 +55,26 @@ final class AdminAddUserCommand extends Command
         $values     = $this->values();
         $interactor = $this->io();
 
+        $email = $values['website'];
+        if ($email) {
+            $user = User::get_from_email($email);
+            if ($user != null) {
+                $interactor->error(T_('User with email already exists'), true);
+                return;
+            }
+        } else {
+            $user = User::get_from_username($username);
+            if ($user) {
+                $interactor->error(T_('User with username already exists'), true);
+                return;
+            }
+        }
+
         $result = (int) User::create(
             $username,
             $values['name'],
             $values['email'],
-            $values['website'],
+            $email,
             $values['password'],
             $values['level']
         );

--- a/src/Module/Cli/AdminAddUserCommand.php
+++ b/src/Module/Cli/AdminAddUserCommand.php
@@ -64,7 +64,7 @@ final class AdminAddUserCommand extends Command
             }
         } else {
             $user = User::get_from_username($username);
-            if ($user) {
+            if ($user->id) {
                 $interactor->error(T_('User with username already exists'), true);
                 return;
             }


### PR DESCRIPTION
# Intro

[Redis] is an in memory data-store with a versatile API and a wealth of clients.
Since ampache is often run in a multi-process environment (PHP FPM e.g), the memory of a single PHP instance dies when then process dies.
Externalising the cache to another process is what redis takes care of for `database_object` subclasses.

**Sorry about the docker stuff!** Once #3119 is merged (or not) I'll know whether to keep it.

# Questions

This is still a draft, but feedback would be great!

## Where else should this be used?

Probably there are other places where the memory cache is used 

## How should the cache be filled?

It seems like only items that are accessed at least once are added to the cache, however certain objects can consist of many other objects that aren't yet in the cache (notably playlists). [\Ampache\Module\Util\Cron::run_cron_cache](https://github.com/ampache/ampache/blob/743782319d3692e9cf1f6084ce450131f8798446/src/Module/Util/Cron.php#L88) was deprecated in a10da55b8659f9d7fd801c267348a305432e52dc and would seem like a great command to run periodically in order to refresh the cache.

----------------------

Related to #2382

[Redis]: https://redis.io