### PR TITLE
Correct sql result field in getRandom artist

### DIFF
--- a/src/Repository/ArtistRepository.php
+++ b/src/Repository/ArtistRepository.php
@@ -74,7 +74,7 @@ final class ArtistRepository implements ArtistRepositoryInterface
         $db_results = Dba::read($sql);
 
         while ($row = Dba::fetch_assoc($db_results)) {
-            $results[] = (int) $row['id'];
+            $results[] = (int) $row['artist_id'];
         }
 
         return $results;


### PR DESCRIPTION
The sql result gives an array where artist_id is the name of the field , but the function checks id as name. This broke random artists function.