### PR TITLE
Multi-artist support for API

### DIFF
--- a/src/Module/Api/Json_Data.php
+++ b/src/Module/Api/Json_Data.php
@@ -1080,6 +1080,12 @@ class Json_Data
             $play_url     = $song->play_url('', 'api', false, $user->id, $user->streamtoken);
             $song_album   = Album::get_name_array_by_id($song->album);
             $song_artist  = Artist::get_name_array_by_id($song->artist);
+            $song_artists = array();
+            foreach ($song->artists as $artist_id) {
+                $artist_info = Artist::get_name_array_by_id($artist_id);
+                $artist_info["mbid"] = Artist::get_mbid_by_id($artist_id);
+                $song_artists[] = $artist_info;
+            }
             $playlist_track++;
 
             $objArray = array(
@@ -1092,6 +1098,7 @@ class Json_Data
                     "prefix" => $song_artist['prefix'],
                     "basename" => $song_artist['basename']
                 ),
+                "artists" => $song_artists,
                 "album" => array(
                     "id" => (string)$song->album,
                     "name" => $song_album['name'],

--- a/src/Module/Api/Method/CatalogAddMethod.php
+++ b/src/Module/Api/Method/CatalogAddMethod.php
@@ -66,6 +66,7 @@ final class CatalogAddMethod
         if (!Api::check_access('interface', 75, $user->id, self::ACTION, $input['api_format'])) {
             return false;
         }
+        $path           = $input['path'];
         $name           = $input['name'];
         $type           = $input['type'] ?? 'local';
         $rename_pattern = $input['file_pattern'] ?? '%T - %t';
@@ -94,12 +95,12 @@ final class CatalogAddMethod
                 return false;
             }
         }
