### PR TITLE
Remove the entry on album_map only if it is the last song of an album

### DIFF
--- a/src/Repository/Model/Catalog.php
+++ b/src/Repository/Model/Catalog.php
@@ -2323,7 +2323,7 @@ abstract class Catalog extends database_object
             $not_found = !in_array($existing_map, $songArtist_array);
             // remove album song map if song artist is changed OR album changes
             if ($not_found || ($song->album != $new_song->album)) {
-                Album::remove_album_map($song->album, 'song', $existing_map);
+                Album::check_album_map($song->album, 'song', $existing_map);
                 $map_change = true;
             }
             // only delete play count on song artist change


### PR DESCRIPTION
Testing album_map update, the code removed the artist entry without checking if the song is the last of an artist ( not album_artist ) in an album. This patch solve this issue.