### PR TITLE
fix uninitialized var access

### DIFF
--- a/src/Module/Catalog/Catalog_Seafile.php
+++ b/src/Module/Catalog/Catalog_Seafile.php
@@ -50,7 +50,7 @@ class Catalog_Seafile extends Catalog
     private static $description = 'Seafile Remote Catalog';
     private static $table_name  = 'catalog_seafile';
 
-    private int $count;
+    private int $count = 0;
     private SeafileAdapter $seafile;
 
     /**


### PR DESCRIPTION
Error Typed property Ampache\Module\Catalog\Catalog_Seafile::$count must not be accessed before initialization
(thrown in src/Module/Catalog/Catalog_Seafile.php:340)

Stack Trace:

  0) Ampache\Module\Catalog\Catalog_Seafile->insert_song()
     at src/Module/Catalog/Catalog_Seafile.php:285
  1) Ampache\Module\Catalog\Catalog_Seafile->Ampache\Module\Catalog\{closure}()
     at src/Module/Catalog/SeafileAdapter.php:268
  2) Ampache\Module\Catalog\SeafileAdapter->for_all_files()
     at src/Module/Catalog/SeafileAdapter.php:266
  3) Ampache\Module\Catalog\SeafileAdapter->for_all_files()
     at src/Module/Catalog/Catalog_Seafile.php:297
  4) Ampache\Module\Catalog\Catalog_Seafile->add_to_catalog()
     at src/Module/Catalog/Update/UpdateCatalog.php:111
  5) Ampache\Module\Catalog\Update\UpdateCatalog->update()
     at src/Module/Cli/UpdateCatalogCommand.php:69
  6) Ampache\Module\Cli\UpdateCatalogCommand->execute()
     at vendor/adhocore/cli/src/Application.php:366
  7) Ahc\Cli\Application->doAction()
     at vendor/adhocore/cli/src/Application.php:280
  8) Ahc\Cli\Application->handle()
     at bin/cli:75