### PR TITLE
Update help with the default actions

### DIFF
--- a/src/Module/Cli/UpdateCatalogCommand.php
+++ b/src/Module/Cli/UpdateCatalogCommand.php
@@ -34,7 +34,7 @@ final class UpdateCatalogCommand extends Command
     public function __construct(
         UpdateCatalogInterface $updateCatalog
     ) {
-        parent::__construct('run:updateCatalog', T_('Perform catalog actions for all files of a catalog'));
+        parent::__construct('run:updateCatalog', T_('Perform catalog actions for all files of a catalog. If no options are given, the defaults actions -ceag are assumed'));
 
         $this->updateCatalog   = $updateCatalog;
 


### PR DESCRIPTION
This is a minor improvement after #3041 to add the default actions in the help of cli run:updateCatalog --help