### PR TITLE
Localplay compatibility with kodi plugin

### DIFF
--- a/src/Module/Playback/Localplay/Xbmc/AmpacheXbmc.php
+++ b/src/Module/Playback/Localplay/Xbmc/AmpacheXbmc.php
@@ -617,7 +617,7 @@ class AmpacheXbmc extends localplay_controller
                 $data['id']    = $i;
                 $data['track'] = $i + 1;
 
-                $url_data = $this->parse_url($data['link']);
+                $url_data = $this->parse_url(rawurldecode($data['link']));
                 if ($url_data != null) {
                     $data['oid'] = $url_data['oid'];
                     $song        = new Song($data['oid']);
@@ -678,7 +678,7 @@ class AmpacheXbmc extends localplay_controller
                 ));
                 $array['repeat'] = ($playprop['repeat'] != "off");
                 $array['random'] = (strtolower($playprop['shuffled']) == 1);
-                $array['track']  = $currentplay['file'];
+                $array['track']  = rawurldecode($currentplay['file']);
 
                 $url_data = $this->parse_url($array['track']);
                 $song     = new Song($url_data['oid']);

--- a/src/Module/Playback/Localplay/localplay_controller.php
+++ b/src/Module/Playback/Localplay/localplay_controller.php
@@ -149,7 +149,7 @@ abstract class localplay_controller
 
         //beautiful urls need their own parsing as parse_url will find nothing.
         if (AmpConfig::get('stream_beautiful_url')) {
-            preg_match('/oid\/(.*?)\//', $url, $match);
+            preg_match('/oid[\=|\/](.*?)[\&|\/]/', $url, $match);
             if (array_key_exists(1, $match) && $match[1]) {
                 return array(
                     'primary_key' => 'oid',


### PR DESCRIPTION
Changed regex to match also oid= pattern, added rawurldecode to clean %20 like patterns. Now localplay sees the plugin songs. Tested also with mpd, no apparent issues.