### PR TITLE
Various quick fixes / features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ public/.maintenance
 public/play/.htaccess
 public/rest/.htaccess
 public/lib/components
+public/lib/javascript/custom.js
 public/client
 public/newclient
 public/core

--- a/public/templates/create_web_player.inc.php
+++ b/public/templates/create_web_player.inc.php
@@ -24,6 +24,7 @@ use Ampache\Config\AmpConfig;
 use Ampache\Module\Playback\WebPlayer;
 
 ?>
+<!DOCTYPE html>
 <html>
 <head>
 <title><?php echo scrub_out(AmpConfig::get('site_title')); ?></title>

--- a/public/templates/create_web_player_embedded.inc.php
+++ b/public/templates/create_web_player_embedded.inc.php
@@ -24,6 +24,7 @@ use Ampache\Config\AmpConfig;
 use Ampache\Module\Playback\WebPlayer;
 
 ?>
+<!DOCTYPE html>
 <html>
 <head>
 <title><?php echo scrub_out(AmpConfig::get('site_title')); ?></title>

--- a/public/templates/header.inc.php
+++ b/public/templates/header.inc.php
@@ -119,6 +119,9 @@ $jQueryContextMenu = (is_dir(__DIR__ . '/../lib/components/jquery-contextmenu'))
         <script src="<?php echo $web_path; ?>/lib/javascript/base.js" defer></script>
         <script src="<?php echo $web_path; ?>/lib/javascript/ajax.js" defer></script>
         <script src="<?php echo $web_path; ?>/lib/javascript/tools.js" defer></script>
