### PR TITLE
Fix db query error in xbmc localplay

### DIFF
--- a/src/Module/Playback/Localplay/Xbmc/AmpacheXbmc.php
+++ b/src/Module/Playback/Localplay/Xbmc/AmpacheXbmc.php
@@ -130,7 +130,7 @@ class AmpacheXbmc extends localplay_controller
             ? Core::get_global('user')->id
             : -1;
 
-        return Dba::query($sql, array($data['name'] ?? null, $data['host'] ?? null, $data['port'] ?? null, $data['user'] ?? null, $data['password'] ?? null, $user_id));
+        return Dba::query($sql, array($data['name'] ?? null, $data['host'] ?? null, $data['port'] ?? null, $data['user'] ?? null, $data['pass'] ?? null, $user_id));
     } // add_instance
 
     /**


### PR DESCRIPTION
The correct name of the field is pass, not password