### PR TITLE
Update Upnp_Api.php

### DIFF
--- a/src/Module/Api/Upnp_Api.php
+++ b/src/Module/Api/Upnp_Api.php
@@ -292,9 +292,9 @@ class Upnp_Api
     {
         $retArr = array();
         $reader = new XMLReader();
-        $result = XMLReader::XML($prmRequest);
+        $result = $reader->XML( $prmRequest );
         if (!$result) {
-            debug_event(self::class, 'XML reader failed', 5);
+            debug_event(self::class, 'XML reader class setup failed', 5);
         }
 
         while ($reader->read()) {


### PR DESCRIPTION
Fix deprecated old php syntax no longer acceptable at line 295, update error message 2 lines later