### PR TITLE
Add possibility to export just one playlist

### DIFF
--- a/src/Module/Cli/ExportPlaylistCommand.php
+++ b/src/Module/Cli/ExportPlaylistCommand.php
@@ -48,7 +48,7 @@ final class ExportPlaylistCommand extends Command
             ->argument('<directory>', T_('Output directory'))
             ->argument('[extension]', T_("Output type ('m3u', 'xspf', 'pls'), (default: m3u)"), 'm3u')
             ->argument('<type>', T_("Playlist type ('albums', 'artists', 'playlists'), (default: playlists)"), 'playlists')
-            ->argument('[playlistid]', T_("A playlist ID"), '-1' )
+            ->argument('[playlistid]', T_("A playlist ID"), '-1')
             ->usage('<bold>  export:playlist</end> <comment>playlist /tmp m3u</end> ## ' . T_('Export playlists as m3u files to /tmp') . '<eol/>');
     }
 

--- a/src/Module/Cli/ExportPlaylistCommand.php
+++ b/src/Module/Cli/ExportPlaylistCommand.php
@@ -48,13 +48,15 @@ final class ExportPlaylistCommand extends Command
             ->argument('<directory>', T_('Output directory'))
             ->argument('[extension]', T_("Output type ('m3u', 'xspf', 'pls'), (default: m3u)"), 'm3u')
             ->argument('<type>', T_("Playlist type ('albums', 'artists', 'playlists'), (default: playlists)"), 'playlists')
+            ->argument('[playlistid]', T_("A playlist ID"), '-1' )
             ->usage('<bold>  export:playlist</end> <comment>playlist /tmp m3u</end> ## ' . T_('Export playlists as m3u files to /tmp') . '<eol/>');
     }
 
     public function execute(
         string $type,
         string $directory,
-        string $extension
+        string $extension,
+        string $playlistid,
     ): void {
         if (!in_array($extension, PlaylistExporter::VALID_FILE_EXTENSIONS)) {
             $extension = current(PlaylistExporter::VALID_FILE_EXTENSIONS);
@@ -64,7 +66,8 @@ final class ExportPlaylistCommand extends Command
             $this->app()->io(),
             $directory,
             $type,
-            $extension
+            $extension,
+            $playlistid
         );
     }
 }

--- a/src/Module/Playlist/PlaylistExporter.php
+++ b/src/Module/Playlist/PlaylistExporter.php
@@ -63,15 +63,17 @@ final class PlaylistExporter implements PlaylistExporterInterface
                 break;
             case 'playlists':
             default:
-                if ( $playlist_id == -1 or is_null($playlist_id) ) {
-                    $ids   = Playlist::get_playlists(-1);
+                if ($playlist_id == -1 or is_null($playlist_id)) {
+                    $ids = Playlist::get_playlists(-1);
                 } else {
                     $ids = array($playlist_id);
                 }
                 $items = array();
                 foreach ($ids as $playlistid) {
                     $pl = new Playlist($playlistid);
-                    if (is_null($pl->id)) continue; // This playlist does not exist, skip it
+                    if (is_null($pl->id)) { // If this playlist does not exist, skip it
+                        continue;
+                    }
                     $items[] = $pl;
                 }
                 break;

--- a/src/Module/Playlist/PlaylistExporter.php
+++ b/src/Module/Playlist/PlaylistExporter.php
@@ -38,7 +38,8 @@ final class PlaylistExporter implements PlaylistExporterInterface
         Interactor $interactor,
         string $dirname,
         string $type,
-        string $ext
+        string $ext,
+        string $playlist_id
     ): void {
         // Make sure the output dir is valid and writeable
         if (!is_writeable($dirname)) {
@@ -62,10 +63,16 @@ final class PlaylistExporter implements PlaylistExporterInterface
                 break;
             case 'playlists':
             default:
-                $ids   = Playlist::get_playlists(-1);
+                if ( $playlist_id == -1 or is_null($playlist_id) ) {
+                    $ids   = Playlist::get_playlists(-1);
+                } else {
+                    $ids = array($playlist_id);
+                }
                 $items = array();
                 foreach ($ids as $playlistid) {
-                    $items[] = new Playlist($playlistid);
+                    $pl = new Playlist($playlistid);
+                    if (is_null($pl->id)) continue; // This playlist does not exist, skip it
+                    $items[] = $pl;
                 }
                 break;
         }

--- a/src/Module/Playlist/PlaylistExporterInterface.php
+++ b/src/Module/Playlist/PlaylistExporterInterface.php
@@ -26,5 +26,5 @@ use Ahc\Cli\IO\Interactor;
 
 interface PlaylistExporterInterface
 {
-    public function export(Interactor $interactor, string $dirname, string $type, string $ext): void;
+    public function export(Interactor $interactor, string $dirname, string $type, string $ext, string $playlist_id): void;
 }


### PR DESCRIPTION
`./bin/cli export:playlist /tmp/ezstream-tempo/ m3u playlists` export **all** playlist. Can be quite long.

This patch add an optional parameters to allow export of just one playlist. Example: 
`./bin/cli export:playlist /tmp/ezstream-tempo/ m3u playlists 42`
