### PR TITLE
Upgrade phpunit to version 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
         "friendsofphp/php-cs-fixer": "3.16.0",
         "mikey179/vfsstream": "^1.6",
         "mockery/mockery": "^1.3",
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^10",
         "squizlabs/php_codesniffer": "^3.5",
         "szymach/c-pchart": "^3.0"
     },
@@ -372,7 +372,7 @@
         }
     },
     "scripts": {
-        "coverage": "./vendor/bin/phpunit --warm-coverage-cache && XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-html build/coverage tests",
+        "coverage": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-html build/coverage tests",
         "qa": "composer run-script syntax && composer run-script fix-cs && composer run-script tests",
         "tests": "./vendor/bin/phpunit tests",
         "codestyle": "resources/scripts/tests/codestyle.sh",

--- a/docs/examples/AmpacheExample.php
+++ b/docs/examples/AmpacheExample.php
@@ -99,4 +99,3 @@ class AmpacheExample
         return true;
     }
 }
-

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,28 +1,18 @@
 <?xml version="1.0"?>
 <phpunit
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
 	backupGlobals="true"
-	backupStaticAttributes="false"
 	bootstrap="tests/bootstrap.php"
-	cacheResult="true"
 	colors="true"
-	convertErrorsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
-	forceCoversAnnotation="false"
-	processIsolation="false"
-	stopOnError="false"
-	stopOnFailure="false"
-	stopOnIncomplete="false"
-	stopOnSkipped="false"
-	stopOnRisky="false">
-	<coverage cacheDirectory="build/coverageCache">
+>
+	<coverage cacheDirectory="build/coverageCache" />
+	<source>
 		<include>
-			<directory suffix=".php">src</directory>
+			<directory>src</directory>
 		</include>
 		<exclude>
 			<directory suffix="service_definition.php">src</directory>
 		</exclude>
-	</coverage>
+	</source>
 </phpunit>

--- a/tests/Config/ConfigContainerTest.php
+++ b/tests/Config/ConfigContainerTest.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace Ampache\Config;
 
 use Ampache\MockeryTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ConfigContainerTest extends MockeryTestCase
 {
@@ -187,9 +188,7 @@ class ConfigContainerTest extends MockeryTestCase
         );
     }
 
-    /**
-     * @dataProvider featureEnabledDataProvider
-     */
+    #[DataProvider(methodName: 'featureEnabledDataProvider')]
     public function testIsFeatureEnabledReturnsExpectedState(
         $value,
         bool $state
@@ -204,7 +203,7 @@ class ConfigContainerTest extends MockeryTestCase
         );
     }
 
-    public function featureEnabledDataProvider(): array
+    public static function featureEnabledDataProvider(): array
     {
         return [
             [true, true],

--- a/tests/Gui/Stats/CatalogStatsTest.php
+++ b/tests/Gui/Stats/CatalogStatsTest.php
@@ -25,12 +25,11 @@ declare(strict_types=1);
 namespace Ampache\Gui\Stats;
 
 use Ampache\MockeryTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CatalogStatsTest extends MockeryTestCase
 {
-    /**
-     * @dataProvider methodDataProvider
-     */
+    #[DataProvider(methodName: 'methodDataProvider')]
     public function testArrayAccessorsReturnData(
         string $methodName,
         string $arrayKey,
@@ -53,7 +52,7 @@ class CatalogStatsTest extends MockeryTestCase
         );
     }
 
-    public function methodDataProvider(): array
+    public static function methodDataProvider(): array
     {
         return [
             ['getConnectedCount', 'connected', 666, 0],

--- a/tests/Module/Application/Admin/Access/Lib/AccessListItemTest.php
+++ b/tests/Module/Application/Admin/Access/Lib/AccessListItemTest.php
@@ -29,16 +29,15 @@ use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\Model\User;
 use Ampache\Module\Authorization\Access;
 use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class AccessListItemTest extends MockeryTestCase
 {
-    /** @var MockInterface|Access|null */
-    private MockInterface $access;
+    private MockInterface&Access $access;
 
-    /** @var MockInterface|ModelFactoryInterface|null */
-    private MockInterface $modelFactory;
+    private MockInterface&ModelFactoryInterface $modelFactory;
 
-    private ?AccessListItem $subject;
+    private AccessListItem $subject;
 
     public function setUp(): void
     {
@@ -51,9 +50,7 @@ class AccessListItemTest extends MockeryTestCase
         );
     }
 
-    /**
-     * @dataProvider levelNameDataProvider
-     */
+    #[DataProvider(methodName: 'levelNameDataProvider')]
     public function testGetLevelNameReturnsLabel(
         int $level,
         string $label
@@ -66,7 +63,7 @@ class AccessListItemTest extends MockeryTestCase
         );
     }
 
-    public function levelNameDataProvider(): array
+    public static function levelNameDataProvider(): array
     {
         return [
             [99, 'All'],
@@ -113,9 +110,7 @@ class AccessListItemTest extends MockeryTestCase
         );
     }
 
-    /**
-     * @dataProvider typeNameDataProvider
-     */
+    #[DataProvider(methodName: 'typeNameDataProvider')]
     public function testGetTypeNameReturnLabel(
         string $typeId,
         string $label
@@ -128,7 +123,7 @@ class AccessListItemTest extends MockeryTestCase
         );
     }
 
-    public function typeNameDataProvider(): array
+    public static function typeNameDataProvider(): array
     {
         return [
             ['rpc', 'API/RPC'],

--- a/tests/Module/WebDav/WebDavFactoryTest.php
+++ b/tests/Module/WebDav/WebDavFactoryTest.php
@@ -28,16 +28,15 @@ use Ampache\Module\Authentication\AuthenticationManagerInterface;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Sabre\DAV\Auth\Plugin;
 use Sabre\DAV\Server;
 
 class WebDavFactoryTest extends MockeryTestCase
 {
-    /** @var AuthenticationManagerInterface|MockInterface|null */
-    private $authenticationManager;
+    private AuthenticationManagerInterface&MockInterface $authenticationManager;
 
-    /** @var WebDavFactory|null */
-    private ?WebDavFactory $subject;
+    private WebDavFactory $subject;
 
     public function setUp(): void
     {
@@ -48,9 +47,7 @@ class WebDavFactoryTest extends MockeryTestCase
         );
     }
 
-    /**
-     * @dataProvider methodDataProvider
-     */
+    #[DataProvider(methodName: 'methodDataProvider')]
     public function testFactoryMethods(string $method, string $expected_instance_name, array $params): void
     {
         static::assertInstanceOf(
@@ -59,7 +56,7 @@ class WebDavFactoryTest extends MockeryTestCase
         );
     }
 
-    public function methodDataProvider(): array
+    public static function methodDataProvider(): array
     {
         return [
             ['createWebDavAuth', WebDavAuth::class, []],


### PR DESCRIPTION
- Update data-provider method definitions (must be static now)
- Use PHP8 Attributes instead of annotations to call data-providers in tests
- Remove cache-warmup in `composer coverage` as it's no longer necessary