### PR TITLE
sql bulk query to speed up playlist streaming

### DIFF
--- a/src/Module/Playback/Stream_Playlist.php
+++ b/src/Module/Playback/Stream_Playlist.php
@@ -144,7 +144,7 @@ class Stream_Playlist
         $sql .= 'INSERT INTO `stream_playlist` (' . implode(',', $fields) . ') VALUES ';
 
         foreach ($holders_arr as $placeholder) {
-            $sql .= ' (' . implode(',', $placeholder) . ' ) ,';
+            $sql .= '(' . implode(',', $placeholder) . '),';
         }
         // remove last comma
         $sql = substr($sql, 0, -1);

--- a/src/Module/Playback/Stream_Playlist.php
+++ b/src/Module/Playback/Stream_Playlist.php
@@ -93,12 +93,12 @@ class Stream_Playlist
         debug_event("stream_playlist.class", "Adding url {" . json_encode($url) . "}...", 5);
 
         $this->urls[] = $url;
-        $fields       = array();
-        $fields[]     = '`sid`';
-        $values       = array();
-        $values[]     = $this->id;
-        $holders      = array();
-        $holders[]    = '?';
+        $fields    = array();
+        $fields[]  = '`sid`';
+        $values    = array();
+        $values[]  = $this->id;
+        $holders   = array();
+        $holders[] = '?';
 
         foreach ($url->properties as $field) {
             if ($url->$field) {
@@ -119,17 +119,17 @@ class Stream_Playlist
     private function _add_urls($urls)
     {
         debug_event("stream_playlist.class", "Adding urls to {" . $this->id . "}...", 5);
-        $sql    = '';
-        $values = array();
+        $sql         = '';
+        $values      = array();
         $holders_arr = array();
 
         foreach ($urls as $url) {
             $this->urls[] = $url;
-            $fields       = array();
-            $fields[]     = '`sid`';
-            $values[]     = $this->id;
-            $holders      = array();
-            $holders[]    = '?';
+            $fields    = array();
+            $fields[]  = '`sid`';
+            $values[]  = $this->id;
+            $holders   = array();
+            $holders[] = '?';
 
             foreach ($url->properties as $field) {
                 if ($url->$field !== null) {
@@ -138,18 +138,17 @@ class Stream_Playlist
                     $holders[] = '?';
                 }
             }
-
             $holders_arr[] = $holders;
         }
 
         $sql .= 'INSERT INTO `stream_playlist` (' . implode(',', $fields) . ') VALUES ';
 
-        foreach ($holders_arr as $t) {
-            $sql .= ' (' . implode(',', $t) . ' ) ,';
+        foreach ($holders_arr as $placeholder) {
+            $sql .= ' (' . implode(',', $placeholder) . ' ) ,';
         }
-        #remove last comma
+        // remove last comma
         $sql = substr($sql, 0, -1);
-        $sql .= '; ';
+        $sql .= ';';
 
         return Dba::write($sql, $values);
     }

--- a/src/Module/Playback/Stream_Playlist.php
+++ b/src/Module/Playback/Stream_Playlist.php
@@ -121,6 +121,8 @@ class Stream_Playlist
         debug_event("stream_playlist.class", "Adding urls to {" . $this->id . "}...", 5);
         $sql    = '';
         $values = array();
+        $holders_arr = array();
+
         foreach ($urls as $url) {
             $this->urls[] = $url;
             $fields       = array();
@@ -136,8 +138,18 @@ class Stream_Playlist
                     $holders[] = '?';
                 }
             }
-            $sql .= 'INSERT INTO `stream_playlist` (' . implode(',', $fields) . ') VALUES (' . implode(',', $holders) . '); ';
+
+            $holders_arr[] = $holders;
         }
+
+        $sql .= 'INSERT INTO `stream_playlist` (' . implode(',', $fields) . ') VALUES ';
+
+        foreach ($holders_arr as $t) {
+            $sql .= ' (' . implode(',', $t) . ' ) ,';
+        }
+        #remove last comma
+        $sql = substr($sql, 0, -1);
+        $sql .= '; ';
 
         return Dba::write($sql, $values);
     }


### PR DESCRIPTION
This patch create a big sql query instead that a long list of  single queries.  The method is way faster.
The only downside that i think is that, in case of huge playlists ( like 10000 or more ) the server could not hanlde it. But i think that huge playlists are already a problem.

It partially solves #2626 , does not handle the first part of the problem, the url creation, but the speed up big ( like 80% less time )
