### PR TITLE
Fix album time update when time is NULL

### DIFF
--- a/src/Repository/Model/Album.php
+++ b/src/Repository/Model/Album.php
@@ -1404,7 +1404,7 @@ class Album extends database_object implements library_item
     {
         debug_event(__CLASS__, 'update_album_counts', 5);
         // album.time
-        $sql = "UPDATE `album`, (SELECT SUM(`song`.`time`) AS `time`, `song`.`album` FROM `song` GROUP BY `song`.`album`) AS `song` SET `album`.`time` = `song`.`time` WHERE `album`.`time` != `song`.`time` AND `album`.`id` = `song`.`album`;";
+        $sql = "UPDATE `album`, (SELECT SUM(`song`.`time`) AS `time`, `song`.`album` FROM `song` GROUP BY `song`.`album`) AS `song` SET `album`.`time` = `song`.`time` WHERE `album`.`id` = `song`.`album` AND ((`album`.`time` != `song`.`time`) OR (`album`.`time` IS NULL AND `song`.`time` > 0));";
         Dba::write($sql);
         // album.addition_time
         $sql = "UPDATE `album`, (SELECT MIN(`song`.`addition_time`) AS `addition_time`, `song`.`album` FROM `song` GROUP BY `song`.`album`) AS `song` SET `album`.`addition_time` = `song`.`addition_time` WHERE `album`.`addition_time` != `song`.`addition_time` AND `song`.`album` = `album`.`id`;";


### PR DESCRIPTION
Hi there,
Thanks a lot for this amazing software I'm using for such a long time!
The initial issue was that new album didn't get the time column filled in.
I fixed the album time value not updated when the initial value is `NULL`. The initial value should be `0` instead of `NULL` if we expect an integer, don't your think?
Have a nice day!