### PR TITLE
Avoid OGG ABR bitrate mode to be updated to VBR

### DIFF
--- a/src/Repository/Model/Catalog.php
+++ b/src/Repository/Model/Catalog.php
@@ -2536,7 +2536,7 @@ abstract class Catalog extends database_object
         $new_song->title    = self::check_length(self::check_title($results['title'], $new_song->file));
         $new_song->bitrate  = $results['bitrate'];
         $new_song->rate     = $results['rate'];
-        $new_song->mode     = ($results['mode'] == 'cbr') ? 'cbr' : 'vbr';
+        $new_song->mode     = (in_array($results['mode'], ['vbr', 'cbr', 'abr'])) ? $results['mode'] : 'vbr';
         $new_song->channels = $results['channels'];
         $new_song->size     = $results['size'];
         $new_song->time     = (strlen((string)$results['time']) > 5)
@@ -2973,7 +2973,7 @@ abstract class Catalog extends database_object
         $podcast_episode->time     = $results['time'];
         $podcast_episode->bitrate  = $results['bitrate'];
         $podcast_episode->rate     = $results['rate'];
-        $podcast_episode->mode     = ($results['mode'] == 'cbr') ? 'cbr' : 'vbr';
+        $podcast_episode->mode     = (in_array($results['mode'], ['vbr', 'cbr', 'abr'])) ? $results['mode'] : 'vbr';
         $podcast_episode->channels = $results['channels'];
 
         $array            = array();


### PR DESCRIPTION
* During Catalog Check, bit rate mode for ogg ABR file must not be updated to VBR

Closes #3582 