+        <?php if ( file_exists( __DIR__.'/../lib/javascript/custom.js') ) { ?>
+            <script src="<?php echo $web_path; ?>/lib/javascript/custom.js" defer></script>
+        <?php } // file exists custom.js ?>
 
         <script>
             $(document).ready(function(){

--- a/public/templates/header.inc.php
+++ b/public/templates/header.inc.php
@@ -119,9 +119,9 @@ $jQueryContextMenu = (is_dir(__DIR__ . '/../lib/components/jquery-contextmenu'))
         <script src="<?php echo $web_path; ?>/lib/javascript/base.js" defer></script>
         <script src="<?php echo $web_path; ?>/lib/javascript/ajax.js" defer></script>
         <script src="<?php echo $web_path; ?>/lib/javascript/tools.js" defer></script>
-        <?php if (file_exists( __DIR__.'/../lib/javascript/custom.js')) { ?>
+        <?php if (file_exists(__DIR__ . '/../lib/javascript/custom.js')) { ?>
             <script src="<?php echo $web_path; ?>/lib/javascript/custom.js" defer></script>
-        <?php } // file exists custom.js ?>
+        <?php } // file exists custom.js?>
 
         <script>
             $(document).ready(function(){

--- a/public/templates/header.inc.php
+++ b/public/templates/header.inc.php
@@ -119,7 +119,7 @@ $jQueryContextMenu = (is_dir(__DIR__ . '/../lib/components/jquery-contextmenu'))
         <script src="<?php echo $web_path; ?>/lib/javascript/base.js" defer></script>
         <script src="<?php echo $web_path; ?>/lib/javascript/ajax.js" defer></script>
         <script src="<?php echo $web_path; ?>/lib/javascript/tools.js" defer></script>
-        <?php if ( file_exists( __DIR__.'/../lib/javascript/custom.js') ) { ?>
+        <?php if (file_exists( __DIR__.'/../lib/javascript/custom.js')) { ?>
             <script src="<?php echo $web_path; ?>/lib/javascript/custom.js" defer></script>
         <?php } // file exists custom.js ?>
 

--- a/public/templates/show_video.inc.php
+++ b/public/templates/show_video.inc.php
@@ -140,7 +140,9 @@ if (get_class($video) != Video::class) {
   $videoprops[T_('Frame Rate')]      = scrub_out($video->f_frame_rate);
   $videoprops[T_('Channels')]        = scrub_out($video->channels);
   if (Access::check('interface', 75)) {
-      $videoprops[T_('Filename')]   = scrub_out($video->file) . " " . $video->f_size;
+      $data                       = pathinfo($video->file);
+      $videoprops[T_('Path')]     = scrub_out((string)$data['dirname'] ?? '');
+      $videoprops[T_('Filename')] = scrub_out((string)$data['filename'] ?? '') . " " . $video->f_size;
   }
   if ($video->update_time) {
       $videoprops[T_('Last Updated')]   = get_datetime((int) $video->update_time);

--- a/resources/templates/album_disk_row.xhtml
+++ b/resources/templates/album_disk_row.xhtml
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <td class="cel_play">
         <span class="cel_play_content"> </span>

--- a/resources/templates/album_row.xhtml
+++ b/resources/templates/album_row.xhtml
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <td class="cel_play">
         <span class="cel_play_content"> </span>

--- a/resources/templates/playlist/new_dialog.xhtml
+++ b/resources/templates/playlist/new_dialog.xhtml
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <ul>
     <li>

--- a/resources/templates/playlist_row.xhtml
+++ b/resources/templates/playlist_row.xhtml
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <td class="cel_play">
         <span class="cel_play_content"> </span>

--- a/resources/templates/song.xhtml
+++ b/resources/templates/song.xhtml
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <dl class="media_details" tal:define="song_id SONG/getId">
     <dt i18n:translate="">Rating</dt>

--- a/resources/templates/song_row.xhtml
+++ b/resources/templates/song_row.xhtml
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <td class="cel_play">
         <span class="cel_play_content">

--- a/resources/templates/stats.xhtml
+++ b/resources/templates/stats.xhtml
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <em i18n:translate="">Catalogs</em>
 <table class="tabledata">

--- a/src/Application/Api/Ajax/Handler/SongAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/SongAjaxHandler.php
@@ -83,10 +83,11 @@ final class SongAjaxHandler implements AjaxHandlerInterface
                     echo "shouts = {};\r\n";
                     foreach ($shouts as $shoutsid) {
                         $shout = new Shoutbox($shoutsid);
-                        $key   = (int) ($shout->data);
+                        $key   = (int)$shout->data;
+                        $time  = (int)$media->time;
                         echo "if (typeof shouts['" . $key . "'] === 'undefined') { shouts['" . $key . "'] = new Array(); }\r\n";
                         echo "shouts['" . $key . "'].push('" . addslashes($shout->get_display(false)) . "');\r\n";
-                        echo "$('.waveform-shouts').append('<div style=\'position:absolute; width: 3px; height: 3px; background-color: #2E2EFE; top: 15px; left: " . (((intval($shout->data) / intval($media->time)) * 400) - 1) . "px;\' />');\r\n";
+                        echo "$('.waveform-shouts').append('<div style=\'position:absolute; width: 3px; height: 3px; background-color: #2E2EFE; top: 15px; left: " . ((($key / $time) * 400) - 1) . "px;\' />');\r\n";
                     }
                     echo "</script>\r\n";
                 }

--- a/src/Application/Api/Ajax/Handler/SongAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/SongAjaxHandler.php
@@ -86,7 +86,7 @@ final class SongAjaxHandler implements AjaxHandlerInterface
                         $key   = (int) ($shout->data);
                         echo "if (typeof shouts['" . $key . "'] === 'undefined') { shouts['" . $key . "'] = new Array(); }\r\n";
                         echo "shouts['" . $key . "'].push('" . addslashes($shout->get_display(false)) . "');\r\n";
-                        echo "$('.waveform-shouts').append('<div style=\'position:absolute; width: 3px; height: 3px; background-color: #2E2EFE; top: 15px; left: " . ((($shout->data / $media->time) * 400) - 1) . "px;\' />');\r\n";
+                        echo "$('.waveform-shouts').append('<div style=\'position:absolute; width: 3px; height: 3px; background-color: #2E2EFE; top: 15px; left: " . (((intval($shout->data) / intval($media->time)) * 400) - 1) . "px;\' />');\r\n";
                     }
                     echo "</script>\r\n";
                 }

--- a/src/Gui/Song/SongViewAdapter.php
+++ b/src/Gui/Song/SongViewAdapter.php
@@ -405,8 +405,9 @@ final class SongViewAdapter implements SongViewAdapterInterface
             $songprops[T_('R128 Album Gain')] = scrub_out($this->song->r128_album_gain);
         }
         if ($this->gatekeeper->mayAccess(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_MANAGER)) {
-            $songprops[T_('Path')]     = scrub_out($this->song->folder);
-            $songprops[T_('Filename')] = scrub_out($this->song->filename) . " " . $this->song->f_size;
+            $data                      = pathinfo($this->song->file);
+            $songprops[T_('Path')]     = scrub_out((string)$data['dirname'] ?? '');
+            $songprops[T_('Filename')] = scrub_out((string)$data['filename'] ?? '') . " " . $this->song->f_size;
         }
         if ($this->song->update_time) {
             $songprops[T_('Last Updated')] = get_datetime((int) $this->song->update_time);

--- a/src/Gui/Song/SongViewAdapter.php
+++ b/src/Gui/Song/SongViewAdapter.php
@@ -405,7 +405,7 @@ final class SongViewAdapter implements SongViewAdapterInterface
             $songprops[T_('R128 Album Gain')] = scrub_out($this->song->r128_album_gain);
         }
         if ($this->gatekeeper->mayAccess(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_MANAGER)) {
-            $songprops[T_('Filename')] = scrub_out($this->song->file) . " " . $this->song->f_size;
+            $songprops[T_('Filename')] = scrub_out($this->song->filename) . " " . $this->song->f_size;
         }
         if ($this->song->update_time) {
             $songprops[T_('Last Updated')] = get_datetime((int) $this->song->update_time);

--- a/src/Gui/Song/SongViewAdapter.php
+++ b/src/Gui/Song/SongViewAdapter.php
@@ -405,6 +405,7 @@ final class SongViewAdapter implements SongViewAdapterInterface
             $songprops[T_('R128 Album Gain')] = scrub_out($this->song->r128_album_gain);
         }
         if ($this->gatekeeper->mayAccess(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_MANAGER)) {
+            $songprops[T_('Path')]     = scrub_out($this->song->folder);
             $songprops[T_('Filename')] = scrub_out($this->song->filename) . " " . $this->song->f_size;
         }
         if ($this->song->update_time) {

--- a/src/Module/Api/Daap_Api.php
+++ b/src/Module/Api/Daap_Api.php
@@ -933,7 +933,7 @@ class Daap_Api
         header("Content-type: text/html");
         header("HTTP/1.0 " . $code . " " . $error, true, $code);
 
-        $html = "<html><head><title>" . $error . "</title></head><body><h1>" . $code . " " . $error . "</h1></body></html>";
+        $html = "<!DOCTYPE html><html><head><title>" . $error . "</title></head><body><h1>" . $code . " " . $error . "</h1></body></html>";
         self::apiOutput($html);
 
         return false;

--- a/src/Module/Api/Subsonic_Api.php
+++ b/src/Module/Api/Subsonic_Api.php
@@ -687,12 +687,12 @@ class Subsonic_Api
     public static function getvideoinfo($input, $user)
     {
         unset($user);
-        $videoid = self::_check_parameter($input, 'id');
-        if (!$videoid) {
+        $video_id = self::_check_parameter($input, 'id');
+        if (!$video_id) {
             return;
         }
         $response = Subsonic_Xml_Data::addSubsonicResponse('getvideoinfo');
-        Subsonic_Xml_Data::addVideoInfo($response, $videoid);
+        Subsonic_Xml_Data::addVideoInfo($response, (int)$video_id);
         self::_apiOutput($input, $response, array());
     }
 

--- a/src/Module/Application/Rss/ShowAction.php
+++ b/src/Module/Application/Rss/ShowAction.php
@@ -74,6 +74,9 @@ final class ShowAction implements ApplicationActionInterface
             $params                = [];
             $params['object_type'] = Core::get_request('object_type');
             $params['object_id']   = filter_input(INPUT_GET, 'object_id', FILTER_SANITIZE_NUMBER_INT);
+            if (empty($params['object_id'])) {
+                return null;
+            }
         }
 
         return $this->responseFactory->createResponse()

--- a/src/Module/Application/Stats/NewestAlbumAction.php
+++ b/src/Module/Application/Stats/NewestAlbumAction.php
@@ -69,7 +69,8 @@ final class NewestAlbumAction implements ApplicationActionInterface
         define('NO_BROWSE_SORTING', true);
 
         $user    = Core::get_global('user');
-        $objects = Stats::get_newest('album', $limit, 0, 0, $user->id);
+        $user_id = $user->id ?? 0;
+        $objects = Stats::get_newest('album', $limit, 0, 0, $user_id);
         $browse  = $this->modelFactory->createBrowse();
         $browse->set_threshold($thresh_value);
         $browse->set_type('album');

--- a/src/Module/Application/Stats/NewestAlbumArtistAction.php
+++ b/src/Module/Application/Stats/NewestAlbumArtistAction.php
@@ -69,7 +69,8 @@ final class NewestAlbumArtistAction implements ApplicationActionInterface
         define('NO_BROWSE_SORTING', true);
 
         $user    = Core::get_global('user');
-        $objects = Stats::get_newest('album_artist', $limit, 0, 0, $user->id);
+        $user_id = $user->id ?? 0;
+        $objects = Stats::get_newest('album_artist', $limit, 0, 0, $user_id);
         $browse  = $this->modelFactory->createBrowse();
         $browse->set_threshold($thresh_value);
         $browse->set_type('album_artist');

--- a/src/Module/Application/Stats/NewestAlbumDiskAction.php
+++ b/src/Module/Application/Stats/NewestAlbumDiskAction.php
@@ -69,7 +69,8 @@ final class NewestAlbumDiskAction implements ApplicationActionInterface
         define('NO_BROWSE_SORTING', true);
 
         $user    = Core::get_global('user');
-        $objects = Stats::get_newest('album_disk', $limit, 0, 0, $user->id);
+        $user_id = $user->id ?? 0;
+        $objects = Stats::get_newest('album_disk', $limit, 0, 0, $user_id);
         $browse  = $this->modelFactory->createBrowse();
         $browse->set_threshold($thresh_value);
         $browse->set_type('album_disk');

--- a/src/Module/Application/Stats/NewestArtistAction.php
+++ b/src/Module/Application/Stats/NewestArtistAction.php
@@ -69,7 +69,8 @@ final class NewestArtistAction implements ApplicationActionInterface
         define('NO_BROWSE_SORTING', true);
 
         $user    = Core::get_global('user');
-        $objects = Stats::get_newest('artist', $limit, 0, 0, $user->id);
+        $user_id = $user->id ?? 0;
+        $objects = Stats::get_newest('artist', $limit, 0, 0, $user_id);
         $browse  = $this->modelFactory->createBrowse();
         $browse->set_threshold($thresh_value);
         $browse->set_type('artist');

--- a/src/Module/Application/Stats/NewestPlaylistAction.php
+++ b/src/Module/Application/Stats/NewestPlaylistAction.php
@@ -69,7 +69,8 @@ final class NewestPlaylistAction implements ApplicationActionInterface
         define('NO_BROWSE_SORTING', true);
 
         $user    = Core::get_global('user');
-        $objects = Stats::get_newest('playlist', $limit, 0, 0, $user->id);
+        $user_id = $user->id ?? 0;
+        $objects = Stats::get_newest('playlist', $limit, 0, 0, $user_id);
         $browse  = $this->modelFactory->createBrowse();
         $browse->set_threshold($thresh_value);
         $browse->set_type('playlist');

--- a/src/Module/Application/Stats/NewestPodcastEpisodeAction.php
+++ b/src/Module/Application/Stats/NewestPodcastEpisodeAction.php
@@ -69,7 +69,8 @@ final class NewestPodcastEpisodeAction implements ApplicationActionInterface
         define('NO_BROWSE_SORTING', true);
 
         $user    = Core::get_global('user');
-        $objects = Stats::get_newest('podcast_episode', $limit, 0, 0, $user->id);
+        $user_id = $user->id ?? 0;
+        $objects = Stats::get_newest('podcast_episode', $limit, 0, 0, $user_id);
         $browse  = $this->modelFactory->createBrowse();
         $browse->set_threshold($thresh_value);
         $browse->set_type('podcast_episode');

--- a/src/Module/Application/Stats/NewestSongAction.php
+++ b/src/Module/Application/Stats/NewestSongAction.php
@@ -69,7 +69,8 @@ final class NewestSongAction implements ApplicationActionInterface
         define('NO_BROWSE_SORTING', true);
 
         $user    = Core::get_global('user');
-        $objects = Stats::get_newest('song', $limit, 0, 0, $user->id);
+        $user_id = $user->id ?? 0;
+        $objects = Stats::get_newest('song', $limit, 0, 0, $user_id);
         $browse  = $this->modelFactory->createBrowse();
         $browse->set_threshold($thresh_value);
         $browse->set_type('song');

--- a/src/Module/Application/Stats/NewestVideoAction.php
+++ b/src/Module/Application/Stats/NewestVideoAction.php
@@ -79,7 +79,8 @@ final class NewestVideoAction implements ApplicationActionInterface
             $this->videoRepository->getItemCount(Video::class)
         ) {
             $user    = Core::get_global('user');
-            $objects = Stats::get_newest('video', $limit, 0, 0, $user->id);
+            $user_id = $user->id ?? 0;
+            $objects = Stats::get_newest('video', $limit, 0, 0, $user_id);
             $browse  = $this->modelFactory->createBrowse();
             $browse->set_threshold($thresh_value);
             $browse->set_type('video');

--- a/src/Module/Application/Waveform/ShowAction.php
+++ b/src/Module/Application/Waveform/ShowAction.php
@@ -93,7 +93,7 @@ final class ShowAction implements ApplicationActionInterface
         return $this->responseFactory
             ->createResponse()
             ->withHeader('Cache-Control', 'public, max-age=864000') // 10 days
-            ->withHeader('ETag', '"waveform-'.$object_type.'_'.$object_id.'"')
+            ->withHeader('ETag', '"waveform-' . $object_type . '_' . $object_id . '"')
             ->withHeader(
                 'Content-type',
                 'image/png'

--- a/src/Module/Application/Waveform/ShowAction.php
+++ b/src/Module/Application/Waveform/ShowAction.php
@@ -92,6 +92,8 @@ final class ShowAction implements ApplicationActionInterface
 
         return $this->responseFactory
             ->createResponse()
+            ->withHeader('Cache-Control', 'public, max-age=864000') // 10 days
+            ->withHeader('ETag', '"waveform-'.$object_type.'_'.$object_id.'"')
             ->withHeader(
                 'Content-type',
                 'image/png'

--- a/src/Module/Playback/Localplay/localplay_controller.php
+++ b/src/Module/Playback/Localplay/localplay_controller.php
@@ -174,9 +174,7 @@ abstract class localplay_controller
         }
         $variables = parse_url($url, PHP_URL_QUERY);
         if ($variables) {
-            debug_event('mdp.controller', print_r($variables, true), 5);
             parse_str($variables, $data);
-
             foreach ($primary_array as $pkey) {
                 if (array_key_exists($pkey, $data)) {
                     $data['primary_key'] = $pkey;

--- a/src/Module/Playback/Localplay/localplay_controller.php
+++ b/src/Module/Playback/Localplay/localplay_controller.php
@@ -166,6 +166,7 @@ abstract class localplay_controller
             preg_match_all('#\b(random_id|random_type)=([^&]*)#', $url, $match);
             if (array_key_exists(1, $match) && $match[1] && array_key_exists(2, $match) && $match[2]) {
                 $result = array_combine($match[1], $match[2]);
+
                 return array(
                     'primary_key' => $result['random_type'],
                     'oid' => $result['random_id']

--- a/src/Module/User/NewPasswordSender.php
+++ b/src/Module/User/NewPasswordSender.php
@@ -59,6 +59,7 @@ final class NewPasswordSender implements NewPasswordSenderInterface
 
         // do not allow administrator password resets
         if ($client->has_access(100)) {
+            debug_event(__CLASS__, 'Administrator can\'t reset their password.', 1);
             return false;
         }
         if ($client->email == $email && Mailer::is_mail_enabled()) {

--- a/src/Module/User/NewPasswordSender.php
+++ b/src/Module/User/NewPasswordSender.php
@@ -60,6 +60,7 @@ final class NewPasswordSender implements NewPasswordSenderInterface
         // do not allow administrator password resets
         if ($client->has_access(100)) {
             debug_event(__CLASS__, 'Administrator can\'t reset their password.', 1);
+
             return false;
         }
         if ($client->email == $email && Mailer::is_mail_enabled()) {

--- a/src/Module/Util/AmpacheRss.php
+++ b/src/Module/Util/AmpacheRss.php
@@ -312,7 +312,7 @@ class AmpacheRss
     public static function load_latest_album($rsstoken = "")
     {
         $user = ($rsstoken) ? static::getUserRepository()->getByRssToken($rsstoken) : null;
-        $ids  = Stats::get_newest('album', 10, 0, 0, $user->id);
+        $ids  = Stats::get_newest('album', 10, 0, 0, (is_null($user)?0:$user->id));
 
         $results = array();
 

--- a/src/Module/Util/AmpacheRss.php
+++ b/src/Module/Util/AmpacheRss.php
@@ -311,8 +311,9 @@ class AmpacheRss
      */
     public static function load_latest_album($rsstoken = "")
     {
-        $user = ($rsstoken) ? static::getUserRepository()->getByRssToken($rsstoken) : null;
-        $ids  = Stats::get_newest('album', 10, 0, 0, (is_null($user)?0:$user->id));
+        $user    = ($rsstoken) ? static::getUserRepository()->getByRssToken($rsstoken) : null;
+        $user_id = $user->id ?? 0;
+        $ids     = Stats::get_newest('album', 10, 0, 0, $user_id);
 
         $results = array();
 
@@ -340,8 +341,9 @@ class AmpacheRss
      */
     public static function load_latest_artist($rsstoken = "")
     {
-        $user = ($rsstoken) ? static::getUserRepository()->getByRssToken($rsstoken) : null;
-        $ids  = Stats::get_newest('artist', 10, 0, 0, $user->id);
+        $user    = ($rsstoken) ? static::getUserRepository()->getByRssToken($rsstoken) : null;
+        $user_id = $user->id ?? 0;
+        $ids     = Stats::get_newest('artist', 10, 0, 0, $user_id);
 
         $results = array();
 

--- a/src/Module/Util/Captcha/easy_captcha.php
+++ b/src/Module/Util/Captcha/easy_captcha.php
@@ -220,7 +220,7 @@ class easy_captcha
 
         #-- assemble
         $HTML = //'<script>if (document.getElementById("captcha")) { document.getElementById("captcha").parentNode.removeChild(document.getElementById("captcha")); }</script>' .   // workaround for double instantiations
-            '<div id="captcha" class="captcha">' . $error . '<input type="hidden" id="' . $p_id . '" name="' . $p_id . '" value="' . $id . '" />' . '<img src="' . $img_url . '&" width="' . $this->image->width . '" height="' . $this->image->height . '" alt="' . $alt_text .'" '. $onClick . ' title="' . CAPTCHA_REDRAW_TEXT . '" />' . '&nbsp;' . $add_text . '<input title="' . CAPTCHA_PROMPT_TEXT . '" type="text" ' . $onKeyDown . ' id="' . $p_input . '" name="' . $p_input . '" value="' . (isset($_REQUEST[$p_input]) ? htmlentities($_REQUEST[$p_input]) : "") . '" size="8" style="' . CAPTCHA_INPUT_STYLE . '" />' . $javascript . '</div>';
+            '<div id="captcha" class="captcha">' . $error . '<input type="hidden" id="' . $p_id . '" name="' . $p_id . '" value="' . $id . '" />' . '<img src="' . $img_url . '&" width="' . $this->image->width . '" height="' . $this->image->height . '" alt="' . $alt_text . '" ' . $onClick . ' title="' . CAPTCHA_REDRAW_TEXT . '" />' . '&nbsp;' . $add_text . '<input title="' . CAPTCHA_PROMPT_TEXT . '" type="text" ' . $onKeyDown . ' id="' . $p_input . '" name="' . $p_input . '" value="' . (isset($_REQUEST[$p_input]) ? htmlentities($_REQUEST[$p_input]) : "") . '" size="8" style="' . CAPTCHA_INPUT_STYLE . '" />' . $javascript . '</div>';
 
         return ($HTML);
     }

--- a/src/Module/Util/Captcha/easy_captcha.php
+++ b/src/Module/Util/Captcha/easy_captcha.php
@@ -220,7 +220,7 @@ class easy_captcha
 
         #-- assemble
         $HTML = //'<script>if (document.getElementById("captcha")) { document.getElementById("captcha").parentNode.removeChild(document.getElementById("captcha")); }</script>' .   // workaround for double instantiations
-            '<div id="captcha" class="captcha">' . $error . '<input type="hidden" id="' . $p_id . '" name="' . $p_id . '" value="' . $id . '" />' . '<img src="' . $img_url . '&" width="' . $this->image->width . '" height="' . $this->image->height . '" alt="' . $alt_text . $onClick . ' title="' . CAPTCHA_REDRAW_TEXT . '" />' . '&nbsp;' . $add_text . '<input title="' . CAPTCHA_PROMPT_TEXT . '" type="text" ' . $onKeyDown . ' id="' . $p_input . '" name="' . $p_input . '" value="' . (isset($_REQUEST[$p_input]) ? htmlentities($_REQUEST[$p_input]) : "") . '" size="8" style="' . CAPTCHA_INPUT_STYLE . '" />' . $javascript . '</div>';
+            '<div id="captcha" class="captcha">' . $error . '<input type="hidden" id="' . $p_id . '" name="' . $p_id . '" value="' . $id . '" />' . '<img src="' . $img_url . '&" width="' . $this->image->width . '" height="' . $this->image->height . '" alt="' . $alt_text .'" '. $onClick . ' title="' . CAPTCHA_REDRAW_TEXT . '" />' . '&nbsp;' . $add_text . '<input title="' . CAPTCHA_PROMPT_TEXT . '" type="text" ' . $onKeyDown . ' id="' . $p_input . '" name="' . $p_input . '" value="' . (isset($_REQUEST[$p_input]) ? htmlentities($_REQUEST[$p_input]) : "") . '" size="8" style="' . CAPTCHA_INPUT_STYLE . '" />' . $javascript . '</div>';
 
         return ($HTML);
     }

--- a/src/Repository/Model/Art.php
+++ b/src/Repository/Model/Art.php
@@ -262,7 +262,9 @@ class Art extends database_object
                 }
                 $this->raw_mime = $results['mime'];
             } elseif (AmpConfig::get('resize_images')) {
-                if (!empty($this->thumb)) continue; // See https://github.com/ampache/ampache/issues/3386
+                if (!empty($this->thumb)) { // See https://github.com/ampache/ampache/issues/3386
+                    continue;
+                }
                 if (AmpConfig::get('album_art_store_disk')) {
                     $this->thumb = self::read_from_dir($results['size'], $this->type, $this->uid, $this->kind, $results['mime']);
                 } elseif ($results['size'] == '275x275') {
@@ -627,7 +629,7 @@ class Art extends database_object
         if ($path === false) {
             return false;
         }
-        if (!is_dir($path)){
+        if (!is_dir($path)) {
             debug_event(self::class, 'Local image art directory '. $path . ' does not even exist.', 1);
             return null;
         }

--- a/src/Repository/Model/Art.php
+++ b/src/Repository/Model/Art.php
@@ -629,8 +629,8 @@ class Art extends database_object
         if ($path === false) {
             return false;
         }
-        if (!is_dir($path)) {
-            debug_event(self::class, 'Local image art directory ' . $path . ' does not even exist.', 1);
+        if (!Core::is_readable($path)) {
+            debug_event(self::class, 'Local image art directory ' . $path . ' does not exist.', 1);
 
             return null;
         }

--- a/src/Repository/Model/Art.php
+++ b/src/Repository/Model/Art.php
@@ -630,7 +630,8 @@ class Art extends database_object
             return false;
         }
         if (!is_dir($path)) {
-            debug_event(self::class, 'Local image art directory '. $path . ' does not even exist.', 1);
+            debug_event(self::class, 'Local image art directory ' . $path . ' does not even exist.', 1);
+
             return null;
         }
         $path .= "art-" . $sizetext . "." . self::extension($mime);

--- a/src/Repository/Model/Art.php
+++ b/src/Repository/Model/Art.php
@@ -262,6 +262,7 @@ class Art extends database_object
                 }
                 $this->raw_mime = $results['mime'];
             } elseif (AmpConfig::get('resize_images')) {
+                if (!empty($this->thumb)) continue; // See https://github.com/ampache/ampache/issues/3386
                 if (AmpConfig::get('album_art_store_disk')) {
                     $this->thumb = self::read_from_dir($results['size'], $this->type, $this->uid, $this->kind, $results['mime']);
                 } elseif ($results['size'] == '275x275') {
@@ -625,6 +626,10 @@ class Art extends database_object
         $path = self::get_dir_on_disk($type, $uid, $kind, true);
         if ($path === false) {
             return false;
+        }
+        if (!is_dir($path)){
+            debug_event(self::class, 'Local image art directory '. $path . ' does not even exist.', 1);
+            return null;
         }
         $path .= "art-" . $sizetext . "." . self::extension($mime);
         if (Core::is_readable($path)) {

--- a/src/Repository/Model/Search.php
+++ b/src/Repository/Model/Search.php
@@ -89,9 +89,15 @@ class Search extends playlist_object
         if ($search_id > 0) {
             $info = $this->get_info($search_id);
             foreach ($info as $key => $value) {
-                $this->$key = ($key == 'rules')
-                    ? json_decode((string)$value, true)
-                    : $value;
+                 if ($key == 'rules') {
+                     $this->rules = json_decode((string)$value, true);
+                     if (is_null($this->rules)) {
+                         debug_event(__CLASS__, "Can't decode key 'rules'. Not a valid json.",1 );
+                         $this->rules = array();
+                     }
+                 } else {
+                     $this->$key = $value;
+                 }
             }
             // make sure saved rules match the correct names
             $rule_count = 0;

--- a/src/Repository/Model/Search.php
+++ b/src/Repository/Model/Search.php
@@ -91,7 +91,7 @@ class Search extends playlist_object
             foreach ($info as $key => $value) {
                 if ($key == 'rules') {
                     $this->rules = json_decode((string)$value, true);
-                    if (is_null($this->rules)) {
+                    if (!is_array($this->rules)) {
                         debug_event(__CLASS__, "Can't decode key 'rules'. Not a valid json.", 1);
                         $this->rules = array();
                     }

--- a/src/Repository/Model/Search.php
+++ b/src/Repository/Model/Search.php
@@ -89,15 +89,15 @@ class Search extends playlist_object
         if ($search_id > 0) {
             $info = $this->get_info($search_id);
             foreach ($info as $key => $value) {
-                 if ($key == 'rules') {
-                     $this->rules = json_decode((string)$value, true);
-                     if (is_null($this->rules)) {
-                         debug_event(__CLASS__, "Can't decode key 'rules'. Not a valid json.",1 );
-                         $this->rules = array();
-                     }
-                 } else {
-                     $this->$key = $value;
-                 }
+                if ($key == 'rules') {
+                    $this->rules = json_decode((string)$value, true);
+                    if (is_null($this->rules)) {
+                        debug_event(__CLASS__, "Can't decode key 'rules'. Not a valid json.", 1);
+                        $this->rules = array();
+                    }
+                } else {
+                    $this->$key = $value;
+                }
             }
             // make sure saved rules match the correct names
             $rule_count = 0;

--- a/src/Repository/Model/Shoutbox.php
+++ b/src/Repository/Model/Shoutbox.php
@@ -203,8 +203,7 @@ class Shoutbox
         $comment = strip_tags($data['comment']);
 
         $sql = "INSERT INTO `user_shout` (`user`, `date`, `text`, `sticky`, `object_id`, `object_type`, `data`) VALUES (?, ?, ?, ?, ?, ?, ?)";
-        Dba::write($sql,
-            array($user, $date, $comment, $sticky, $data['object_id'], $data['object_type'], $data['data']));
+        Dba::write($sql, array($user, $date, $comment, $sticky, $data['object_id'], $data['object_type'], $data['data'] ?? 0));
 
         static::getUserActivityPoster()->post((int) $user, 'shout', $data['object_type'], (int) $data['object_id'], time());
 

--- a/src/Repository/Model/Song.php
+++ b/src/Repository/Model/Song.php
@@ -56,10 +56,6 @@ class Song extends database_object implements Media, library_item, GarbageCollec
      */
     public $file;
     /**
-     * @var string $filename
-     */
-    public $filename;
-    /**
      * @var integer $album
      */
     public $album;
@@ -181,6 +177,14 @@ class Song extends database_object implements Media, library_item, GarbageCollec
      */
     public $channels;
 
+    /**
+     * @var string $folder
+     */
+    public $folder;
+    /**
+     * @var string $filename
+     */
+    public $filename;
     /**
      * @var array $tags
      */
@@ -400,6 +404,7 @@ class Song extends database_object implements Media, library_item, GarbageCollec
             }
             $data              = pathinfo($this->file);
             $this->type        = strtolower((string)$data['extension']);
+            $this->folder      = (string)$data['dirname'];
             $this->filename    = (string)$data['filename'];
             $this->mime        = self::type_to_mime($this->type);
             $this->total_count = (int)$this->total_count;

--- a/src/Repository/Model/Song.php
+++ b/src/Repository/Model/Song.php
@@ -56,6 +56,10 @@ class Song extends database_object implements Media, library_item, GarbageCollec
      */
     public $file;
     /**
+     * @var string $filename
+     */
+    public $filename;
+    /**
      * @var integer $album
      */
     public $album;
@@ -396,6 +400,7 @@ class Song extends database_object implements Media, library_item, GarbageCollec
             }
             $data              = pathinfo($this->file);
             $this->type        = strtolower((string)$data['extension']);
+            $this->filename    = (string)$data['filename'];
             $this->mime        = self::type_to_mime($this->type);
             $this->total_count = (int)$this->total_count;
         } else {

--- a/src/Repository/Model/Song.php
+++ b/src/Repository/Model/Song.php
@@ -178,14 +178,6 @@ class Song extends database_object implements Media, library_item, GarbageCollec
     public $channels;
 
     /**
-     * @var string $folder
-     */
-    public $folder;
-    /**
-     * @var string $filename
-     */
-    public $filename;
-    /**
      * @var array $tags
      */
     public $tags;
@@ -404,8 +396,6 @@ class Song extends database_object implements Media, library_item, GarbageCollec
             }
             $data              = pathinfo($this->file);
             $this->type        = strtolower((string)$data['extension']);
-            $this->folder      = (string)$data['dirname'];
-            $this->filename    = (string)$data['filename'];
             $this->mime        = self::type_to_mime($this->type);
             $this->total_count = (int)$this->total_count;
         } else {

--- a/src/Repository/Model/User.php
+++ b/src/Repository/Model/User.php
@@ -195,8 +195,8 @@ class User extends database_object
                     continue;
                 }
                 $this->$key = $value;
-             }
-         }
+            }
+        }
 
         // Make sure the Full name is always filled
         if (strlen((string)$this->fullname) < 1) {

--- a/src/Repository/Model/User.php
+++ b/src/Repository/Model/User.php
@@ -188,13 +188,15 @@ class User extends database_object
 
         $this->id = (int)($user_id);
         $info     = $this->has_info();
-        foreach ($info as $key => $value) {
-            // Let's not save the password in this object :S
-            if ($key == 'password') {
-                continue;
-            }
-            $this->$key = $value;
-        }
+        if (!empty($info)) {
+            foreach ($info as $key => $value) {
+                // Let's not save the password in this object :S
+                if ($key == 'password') {
+                    continue;
+                }
+                $this->$key = $value;
+             }
+         }
 
         // Make sure the Full name is always filled
         if (strlen((string)$this->fullname) < 1) {

--- a/src/Repository/Model/User.php
+++ b/src/Repository/Model/User.php
@@ -190,10 +190,6 @@ class User extends database_object
         $info     = $this->has_info();
         if (!empty($info)) {
             foreach ($info as $key => $value) {
-                // Let's not save the password in this object :S
-                if ($key == 'password') {
-                    continue;
-                }
                 $this->$key = $value;
             }
         }
@@ -259,8 +255,8 @@ class User extends database_object
             return $data;
         }
 
-        $sql        = "SELECT * FROM `user` WHERE `id`='$user_id'";
-        $db_results = Dba::read($sql);
+        $sql        = "SELECT `id`, `username`, `fullname`, `email`, `website`, `apikey`, `access`, `disabled`, `last_seen`, `create_date`, `validation`, `state`, `city`, `fullname_public`, `rsstoken`, `streamtoken`, `catalog_filter_group` FROM `user` WHERE `id` = ?;";
+        $db_results = Dba::read($sql, array($user_id));
 
         $data = Dba::fetch_assoc($db_results);
 

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -48,7 +48,9 @@ final class UserRepository implements UserRepositoryInterface
      */
     public function idByUsername(string $username): int
     {
-        if ($username == '-1') return 0;
+        if ($username == '-1') {
+            return 0;
+        }
         $db_results = Dba::read(
             'SELECT `id` FROM `user` WHERE `username`= ?',
             [$username]

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -48,6 +48,7 @@ final class UserRepository implements UserRepositoryInterface
      */
     public function idByUsername(string $username): int
     {
+        if ($username == '-1') return 0;
         $db_results = Dba::read(
             'SELECT `id` FROM `user` WHERE `username`= ?',
             [$username]


### PR DESCRIPTION
Lot of quick fixes, most of them based on what /var/log/ampache/ampache.log warned me.

Sorry to push a mess like that.

Also, a few features.

Features:
- Add possibility to have a custom.js
- Add header to allow browser cache on waveform
- Add filename properties to song object
- Add an easy optimisation when it's the guest user
- Add log event when preventing Administrator to reset their password


Fix:
- Add missing doctype
- Handle $user is null
- Handle if there are no info for the user
- Handle bad object
- Handle if the json can't be decoded
- Force cast on some value before doing arithmetic
- Display filename and not the whole path and filename
- Partial fix of https://github.com/ampache/ampache/issues/3386 - Better, but not good 

