### PR TITLE
Streamline and consolidate user-admin confirmations

### DIFF
--- a/src/Module/Application/Admin/User/ShowDeleteApikeyAction.php
+++ b/src/Module/Application/Admin/User/ShowDeleteApikeyAction.php
@@ -20,54 +20,45 @@
  *
  */
 
-declare(strict_types=0);
+declare(strict_types=1);
 
 namespace Ampache\Module\Application\Admin\User;
 
-use Ampache\Config\ConfigContainerInterface;
 use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Renders the confirmation-dialogue for api-key deletion
+ */
 final class ShowDeleteApikeyAction extends AbstractUserAction
 {
+    use UserAdminApplicationTrait;
+
     public const REQUEST_KEY = 'show_delete_apikey';
 
-    private UiInterface $ui;
-
-    private ConfigContainerInterface $configContainer;
-
     public function __construct(
-        UiInterface $ui,
-        ConfigContainerInterface $configContainer
+        private readonly UiInterface $ui,
     ) {
-        $this->ui              = $ui;
-        $this->configContainer = $configContainer;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface
     {
-        $this->ui->showHeader();
-
-        $userId = (int)($request->getQueryParams()['user_id'] ?? 0);
-        if ($userId < 1) {
-            echo T_('You have requested an object that does not exist');
-        } else {
-            $this->ui->showConfirmation(
-                T_('Are You Sure?'),
-                T_('This Token will be deleted'),
-                sprintf(
-                    'admin/users.php?action=%s&user_id=%d',
-                    DeleteApikeyAction::REQUEST_KEY,
-                    $userId
-                ),
-                1,
-                'delete_apikey'
-            );
-        }
-        $this->ui->showQueryStats();
-        $this->ui->showFooter();
-
-        return null;
+        return $this->showGenericUserConfirmation(
+            $request,
+            function (int $userId): void {
+                $this->ui->showConfirmation(
+                    T_('Are You Sure?'),
+                    T_('This Token will be deleted'),
+                    sprintf(
+                        'admin/users.php?action=%s&user_id=%d',
+                        DeleteApikeyAction::REQUEST_KEY,
+                        $userId
+                    ),
+                    1,
+                    'delete_apikey'
+                );
+            }
+        );
     }
 }

--- a/src/Module/Application/Admin/User/ShowDeleteAvatarAction.php
+++ b/src/Module/Application/Admin/User/ShowDeleteAvatarAction.php
@@ -20,54 +20,45 @@
  *
  */
 
-declare(strict_types=0);
+declare(strict_types=1);
 
 namespace Ampache\Module\Application\Admin\User;
 
-use Ampache\Config\ConfigContainerInterface;
 use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Renders the confirmation dialogue for avatar deletion
+ */
 final class ShowDeleteAvatarAction extends AbstractUserAction
 {
+    use UserAdminApplicationTrait;
+
     public const REQUEST_KEY = 'show_delete_avatar';
 
-    private UiInterface $ui;
-
-    private ConfigContainerInterface $configContainer;
-
     public function __construct(
-        UiInterface $ui,
-        ConfigContainerInterface $configContainer
+        private readonly UiInterface $ui,
     ) {
-        $this->ui              = $ui;
-        $this->configContainer = $configContainer;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface
     {
-        $this->ui->showHeader();
-
-        $userId = (int)($request->getQueryParams()['user_id'] ?? 0);
-        if ($userId < 1) {
-            echo T_('You have requested an object that does not exist');
-        } else {
-            $this->ui->showConfirmation(
-                T_('Are You Sure?'),
-                T_('This Avatar will be deleted'),
-                sprintf(
-                    'admin/users.php?action=%s&user_id=%d',
-                    DeleteAvatarAction::REQUEST_KEY,
-                    $userId
-                ),
-                1,
-                'delete_avatar'
-            );
-        }
-        $this->ui->showQueryStats();
-        $this->ui->showFooter();
-
-        return null;
+        return $this->showGenericUserConfirmation(
+            $request,
+            function (int $userId): void {
+                $this->ui->showConfirmation(
+                    T_('Are You Sure?'),
+                    T_('This Avatar will be deleted'),
+                    sprintf(
+                        'admin/users.php?action=%s&user_id=%d',
+                        DeleteAvatarAction::REQUEST_KEY,
+                        $userId
+                    ),
+                    1,
+                    'delete_avatar'
+                );
+            }
+        );
     }
 }

--- a/src/Module/Application/Admin/User/ShowDeleteRsstokenAction.php
+++ b/src/Module/Application/Admin/User/ShowDeleteRsstokenAction.php
@@ -20,54 +20,45 @@
  *
  */
 
-declare(strict_types=0);
+declare(strict_types=1);
 
 namespace Ampache\Module\Application\Admin\User;
 
-use Ampache\Config\ConfigContainerInterface;
 use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Renders the confirmation dialogue for rss-token deletion
+ */
 final class ShowDeleteRsstokenAction extends AbstractUserAction
 {
+    use UserAdminApplicationTrait;
+
     public const REQUEST_KEY = 'show_delete_rsstoken';
 
-    private UiInterface $ui;
-
-    private ConfigContainerInterface $configContainer;
-
     public function __construct(
-        UiInterface $ui,
-        ConfigContainerInterface $configContainer
+        private readonly UiInterface $ui,
     ) {
-        $this->ui              = $ui;
-        $this->configContainer = $configContainer;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface
     {
-        $this->ui->showHeader();
-
-        $userId = (int)($request->getQueryParams()['user_id'] ?? 0);
-        if ($userId < 1) {
-            echo T_('You have requested an object that does not exist');
-        } else {
-            $this->ui->showConfirmation(
-                T_('Are You Sure?'),
-                T_('This Token will be deleted'),
-                sprintf(
-                    'admin/users.php?action=%s&user_id=%d',
-                    DeleteRsstokenAction::REQUEST_KEY,
-                    $userId
-                ),
-                1,
-                'delete_rsstoken'
-            );
-        }
-        $this->ui->showQueryStats();
-        $this->ui->showFooter();
-
-        return null;
+        return $this->showGenericUserConfirmation(
+            $request,
+            function (int $userId): void {
+                $this->ui->showConfirmation(
+                    T_('Are You Sure?'),
+                    T_('This Token will be deleted'),
+                    sprintf(
+                        'admin/users.php?action=%s&user_id=%d',
+                        DeleteRsstokenAction::REQUEST_KEY,
+                        $userId
+                    ),
+                    1,
+                    'delete_rsstoken'
+                );
+            }
+        );
     }
 }

--- a/src/Module/Application/Admin/User/ShowDeleteStreamtokenAction.php
+++ b/src/Module/Application/Admin/User/ShowDeleteStreamtokenAction.php
@@ -20,54 +20,45 @@
  *
  */
 
-declare(strict_types=0);
+declare(strict_types=1);
 
 namespace Ampache\Module\Application\Admin\User;
 
-use Ampache\Config\ConfigContainerInterface;
 use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Renders the confirmation dialogue for stream-token deletion
+ */
 final class ShowDeleteStreamtokenAction extends AbstractUserAction
 {
+    use UserAdminApplicationTrait;
+
     public const REQUEST_KEY = 'show_delete_streamtoken';
 
-    private UiInterface $ui;
-
-    private ConfigContainerInterface $configContainer;
-
     public function __construct(
-        UiInterface $ui,
-        ConfigContainerInterface $configContainer
+        private readonly UiInterface $ui,
     ) {
-        $this->ui              = $ui;
-        $this->configContainer = $configContainer;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface
     {
-        $this->ui->showHeader();
-
-        $userId = (int)($request->getQueryParams()['user_id'] ?? 0);
-        if ($userId < 1) {
-            echo T_('You have requested an object that does not exist');
-        } else {
-            $this->ui->showConfirmation(
-                T_('Are You Sure?'),
-                T_('This Token will be deleted'),
-                sprintf(
-                    'admin/users.php?action=%s&user_id=%d',
-                    DeleteStreamtokenAction::REQUEST_KEY,
-                    $userId
-                ),
-                1,
-                'delete_streamtoken'
-            );
-        }
-        $this->ui->showQueryStats();
-        $this->ui->showFooter();
-
-        return null;
+        return $this->showGenericUserConfirmation(
+            $request,
+            function (int $userId): void {
+                $this->ui->showConfirmation(
+                    T_('Are You Sure?'),
+                    T_('This Token will be deleted'),
+                    sprintf(
+                        'admin/users.php?action=%s&user_id=%d',
+                        DeleteStreamtokenAction::REQUEST_KEY,
+                        $userId
+                    ),
+                    1,
+                    'delete_streamtoken'
+                );
+            }
+        );
     }
 }

--- a/src/Module/Application/Admin/User/ShowGenerateApikeyAction.php
+++ b/src/Module/Application/Admin/User/ShowGenerateApikeyAction.php
@@ -24,50 +24,42 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Application\Admin\User;
 
-use Ampache\Config\ConfigContainerInterface;
 use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Renders the confirmation dialogue for api-key generation
+ */
 final class ShowGenerateApikeyAction extends AbstractUserAction
 {
+    use UserAdminApplicationTrait;
+
     public const REQUEST_KEY = 'show_generate_apikey';
 
-    private UiInterface $ui;
-
-    private ConfigContainerInterface $configContainer;
 
     public function __construct(
-        UiInterface $ui,
-        ConfigContainerInterface $configContainer
+        private readonly UiInterface $ui,
     ) {
-        $this->ui              = $ui;
-        $this->configContainer = $configContainer;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface
     {
-        $this->ui->showHeader();
-
-        $userId = (int)($request->getQueryParams()['user_id'] ?? 0);
-        if ($userId < 1) {
-            echo T_('You have requested an object that does not exist');
-        } else {
-            $this->ui->showConfirmation(
-                T_('Are You Sure?'),
-                T_('This will replace your existing API key'),
-                sprintf(
-                    'admin/users.php?action=%s&user_id=%d',
-                    GenerateApikeyAction::REQUEST_KEY,
-                    $userId
-                ),
-                1,
-                'generate_apikey'
-            );
-        }
-        $this->ui->showQueryStats();
-        $this->ui->showFooter();
-
-        return null;
+        return $this->showGenericUserConfirmation(
+            $request,
+            function (int $userId): void {
+                $this->ui->showConfirmation(
+                    T_('Are You Sure?'),
+                    T_('This will replace your existing API key'),
+                    sprintf(
+                        'admin/users.php?action=%s&user_id=%d',
+                        GenerateApikeyAction::REQUEST_KEY,
+                        $userId
+                    ),
+                    1,
+                    'generate_apikey'
+                );
+            }
+        );
     }
 }

--- a/src/Module/Application/Admin/User/ShowGenerateRsstokenAction.php
+++ b/src/Module/Application/Admin/User/ShowGenerateRsstokenAction.php
@@ -24,50 +24,41 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Application\Admin\User;
 
-use Ampache\Config\ConfigContainerInterface;
 use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Renders the confirmation dialogue for rss-token generation
+ */
 final class ShowGenerateRsstokenAction extends AbstractUserAction
 {
+    use UserAdminApplicationTrait;
+
     public const REQUEST_KEY = 'show_generate_rsstoken';
 
-    private UiInterface $ui;
-
-    private ConfigContainerInterface $configContainer;
-
     public function __construct(
-        UiInterface $ui,
-        ConfigContainerInterface $configContainer
+        private readonly UiInterface $ui,
     ) {
-        $this->ui              = $ui;
-        $this->configContainer = $configContainer;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface
     {
-        $this->ui->showHeader();
-
-        $userId = (int)($request->getQueryParams()['user_id'] ?? 0);
-        if ($userId < 1) {
-            echo T_('You have requested an object that does not exist');
-        } else {
-            $this->ui->showConfirmation(
-                T_('Are You Sure?'),
-                T_('This will replace your existing token. Links with the old token might not work properly'),
-                sprintf(
-                    'admin/users.php?action=%s&user_id=%d',
-                    GenerateRsstokenAction::REQUEST_KEY,
-                    $userId
-                ),
-                1,
-                'generate_rsstoken'
-            );
-        }
-        $this->ui->showQueryStats();
-        $this->ui->showFooter();
-
-        return null;
+        return $this->showGenericUserConfirmation(
+            $request,
+            function (int $userId): void {
+                $this->ui->showConfirmation(
+                    T_('Are You Sure?'),
+                    T_('This will replace your existing token. Links with the old token might not work properly'),
+                    sprintf(
+                        'admin/users.php?action=%s&user_id=%d',
+                        GenerateRsstokenAction::REQUEST_KEY,
+                        $userId
+                    ),
+                    1,
+                    'generate_rsstoken'
+                );
+            }
+        );
     }
 }

--- a/src/Module/Application/Admin/User/ShowGenerateStreamtokenAction.php
+++ b/src/Module/Application/Admin/User/ShowGenerateStreamtokenAction.php
@@ -24,50 +24,41 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Application\Admin\User;
 
-use Ampache\Config\ConfigContainerInterface;
 use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Renders the confirmation dialogue for stream-token deletion
+ */
 final class ShowGenerateStreamtokenAction extends AbstractUserAction
 {
+    use UserAdminApplicationTrait;
+
     public const REQUEST_KEY = 'show_generate_streamtoken';
 
-    private UiInterface $ui;
-
-    private ConfigContainerInterface $configContainer;
-
     public function __construct(
-        UiInterface $ui,
-        ConfigContainerInterface $configContainer
+        private readonly UiInterface $ui,
     ) {
-        $this->ui              = $ui;
-        $this->configContainer = $configContainer;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface
     {
-        $this->ui->showHeader();
-
-        $userId = (int)($request->getQueryParams()['user_id'] ?? 0);
-        if ($userId < 1) {
-            echo T_('You have requested an object that does not exist');
-        } else {
-            $this->ui->showConfirmation(
-                T_('Are You Sure?'),
-                T_('This will replace your existing token. Links with the old token might not work properly'),
-                sprintf(
-                    'admin/users.php?action=%s&user_id=%d',
-                    GenerateStreamtokenAction::REQUEST_KEY,
-                    $userId
-                ),
-                1,
-                'generate_streamtoken'
-            );
-        }
-        $this->ui->showQueryStats();
-        $this->ui->showFooter();
-
-        return null;
+        return $this->showGenericUserConfirmation(
+            $request,
+            function (int $userId): void {
+                $this->ui->showConfirmation(
+                    T_('Are You Sure?'),
+                    T_('This will replace your existing token. Links with the old token might not work properly'),
+                    sprintf(
+                        'admin/users.php?action=%s&user_id=%d',
+                        GenerateStreamtokenAction::REQUEST_KEY,
+                        $userId
+                    ),
+                    1,
+                    'generate_streamtoken'
+                );
+            }
+        );
     }
 }

--- a/src/Module/Application/Admin/User/UserAdminApplicationTrait.php
+++ b/src/Module/Application/Admin/User/UserAdminApplicationTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ampache\Module\Application\Admin\User;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Provides generic methods for re-use within the user-admin application context
+ */
+trait UserAdminApplicationTrait
+{
+    /**
+     * Renders a simple confirmation dialogue
+     *
+     * @param callable(int): void $dialogCallback The custom dialogue renderer callback
+     */
+    public function showGenericUserConfirmation(
+        ServerRequestInterface $request,
+        callable $dialogCallback
+    ): ?ResponseInterface {
+        $this->ui->showHeader();
+
+        $userId = (int) ($request->getQueryParams()['user_id'] ?? 0);
+
+        if ($userId < 1) {
+            echo T_('You have requested an object that does not exist');
+        } else {
+            $dialogCallback($userId);
+        }
+
+        $this->ui->showQueryStats();
+        $this->ui->showFooter();
+
+        return null;
+    }
+}

--- a/tests/Module/Application/Admin/User/ShowDeleteApikeyActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowDeleteApikeyActionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -28,18 +29,19 @@ use Ampache\Module\Util\UiInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class ShowDeleteAvatarActionTest extends TestCase
+class ShowDeleteApikeyActionTest extends TestCase
 {
     use UserAdminConfirmationTestTrait;
+
     private MockObject&UiInterface $ui;
 
-    private ShowDeleteAvatarAction $subject;
+    private ShowDeleteApikeyAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->createMock(UiInterface::class);
 
-        $this->subject = new ShowDeleteAvatarAction(
+        $this->subject = new ShowDeleteApikeyAction(
             $this->ui,
         );
     }
@@ -52,14 +54,14 @@ class ShowDeleteAvatarActionTest extends TestCase
                     ->method('showConfirmation')
                     ->with(
                         'Are You Sure?',
-                        'This Avatar will be deleted',
+                        'This Token will be deleted',
                         sprintf(
                             'admin/users.php?action=%s&user_id=%d',
-                            DeleteAvatarAction::REQUEST_KEY,
+                            DeleteApikeyAction::REQUEST_KEY,
                             $userId
                         ),
                         1,
-                        'delete_avatar'
+                        'delete_apikey'
                     );
             }
         );

--- a/tests/Module/Application/Admin/User/ShowDeleteRsstokenActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowDeleteRsstokenActionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -28,18 +29,18 @@ use Ampache\Module\Util\UiInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class ShowDeleteAvatarActionTest extends TestCase
+class ShowDeleteRsstokenActionTest extends TestCase
 {
     use UserAdminConfirmationTestTrait;
     private MockObject&UiInterface $ui;
 
-    private ShowDeleteAvatarAction $subject;
+    private ShowDeleteRsstokenAction $subject;
 
     public function setUp(): void
     {
         $this->ui = $this->createMock(UiInterface::class);
 
-        $this->subject = new ShowDeleteAvatarAction(
+        $this->subject = new ShowDeleteRsstokenAction(
             $this->ui,
         );
     }
@@ -52,14 +53,14 @@ class ShowDeleteAvatarActionTest extends TestCase
                     ->method('showConfirmation')
                     ->with(
                         'Are You Sure?',
-                        'This Avatar will be deleted',
+                        'This Token will be deleted',
                         sprintf(
                             'admin/users.php?action=%s&user_id=%d',
-                            DeleteAvatarAction::REQUEST_KEY,
+                            DeleteRsstokenAction::REQUEST_KEY,
                             $userId
                         ),
                         1,
-                        'delete_avatar'
+                        'delete_rsstoken'
                     );
             }
         );

--- a/tests/Module/Application/Admin/User/ShowDeleteStreamtokenActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowDeleteStreamtokenActionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -28,18 +29,18 @@ use Ampache\Module\Util\UiInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class ShowDeleteAvatarActionTest extends TestCase
+class ShowDeleteStreamtokenActionTest extends TestCase
 {
     use UserAdminConfirmationTestTrait;
     private MockObject&UiInterface $ui;
 
-    private ShowDeleteAvatarAction $subject;
+    private ShowDeleteStreamtokenAction $subject;
 
     public function setUp(): void
     {
         $this->ui = $this->createMock(UiInterface::class);
 
-        $this->subject = new ShowDeleteAvatarAction(
+        $this->subject = new ShowDeleteStreamtokenAction(
             $this->ui,
         );
     }
@@ -52,14 +53,14 @@ class ShowDeleteAvatarActionTest extends TestCase
                     ->method('showConfirmation')
                     ->with(
                         'Are You Sure?',
-                        'This Avatar will be deleted',
+                        'This Token will be deleted',
                         sprintf(
                             'admin/users.php?action=%s&user_id=%d',
-                            DeleteAvatarAction::REQUEST_KEY,
+                            DeleteStreamtokenAction::REQUEST_KEY,
                             $userId
                         ),
                         1,
-                        'delete_avatar'
+                        'delete_streamtoken'
                     );
             }
         );

--- a/tests/Module/Application/Admin/User/ShowGenerateApikeyActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowGenerateApikeyActionTest.php
@@ -28,71 +28,45 @@ use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Util\UiInterface;
 use Mockery\MockInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
-class ShowGenerateApikeyActionTest extends MockeryTestCase
+class ShowGenerateApikeyActionTest extends TestCase
 {
-    /** @var UiInterface|MockInterface|null */
-    private MockInterface $ui;
+    use UserAdminConfirmationTestTrait;
 
-    /** @var ConfigContainerInterface|MockInterface|null */
-    private MockInterface $configContainer;
+    private MockObject&UiInterface $ui;
 
-    private ?ShowGenerateApikeyAction $subject;
+    private ShowGenerateApikeyAction $subject;
 
     public function setUp(): void
     {
-        $this->ui              = $this->mock(UiInterface::class);
-        $this->configContainer = $this->mock(ConfigContainerInterface::class);
+        $this->ui = $this->createMock(UiInterface::class);
 
         $this->subject = new ShowGenerateApikeyAction(
             $this->ui,
-            $this->configContainer
         );
     }
 
-    public function testRunRendersConfirmation(): void
+    public function testHandleRendersConfirmation(): void
     {
-        $request    = $this->mock(ServerRequestInterface::class);
-        $gatekeeper = $this->mock(GuiGatekeeperInterface::class);
-
-        $userId = 42;
-
-        $gatekeeper->shouldReceive('mayAccess')
-            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
-            ->once()
-            ->andReturnTrue();
-
-        $request->shouldReceive('getQueryParams')
-            ->withNoArgs()
-            ->once()
-            ->andReturn(['user_id' => (string) $userId]);
-
-        $this->ui->shouldReceive('showHeader')
-            ->withNoArgs()
-            ->once();
-        $this->ui->shouldReceive('showQueryStats')
-            ->withNoArgs()
-            ->once();
-        $this->ui->shouldReceive('showFooter')
-            ->withNoArgs()
-            ->once();
-        $this->ui->shouldReceive('showConfirmation')
-            ->with(
-                'Are You Sure?',
-                'This will replace your existing API key',
-                sprintf(
-                    'admin/users.php?action=%s&user_id=%d',
-                    GenerateApikeyAction::REQUEST_KEY,
-                    $userId
-                ),
-                1,
-                'generate_apikey'
-            )
-            ->once();
-
-        $this->assertNull(
-            $this->subject->run($request, $gatekeeper)
+        $this->createConfirmationExpectations(
+            function (int $userId): void {
+                $this->ui->expects(static::once())
+                    ->method('showConfirmation')
+                    ->with(
+                        'Are You Sure?',
+                        'This will replace your existing API key',
+                        sprintf(
+                            'admin/users.php?action=%s&user_id=%d',
+                            GenerateApikeyAction::REQUEST_KEY,
+                            $userId
+                        ),
+                        1,
+                        'generate_apikey'
+                    );
+            }
         );
     }
 }

--- a/tests/Module/Application/Admin/User/ShowGenerateRsstokenActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowGenerateRsstokenActionTest.php
@@ -24,77 +24,45 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Application\Admin\User;
 
-use Ampache\Config\ConfigContainerInterface;
-use Ampache\MockeryTestCase;
-use Ampache\Module\Authorization\AccessLevelEnum;
-use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Util\UiInterface;
-use Mockery\MockInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class ShowGenerateRsstokenActionTest extends MockeryTestCase
+class ShowGenerateRsstokenActionTest extends TestCase
 {
-    /** @var UiInterface|MockInterface|null */
-    private MockInterface $ui;
+    use UserAdminConfirmationTestTrait;
 
-    /** @var ConfigContainerInterface|MockInterface|null */
-    private MockInterface $configContainer;
+    private MockObject&UiInterface $ui;
 
-    private ?ShowGenerateRsstokenAction $subject;
+    private ShowGenerateRsstokenAction $subject;
 
     public function setUp(): void
     {
-        $this->ui              = $this->mock(UiInterface::class);
-        $this->configContainer = $this->mock(ConfigContainerInterface::class);
+        $this->ui = $this->createMock(UiInterface::class);
 
         $this->subject = new ShowGenerateRsstokenAction(
             $this->ui,
-            $this->configContainer
         );
     }
 
-    public function testRunRendersConfirmation(): void
+    public function testHandleRendersConfirmation(): void
     {
-        $request    = $this->mock(ServerRequestInterface::class);
-        $gatekeeper = $this->mock(GuiGatekeeperInterface::class);
-
-        $userId = 42;
-
-        $gatekeeper->shouldReceive('mayAccess')
-            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
-            ->once()
-            ->andReturnTrue();
-
-        $request->shouldReceive('getQueryParams')
-            ->withNoArgs()
-            ->once()
-            ->andReturn(['user_id' => (string) $userId]);
-
-        $this->ui->shouldReceive('showHeader')
-            ->withNoArgs()
-            ->once();
-        $this->ui->shouldReceive('showQueryStats')
-            ->withNoArgs()
-            ->once();
-        $this->ui->shouldReceive('showFooter')
-            ->withNoArgs()
-            ->once();
-        $this->ui->shouldReceive('showConfirmation')
-            ->with(
-                'Are You Sure?',
-                'This will replace your existing token. Links with the old token might not work properly',
-                sprintf(
-                    'admin/users.php?action=%s&user_id=%d',
-                    GenerateRsstokenAction::REQUEST_KEY,
-                    $userId
-                ),
-                1,
-                'generate_rsstoken'
-            )
-        ->once();
-
-        $this->assertNull(
-            $this->subject->run($request, $gatekeeper)
+        $this->createConfirmationExpectations(
+            function (int $userId): void {
+                $this->ui->expects(static::once())
+                    ->method('showConfirmation')
+                    ->with(
+                        'Are You Sure?',
+                        'This will replace your existing token. Links with the old token might not work properly',
+                        sprintf(
+                            'admin/users.php?action=%s&user_id=%d',
+                            GenerateRsstokenAction::REQUEST_KEY,
+                            $userId
+                        ),
+                        1,
+                        'generate_rsstoken'
+                    );
+            }
         );
     }
 }

--- a/tests/Module/Application/Admin/User/ShowGenerateStreamtokenActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowGenerateStreamtokenActionTest.php
@@ -24,77 +24,46 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Application\Admin\User;
 
-use Ampache\Config\ConfigContainerInterface;
-use Ampache\MockeryTestCase;
-use Ampache\Module\Authorization\AccessLevelEnum;
-use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Util\UiInterface;
-use Mockery\MockInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class ShowGenerateStreamtokenActionTest extends MockeryTestCase
+class ShowGenerateStreamtokenActionTest extends TestCase
 {
-    /** @var UiInterface|MockInterface|null */
-    private MockInterface $ui;
+    use UserAdminConfirmationTestTrait;
 
-    /** @var ConfigContainerInterface|MockInterface|null */
-    private MockInterface $configContainer;
+    private MockObject&UiInterface $ui;
 
-    private ?ShowGenerateStreamtokenAction $subject;
+    private ShowGenerateStreamtokenAction $subject;
 
     public function setUp(): void
     {
-        $this->ui              = $this->mock(UiInterface::class);
-        $this->configContainer = $this->mock(ConfigContainerInterface::class);
+        $this->ui = $this->createMock(UiInterface::class);
 
         $this->subject = new ShowGenerateStreamtokenAction(
             $this->ui,
-            $this->configContainer
         );
     }
 
-    public function testRunRendersConfirmation(): void
+
+    public function testHandleRendersConfirmation(): void
     {
-        $request    = $this->mock(ServerRequestInterface::class);
-        $gatekeeper = $this->mock(GuiGatekeeperInterface::class);
-
-        $userId = 42;
-
-        $gatekeeper->shouldReceive('mayAccess')
-            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
-            ->once()
-            ->andReturnTrue();
-
-        $request->shouldReceive('getQueryParams')
-            ->withNoArgs()
-            ->once()
-            ->andReturn(['user_id' => (string) $userId]);
-
-        $this->ui->shouldReceive('showHeader')
-            ->withNoArgs()
-            ->once();
-        $this->ui->shouldReceive('showQueryStats')
-            ->withNoArgs()
-            ->once();
-        $this->ui->shouldReceive('showFooter')
-            ->withNoArgs()
-            ->once();
-        $this->ui->shouldReceive('showConfirmation')
-            ->with(
-                'Are You Sure?',
-                'This will replace your existing token. Links with the old token might not work properly',
-                sprintf(
-                    'admin/users.php?action=%s&user_id=%d',
-                    GenerateStreamtokenAction::REQUEST_KEY,
-                    $userId
-                ),
-                1,
-                'generate_streamtoken'
-            )
-        ->once();
-
-        $this->assertNull(
-            $this->subject->run($request, $gatekeeper)
+        $this->createConfirmationExpectations(
+            function (int $userId): void {
+                $this->ui->expects(static::once())
+                    ->method('showConfirmation')
+                    ->with(
+                        'Are You Sure?',
+                        'This will replace your existing token. Links with the old token might not work properly',
+                        sprintf(
+                            'admin/users.php?action=%s&user_id=%d',
+                            GenerateStreamtokenAction::REQUEST_KEY,
+                            $userId
+                        ),
+                        1,
+                        'generate_streamtoken'
+                    );
+            }
         );
     }
 }

--- a/tests/Module/Application/Admin/User/UserAdminConfirmationTestTrait.php
+++ b/tests/Module/Application/Admin/User/UserAdminConfirmationTestTrait.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ampache\Module\Application\Admin\User;
+
+use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\GuiGatekeeperInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+trait UserAdminConfirmationTestTrait
+{
+    public function testHandleErrorsIfTheProvidedUserIdIsLesserThenOne(): void
+    {
+        $request    = $this->createMock(ServerRequestInterface::class);
+        $gatekeeper = $this->createMock(GuiGatekeeperInterface::class);
+
+        $gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $request->expects(static::once())
+            ->method('getQueryParams')
+            ->willReturn(['user_id' => (string) -1]);
+
+        $this->ui->expects(static::once())
+            ->method('showHeader');
+        $this->ui->expects(static::once())
+            ->method('showQueryStats');
+        $this->ui->expects(static::once())
+            ->method('showFooter');
+
+        static::expectOutputString('You have requested an object that does not exist');
+
+        static::assertNull(
+            $this->subject->run($request, $gatekeeper)
+        );
+    }
+
+    /**
+     * @param callable(int):void $confirmationExpectationsCallback
+     */
+    private function createConfirmationExpectations(
+        callable $confirmationExpectationsCallback
+    ): void {
+        $request    = $this->createMock(ServerRequestInterface::class);
+        $gatekeeper = $this->createMock(GuiGatekeeperInterface::class);
+
+        $userId = 666;
+
+        $gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $request->expects(static::once())
+            ->method('getQueryParams')
+            ->willReturn(['user_id' => (string) $userId]);
+
+        $this->ui->expects(static::once())
+            ->method('showHeader');
+        $this->ui->expects(static::once())
+            ->method('showQueryStats');
+        $this->ui->expects(static::once())
+            ->method('showFooter');
+
+        $confirmationExpectationsCallback($userId);
+
+        static::assertNull(
+            $this->subject->run($request, $gatekeeper)
+        );
+    }
+}


### PR DESCRIPTION
Avoid c/p code by using a trait for all those user-admin confirmation dialogues. Also add some more tests.