### PR TITLE
Fix autoplay in xbmc localplay

### DIFF
--- a/src/Module/Playback/Localplay/Xbmc/AmpacheXbmc.php
+++ b/src/Module/Playback/Localplay/Xbmc/AmpacheXbmc.php
@@ -325,9 +325,9 @@ class AmpacheXbmc extends localplay_controller
 
         try {
             // XBMC requires to load a playlist to play. We don't know if this play is after a new playlist or after pause
-            // So we get current status
-            $status = $this->status();
-            if ($status['state'] == 'stop') {
+            // So we get active players
+            $xbmc_players = $this->_xbmc->Player->GetActivePlayers();
+            if (empty($xbmc_players)) {
                 $this->_xbmc->Player->Open(array(
                     'item' => array('playlistid' => $this->_playlistId)
                 ));

--- a/src/Module/Playback/Localplay/Xbmc/AmpacheXbmc.php
+++ b/src/Module/Playback/Localplay/Xbmc/AmpacheXbmc.php
@@ -333,7 +333,7 @@ class AmpacheXbmc extends localplay_controller
                 ));
             } else {
                 $this->_xbmc->Player->PlayPause(array(
-                    'playerid' => $this->_playlistId,
+                    'playerid' => $this->_playerId,
                     'play' => true
                 ));
             }


### PR DESCRIPTION
Not perfect patch, but a working one.
Fixes autoplay when playlist is new.
Do not autoplay when another song is playing ( changing playlist ) , cause both have the same id.
It should be better to place getActivePlayers in the status, but i have no idea ho to do it.