### PR TITLE
Add the default filter group to the create user call.

### DIFF
--- a/src/Module/Application/Login/DefaultAction.php
+++ b/src/Module/Application/Login/DefaultAction.php
@@ -231,10 +231,10 @@ final class DefaultAction implements ApplicationActionInterface
                 $website  = array_key_exists('website', $auth) ? $auth['website'] : '';
                 $state    = array_key_exists('state', $auth) ? $auth['state'] : '';
                 $city     = array_key_exists('city', $auth) ? $auth['city'] : '';
-                $fg       = 0; //This is the default filter group
+                $dfg       = 0; //This is the default filter group
 
                 // Attempt to create the user
-                $user_id = User::create($username, $fullname, $email, $website, hash('sha256', bin2hex(random_bytes(20))), $access, $fg, $state, $city);
+                $user_id = User::create($username, $fullname, $email, $website, hash('sha256', bin2hex(random_bytes(20))), $access, $dfg, $state, $city);
                 if ($user_id > 0) {
                     // tell me you're creating the user
                     $this->logger->info(

--- a/src/Module/Application/Login/DefaultAction.php
+++ b/src/Module/Application/Login/DefaultAction.php
@@ -231,7 +231,7 @@ final class DefaultAction implements ApplicationActionInterface
                 $website  = array_key_exists('website', $auth) ? $auth['website'] : '';
                 $state    = array_key_exists('state', $auth) ? $auth['state'] : '';
                 $city     = array_key_exists('city', $auth) ? $auth['city'] : '';
-                $dfg       = 0; //This is the default filter group
+                $dfg      = 0; // This is the default filter group
 
                 // Attempt to create the user
                 $user_id = User::create($username, $fullname, $email, $website, hash('sha256', bin2hex(random_bytes(20))), $access, $dfg, $state, $city);

--- a/src/Module/Application/Login/DefaultAction.php
+++ b/src/Module/Application/Login/DefaultAction.php
@@ -231,9 +231,10 @@ final class DefaultAction implements ApplicationActionInterface
                 $website  = array_key_exists('website', $auth) ? $auth['website'] : '';
                 $state    = array_key_exists('state', $auth) ? $auth['state'] : '';
                 $city     = array_key_exists('city', $auth) ? $auth['city'] : '';
+                $fg       = 0; //This is the default filter group
 
                 // Attempt to create the user
-                $user_id = User::create($username, $fullname, $email, $website, hash('sha256', bin2hex(random_bytes(20))), $access, $state, $city);
+                $user_id = User::create($username, $fullname, $email, $website, hash('sha256', bin2hex(random_bytes(20))), $access, $fg, $state, $city);
                 if ($user_id > 0) {
                     // tell me you're creating the user
                     $this->logger->info(


### PR DESCRIPTION
Add the default filter group ID to the create user call.  Use a variable name instead of a constant.
Closes #3308 