### PR TITLE
Catalog: Stop filtering items beginning with a "."

### DIFF
--- a/src/Module/Catalog/Catalog_local.php
+++ b/src/Module/Catalog/Catalog_local.php
@@ -283,8 +283,7 @@ class Catalog_local extends Catalog
 
         /* Recurse through this dir and create the files array */
         while (false !== ($file = readdir($handle))) {
-            /* Skip to next if we've got . or .. */
-            if (substr($file, 0, 1) == '.') {
+            if ('.' === $file || '..' === $file) {
                 continue;
             }
             // reduce the crazy log info


### PR DESCRIPTION
This is preventing legitimate directories and files from being scanned into the catalog. ("Legitimate" here meaning files and directories where the name matches that of the album or track, such as "...Like Clockwork".

This style of skipping the pseudo-directories is consistent with that of src/Repository/Model/Art.php.

fixes #3422