### PR TITLE
Improve description of rss feed

### DIFF
--- a/src/Module/Util/AmpacheRss.php
+++ b/src/Module/Util/AmpacheRss.php
@@ -284,11 +284,12 @@ class AmpacheRss
             $is_allowed_recent  = ($user) ? $user->id == $row_id : $has_allowed_recent;
             if ($song->enabled && $is_allowed_recent) {
                 $song->format();
+                $description =  '<p>' . T_('User') . ': ' . $client->username . '</p><p>' . T_('Title') . ': ' . $song->f_name . '</p><p>' . T_('Artist') . ': ' . $song->f_artist_full . '</p><p>' . T_('Album') . ': ' . $song->f_album_full . '</p><p>' . T_('Play date') .': ' . get_datetime($item['date']) . '</p>';
 
                 $xml_array = array(
                     'title' => $song->f_name . ' - ' . $song->f_artist . ' - ' . $song->f_album,
                     'link' => str_replace('&amp;', '&', $song->get_link()),
-                    'description' => $song->title . ' - ' . $song->f_artist_full . ' - ' . $song->f_album_full,
+                    'description' => $description,
                     'comments' => $client->username,
                     'pubDate' => date("r", (int)$item['date'])
                 );


### PR DESCRIPTION
This PR will improve the description of the rss feeds that ampache creates. The new content looks like this:
```
User: my_user
Title: The Song title
Artist: My Artist
Album: The Album Titile
Play date: 21/1/22 19:29

```
Apart from improving a bit the contents so that it is more useful there is an additional benefit: in some RSS readers (like Akregator), if the description of the feed does not change with respect to the stored feed items then it is considered as the same feed item. If a song is played twice within the 10 last feed items then it appears as only one played item. With this change it will appear as two distinct items with a different play timestamp.