### PR TITLE
Server would return incorrect url if 'local' was true

### DIFF
--- a/src/Module/Api/Method/Api4/Download4Method.php
+++ b/src/Module/Api/Method/Api4/Download4Method.php
@@ -69,11 +69,11 @@ final class Download4Method
         }
         if ($type == 'song') {
             $media = new Song($fileid);
-            $url   = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url   = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if ($type == 'podcast_episode' || $type == 'podcast') {
             $media = new Podcast_Episode($fileid);
-            $url   = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url   = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if (!empty($url)) {
             header('Location: ' . str_replace(':443/play', '/play', $url));

--- a/src/Module/Api/Method/Api4/Stream4Method.php
+++ b/src/Module/Api/Method/Api4/Stream4Method.php
@@ -85,11 +85,11 @@ final class Stream4Method
         $url = '';
         if ($type == 'song') {
             $media = new Song($fileid);
-            $url   = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url   = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if ($type == 'podcast') {
             $media = new Podcast_Episode($fileid);
-            $url   = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url   = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if (!empty($url)) {
             Session::extend($input['auth']);

--- a/src/Module/Api/Method/Api5/Download5Method.php
+++ b/src/Module/Api/Method/Api5/Download5Method.php
@@ -69,16 +69,16 @@ final class Download5Method
         $url = '';
         if ($type == 'song') {
             $media = new Song($object_id);
-            $url   = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url   = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if ($type == 'podcast_episode' || $type == 'podcast') {
             $media = new Podcast_Episode($object_id);
-            $url   = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url   = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if ($type == 'search' || $type == 'playlist') {
             $song_id = Random::get_single_song($type, $user, (int)$_REQUEST['random_id']);
             $media   = new Song($song_id);
-            $url     = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url     = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if (!empty($url)) {
             Session::extend($input['auth']);

--- a/src/Module/Api/Method/Api5/Stream5Method.php
+++ b/src/Module/Api/Method/Api5/Stream5Method.php
@@ -89,16 +89,16 @@ final class Stream5Method
         $url = '';
         if ($type == 'song') {
             $media = new Song($object_id);
-            $url   = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url   = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if ($type == 'podcast_episode' || $type == 'podcast') {
             $media = new Podcast_Episode($object_id);
-            $url   = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url   = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if ($type == 'search' || $type == 'playlist') {
             $song_id = Random::get_single_song($type, $user, (int)$_REQUEST['random_id']);
             $media   = new Song($song_id);
-            $url     = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url     = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if (!empty($url)) {
             Session::extend($input['auth']);

--- a/src/Module/Api/Method/DownloadMethod.php
+++ b/src/Module/Api/Method/DownloadMethod.php
@@ -70,16 +70,16 @@ final class DownloadMethod
         $url = '';
         if ($type == 'song') {
             $media = new Song($object_id);
-            $url   = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url   = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if ($type == 'podcast_episode' || $type == 'podcast') {
             $media = new Podcast_Episode($object_id);
-            $url   = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url   = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if ($type == 'search' || $type == 'playlist') {
             $song_id = Random::get_single_song($type, $user, (int)$_REQUEST['random_id']);
             $media   = new Song($song_id);
-            $url     = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url     = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if (!empty($url)) {
             Session::extend($input['auth']);

--- a/src/Module/Api/Method/StreamMethod.php
+++ b/src/Module/Api/Method/StreamMethod.php
@@ -90,16 +90,16 @@ final class StreamMethod
         $url = '';
         if ($type == 'song') {
             $media = new Song($object_id);
-            $url   = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url   = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if ($type == 'podcast_episode') {
             $media = new Podcast_Episode($object_id);
-            $url   = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url   = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if ($type == 'search' || $type == 'playlist') {
             $song_id = Random::get_single_song($type, $user, (int)$_REQUEST['random_id']);
             $media   = new Song($song_id);
-            $url     = $media->play_url($params, 'api', function_exists('curl_version'), $user->id, $user->streamtoken);
+            $url     = $media->play_url($params, 'api', false, $user->id, $user->streamtoken);
         }
         if (!empty($url)) {
             Session::extend($input['auth']);


### PR DESCRIPTION
download/stream API methods were fine on my local dev setup, but on my remote server (ampache-docker which comes with curl installed) they were returning ```http://localhost/play/index.php?ssid...``` due to ```function_exists('curl_version'),``` being ```true```

The default for ```play_url()``` is ```local: false``` so after removing the checks the correct URLs were returned

After this change the only other instances of ```local``` being checked or forced are these places:

https://github.com/ampache/ampache/blob/e9408ed52c214680b650a803f653c29dfb86a753/src/Module/Api/Daap_Api.php#L437

https://github.com/ampache/ampache/blob/e9408ed52c214680b650a803f653c29dfb86a753/src/Module/Api/Subsonic_Api.php#L1396

https://github.com/ampache/ampache/blob/e9408ed52c214680b650a803f653c29dfb86a753/src/Module/Api/Upnp_Api.php#L1713