### PR TITLE
Do not scrub title for RSS output

### DIFF
--- a/src/Module/Util/AmpacheRss.php
+++ b/src/Module/Util/AmpacheRss.php
@@ -133,7 +133,7 @@ class AmpacheRss
             'latest_shout' => T_('Newest Shouts')
         );
 
-        return scrub_out(AmpConfig::get('site_title')) . ' - ' . $titles[$this->type];
+        return AmpConfig::get('site_title') . ' - ' . $titles[$this->type];
     } // get_title
 
     /**


### PR DESCRIPTION
This small PR simply avoids scrubing the Ampache installation title when using the RSS output. If the title contains accents some RSS readers have trouble. For instance, Firefox is unable to parse the XML, whereas Akregator will ignore the character with the accent.
Since for the RSS XML there is no need to escape HTML characters, simply removing scrub_out() call will work
For a reference, this is the error shown in Firefox when it fails to parse the XML without this patch:
![image](https://user-images.githubusercontent.com/17937361/232545970-1030f1f4-e115-4517-b0e2-4abec2b2d837.png)
