### PR TITLE
subsonic: Do not send convertArt for album if art does not exist

### DIFF
--- a/src/Module/Api/Subsonic_Xml_Data.php
+++ b/src/Module/Api/Subsonic_Xml_Data.php
@@ -691,7 +691,9 @@ class Subsonic_Xml_Data
         $xalbum->addAttribute('isDir', 'true');
         $xalbum->addAttribute('discNumber', (string)$album->disk);
 
-        $xalbum->addAttribute('coverArt', 'al-' . self::getAlbumId($album->id));
+        if ($album->has_art) {
+            $xalbum->addAttribute('coverArt', 'al-' . self::getAlbumId($album->id));
+        }
         $xalbum->addAttribute('songCount', (string) $album->song_count);
         $xalbum->addAttribute('created', date("c", (int)$album->addition_time));
         $xalbum->addAttribute('duration', (string) $album->total_duration);


### PR DESCRIPTION
This PR will avoid sending the cover art for albums that do not have art. This prevents errors when the client will ask for a non-existing art.
It would fix #3149.