### PR TITLE
Remove duplicates and order largest to smallest for LastFM art collector

### DIFF
--- a/src/Module/Art/Collector/LastFmCollectorModule.php
+++ b/src/Module/Art/Collector/LastFmCollectorModule.php
@@ -129,6 +129,10 @@ final class LastFmCollectorModule implements CollectorModuleInterface
             );
         }
 
-        return $images;
+        // Drop any duplicates
+        $images = array_map("unserialize", array_unique(array_map("serialize", $images)));
+
+        // Order is smallest to largest so reverse it
+        return array_reverse($images);
     }
 }


### PR DESCRIPTION
Fixes #2268 

Example is the last row

**Before**

![firefox_I6hvXGq2BQ](https://user-images.githubusercontent.com/5735900/166148021-7a8f66bc-82f9-4903-ad8f-850118f57c01.jpg)


**After**

![firefox_O25OwPhjPQ](https://user-images.githubusercontent.com/5735900/166148032-a93cdca9-c261-4cd5-aaec-402a2f766b3c.jpg)

