### PR TITLE
Set login_message from config

### DIFF
--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -371,6 +371,10 @@ catalog_prefix_pattern = "The|An|A|Die|Das|Ein|Eine|Les|Le|La"
 ; DEFAULT: 42 days
 ;user_ip_cardinality = "42"
 
+; Display this message on the Login page
+; DEFAULT: ""
+;login_message = "For the love of music"
+
 ; Allow Zip Download
 ; This setting allows/disallows using zlib to zip up an entire
 ; playlist/album for download. Even if this is turned on you will

--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -373,7 +373,7 @@ catalog_prefix_pattern = "The|An|A|Die|Das|Ein|Eine|Les|Le|La"
 
 ; Display this message on the Login page
 ; DEFAULT: ""
-;login_message = "For the love of music"
+;login_message = "For the Love of Music"
 
 ; Allow Zip Download
 ; This setting allows/disallows using zlib to zip up an entire

--- a/public/templates/show_login_form.inc.php
+++ b/public/templates/show_login_form.inc.php
@@ -88,9 +88,9 @@ $_SESSION['login'] = true; ?>
                         <input class="button" id="loginbutton" type="submit" value="<?php echo T_('Login'); ?>" />
                         <input type="hidden" name="referrer" value="<?php echo scrub_out(Core::get_server('HTTP_REFERER')); ?>" />
                         <input type="hidden" name="action" value="login" />
-                        <?php echo AmpConfig::get('login_message'); ?>
                     </div>
                 </div>
+                <div class="loginmessage"><?php echo AmpConfig::get('login_message'); ?></div>
                 <div class="loginoptions">
                 <?php if (AmpConfig::get('allow_public_registration')) { ?>
                             <a class="button nohtml" id="registerbutton" href="<?php echo $web_path; ?>/register.php"><?php echo T_('Register'); ?></a>


### PR DESCRIPTION
"login_message" is mentioned on the login page but isn't present in the config, this fixes that

![firefox_sNpumgEcld](https://github.com/ampache/ampache/assets/5735900/2a4629ff-0f54-43dd-a6ae-5b711eed6737)
