### PR TITLE
Division of sql bulk query in  chunks

### DIFF
--- a/src/Module/Playback/Stream_Playlist.php
+++ b/src/Module/Playback/Stream_Playlist.php
@@ -141,9 +141,8 @@ class Stream_Playlist
             $holders_arr[] = $holders;
 	}
 
-	$holders_chunks = array_chunk( $holders_arr, 500 );
-        
-        foreach( $holders_chunks as $holders_arr_temp) {
+	$holders_chunks = array_chunk($holders_arr, 500);
+        foreach ($holders_chunks as $holders_arr_temp) {
             $sql .= 'INSERT INTO `stream_playlist` (' . implode(',', $fields) . ') VALUES ';
             
             foreach ($holders_arr_temp as $placeholder) {

--- a/src/Module/Playback/Stream_Playlist.php
+++ b/src/Module/Playback/Stream_Playlist.php
@@ -139,16 +139,20 @@ class Stream_Playlist
                 }
             }
             $holders_arr[] = $holders;
-        }
+	}
 
-        $sql .= 'INSERT INTO `stream_playlist` (' . implode(',', $fields) . ') VALUES ';
-
-        foreach ($holders_arr as $placeholder) {
-            $sql .= '(' . implode(',', $placeholder) . '),';
+	$holders_chunks = array_chunk( $holders_arr, 500 );
+        
+        foreach( $holders_chunks as $holders_arr_temp) {
+            $sql .= 'INSERT INTO `stream_playlist` (' . implode(',', $fields) . ') VALUES ';
+            
+            foreach ($holders_arr_temp as $placeholder) {
+                $sql .= '(' . implode(',', $placeholder) . '),';
+            }
+            // remove last comma
+            $sql = substr($sql, 0, -1);
+            $sql .= ';';
         }
-        // remove last comma
-        $sql = substr($sql, 0, -1);
-        $sql .= ';';
 
         return Dba::write($sql, $values);
     }


### PR DESCRIPTION
This patch divides the sql query in chunks of length 500, the impact on the performance is negiglible ( for 10000 items are 20 queries instead 10000, for 100000 are 200 and so on... and the bottleneck for those numbers is the server ), but avoid to  risk to overload the server. Btw, with list bigger than 2-3000 items the browser start to show some problem ( firefox start complaining that the page is too slow and it is better to block )