-        $path = ($is_remote)
-            ? filter_var(urldecode($input['path']), FILTER_VALIDATE_URL)
-            : Catalog_local::check_path($input['path']);
-        if (!$path) {
+        $path_ok = ($is_remote)
+            ? filter_var(urldecode($path), FILTER_VALIDATE_URL)
+            : Catalog_local::check_path($path);
+        if (!$path_ok) {
             /* HINT: Requested object string/id/type ("album", "myusername", "some song title", 1298376) */
-            Api::error(sprintf(T_('Bad Request: %s'), $input['path']), '4710', self::ACTION, 'path', $input['api_format']);
+            Api::error(sprintf(T_('Bad Request: %s'), $path), '4710', self::ACTION, 'path', $input['api_format']);
 
             return false;
         }

--- a/src/Module/Api/Xml_Data.php
+++ b/src/Module/Api/Xml_Data.php
@@ -1012,6 +1012,12 @@ class Xml_Data
             $song->format();
             $song_album    = Album::get_name_array_by_id($song->album);
             $song_artist   = Artist::get_name_array_by_id($song->artist);
+            $song_artists = array();
+            foreach ($song->artists as $artist_id) {
+                $artist_info = Artist::get_name_array_by_id($artist_id);
+                $artist_info["mbid"] = Artist::get_mbid_by_id($artist_id);
+                $song_artists[] = $artist_info;
+            }
             $tag_string    = self::genre_string(Tag::get_top_tags('song', $song_id));
             $rating        = new Rating($song_id, 'song');
             $user_rating   = $rating->get_user_rating($user->getId());
@@ -1027,9 +1033,11 @@ class Xml_Data
             $play_url      = $song->play_url('', 'api', false, $user->id, $user->streamtoken);
             $playlist_track++;
 
-            $string .= "<song id=\"" . $song->id . "\">\n\t<name><![CDATA[" . $song->f_name . "]]></name>\n\t<title><![CDATA[" . $song->get_fullname() . "]]></title>\n" .
-                "\t<artist id=\"" . $song->artist . "\"><name><![CDATA[" . $song_artist['name'] . "]]></name>\n\t<prefix><![CDATA[" . $song_artist['prefix'] . "]]></prefix>\n\t<basename><![CDATA[" . $song_artist['basename'] . "]]></basename>\n</artist>\n" .
-                "\t<album id=\"" . $song->album . "\"><name><![CDATA[" . $song_album['name'] . "]]></name>\n\t<prefix><![CDATA[" . $song_album['prefix'] . "]]></prefix>\n\t<basename><![CDATA[" . $song_album['basename'] . "]]></basename>\n</album>\n";
+            $string .= "<song id=\"" . $song->id . "\">\n\t<name><![CDATA[" . $song->f_name . "]]></name>\n\t<title><![CDATA[" . $song->get_fullname() . "]]></title>\n";
+            foreach($song_artists as $this_artist) {
+                $string .= "\t<artist id=\"" . $this_artist['id'] . "\"><name><![CDATA[" . $this_artist['name'] . "]]></name>\n\t<prefix><![CDATA[" . $this_artist['prefix'] . "]]></prefix>\n\t<basename><![CDATA[" . $this_artist['basename'] . "]]></basename>\n\t<mbid><![CDATA[" . $this_artist['mbid'] . "]]></mbid>\n</artist>\n";
+            }
+            $string .= "\t<album id=\"" . $song->album . "\"><name><![CDATA[" . $song_album['name'] . "]]></name>\n\t<prefix><![CDATA[" . $song_album['prefix'] . "]]></prefix>\n\t<basename><![CDATA[" . $song_album['basename'] . "]]></basename>\n</album>\n";
             if ($song->get_album_artist_fullname() != "") {
                 $album_artist = ($song->artist !== $song->albumartist)
                     ? Artist::get_name_array_by_id($song->albumartist)

--- a/src/Repository/Model/Artist.php
+++ b/src/Repository/Model/Artist.php
@@ -616,6 +616,25 @@ class Artist extends database_object implements library_item, GarbageCollectible
     }
 
     /**
+     * Get MusicBrainz ID by the artist id.
+     * @param int|string|null $artist_id
+     * @return string
+     */
+    public static function get_mbid_by_id($artist_id)
+    {
+        if ($artist_id === 0) {
+            return "89ad4ac3-39f7-470e-963a-56509c546377";
+        }
+        $sql        = "SELECT `artist`.`mbid` FROM `artist` WHERE `id` = ?;";
+        $db_results = Dba::read($sql, array($artist_id));
+        if ($row = Dba::fetch_assoc($db_results)) {
+            return (string)$row['mbid'];
+        }
+
+        return '';
+    }
+
+    /**
      * get_display
      * This returns a csv formatted version of the artists that we are given
      * @param array $artists


### PR DESCRIPTION
For JSON I've added a new ```artists``` array which also includes the artist MBID since there was (and still is) a separate ```artist_mbid```

For XML there will be extra ```<artist>``` entries, each with its own MBID

Have left in the  ```artist_mbid``` (and single ```artist``` for JSON) for the time being, I'm guessing it should be left in for compatibility but nows the time to break things!

Examples:
```json
 {
    "id": "34687",
    "title": "Enth E Nd (feat. Motion Man)",
    "name": "Enth E Nd (feat. Motion Man)",
    "artist": {
        "id": "2503",
        "name": "Kutmasta Kurt",
        "prefix": null,
        "basename": "Kutmasta Kurt"
    },
    "artists": [
        {
            "id": "2503",
            "name": "Kutmasta Kurt",
            "prefix": null,
            "basename": "Kutmasta Kurt",
            "mbid": "abf9f319-da2f-4fdf-a3e4-40c4d0b0075d"
        },
        {
            "id": "2504",
            "name": "Motion Man",
            "prefix": null,
            "basename": "Motion Man",
            "mbid": "1cee1f74-179d-446d-8347-de31e8202f2b"
        }
    ],
    ...
    ...
    ...
    "artist_mbid": "abf9f319-da2f-4fdf-a3e4-40c4d0b0075d",
}
```

```xml
<song id="34687">
    <name><![CDATA[Enth E Nd (feat. Motion Man)]]></name>
    <title><![CDATA[Enth E Nd (feat. Motion Man)]]></title>
    <artist id="2503">
      <name><![CDATA[Kutmasta Kurt]]></name>
      <prefix><![CDATA[]]></prefix>
      <basename><![CDATA[Kutmasta Kurt]]></basename>
      <mbid><![CDATA[abf9f319-da2f-4fdf-a3e4-40c4d0b0075d]]></mbid>
    </artist>
    <artist id="2504">
      <name><![CDATA[Motion Man]]></name>
      <prefix><![CDATA[]]></prefix>
      <basename><![CDATA[Motion Man]]></basename>
      <mbid><![CDATA[1cee1f74-179d-446d-8347-de31e8202f2b]]></mbid>
    </artist>
    ...
    ...
    ...
    <artist_mbid><![CDATA[abf9f319-da2f-4fdf-a3e4-40c4d0b0075d]]></mbid>
</song>
```