### PR TITLE
Fix 304 for images

### DIFF
--- a/src/Module/Application/Image/ShowAction.php
+++ b/src/Module/Application/Image/ShowAction.php
@@ -230,7 +230,7 @@ final class ShowAction implements ApplicationActionInterface
             if (!empty($etag)) {
                 $response = $response->withHeader(
                     'ETag',
-                    '"'.$etag.'"'
+                    '"' . $etag . '"'
                 )->withHeader(
                     'Expires',
                     gmdate('D, d M Y H:i:s \G\M\T', time() + (60 * 60 * 24 * 7)) // 7 day
@@ -247,7 +247,7 @@ final class ShowAction implements ApplicationActionInterface
             $reqheaders = getallheaders();
             if (is_array($reqheaders) && array_key_exists('If-Modified-Since', $reqheaders) && array_key_exists('If-None-Match', $reqheaders)) {
                 if (!array_key_exists('Cache-Control', $reqheaders) || (array_key_exists('Cache-Control', $reqheaders) && $reqheaders['Cache-Control'] != 'no-cache')) {
-                    $cetag  = str_replace('"','', $reqheaders['If-None-Match'] );
+                    $cetag  = str_replace('"','', $reqheaders['If-None-Match']);
                     // Same image than the cached one? Use the cache.
                     if ($cetag == $etag) {
                         return $response->withStatus(304);

--- a/src/Module/Application/Image/ShowAction.php
+++ b/src/Module/Application/Image/ShowAction.php
@@ -183,21 +183,8 @@ final class ShowAction implements ApplicationActionInterface
 
             $art = new Art($object_id, $type, $kind);
             $art->has_db_info();
+
             $etag = $art->id;
-
-            // That means the client has a cached version of the image
-            $reqheaders = getallheaders();
-            if (is_array($reqheaders) && array_key_exists('If-Modified-Since', $reqheaders) && array_key_exists('If-None-Match', $reqheaders)) {
-                if (!array_key_exists('Cache-Control', $reqheaders) || (array_key_exists('Cache-Control', $reqheaders) && $reqheaders['Cache-Control'] != 'no-cache')) {
-                    $cetagf = explode('-', $reqheaders['If-None-Match']);
-                    $cetag  = $cetagf[0];
-                    // Same image than the cached one? Use the cache.
-                    if ($cetag == $etag) {
-                        return $response->withStatus(304);
-                    }
-                }
-            }
-
             if (!$art->raw_mime) {
                 $rootimg = sprintf(
                     '%s/../../../../public/%s/images/',
@@ -243,7 +230,10 @@ final class ShowAction implements ApplicationActionInterface
             if (!empty($etag)) {
                 $response = $response->withHeader(
                     'ETag',
-                    $etag
+                    '"'.$etag.'"'
+                )->withHeader(
+                    'Expires',
+                    gmdate('D, d M Y H:i:s \G\M\T', time() + (60 * 60 * 24 * 7)) // 7 day
                 )->withHeader(
                     'Cache-Control',
                     'private'
@@ -251,6 +241,18 @@ final class ShowAction implements ApplicationActionInterface
                     'Last-Modified',
                     gmdate('D, d M Y H:i:s \G\M\T', time())
                 );
+            }
+
+            // That means the client has a cached version of the image
+            $reqheaders = getallheaders();
+            if (is_array($reqheaders) && array_key_exists('If-Modified-Since', $reqheaders) && array_key_exists('If-None-Match', $reqheaders)) {
+                if (!array_key_exists('Cache-Control', $reqheaders) || (array_key_exists('Cache-Control', $reqheaders) && $reqheaders['Cache-Control'] != 'no-cache')) {
+                    $cetag  = str_replace('"','', $reqheaders['If-None-Match'] );
+                    // Same image than the cached one? Use the cache.
+                    if ($cetag == $etag) {
+                        return $response->withStatus(304);
+                    }
+                }
             }
 
             $headers = $this->horde_browser->getDownloadHeaders($filename, $mime, true);


### PR DESCRIPTION
Hi,

I found several issues in the actual implementation of the ETag header to enable 304 responses.

- Based on file https://github.com/ampache/ampache/blob/2ca159ba032fd1921438b27a4eb4b280f4719d0c/src/Module/Application/Image/ShowAction.php : ETag is compared at line L195 but is modified at line L230 (yes there is an explode at line L192 but, still, it isn't the same image).
- ETag should be betwen `"`
- 304 responses must have ETag header, or the next answer won't be cached.
- Expires headers is recommended with ETag