### PR TITLE
Add tests for admin user deletion confirmation

### DIFF
--- a/src/Module/Application/Admin/User/ShowDeleteApikeyAction.php
+++ b/src/Module/Application/Admin/User/ShowDeleteApikeyAction.php
@@ -37,9 +37,12 @@ final class ShowDeleteApikeyAction extends AbstractUserAction
 
     public const REQUEST_KEY = 'show_delete_apikey';
 
+    private UiInterface $ui;
+
     public function __construct(
-        private readonly UiInterface $ui,
+        UiInterface $ui
     ) {
+        $this->ui = $ui;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface

--- a/src/Module/Application/Admin/User/ShowDeleteAvatarAction.php
+++ b/src/Module/Application/Admin/User/ShowDeleteAvatarAction.php
@@ -37,9 +37,12 @@ final class ShowDeleteAvatarAction extends AbstractUserAction
 
     public const REQUEST_KEY = 'show_delete_avatar';
 
+    private UiInterface $ui;
+
     public function __construct(
-        private readonly UiInterface $ui,
+        UiInterface $ui
     ) {
+        $this->ui = $ui;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface

--- a/src/Module/Application/Admin/User/ShowDeleteRsstokenAction.php
+++ b/src/Module/Application/Admin/User/ShowDeleteRsstokenAction.php
@@ -37,9 +37,12 @@ final class ShowDeleteRsstokenAction extends AbstractUserAction
 
     public const REQUEST_KEY = 'show_delete_rsstoken';
 
+    private UiInterface $ui;
+
     public function __construct(
-        private readonly UiInterface $ui,
+        UiInterface $ui
     ) {
+        $this->ui = $ui;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface

--- a/src/Module/Application/Admin/User/ShowDeleteStreamtokenAction.php
+++ b/src/Module/Application/Admin/User/ShowDeleteStreamtokenAction.php
@@ -37,9 +37,12 @@ final class ShowDeleteStreamtokenAction extends AbstractUserAction
 
     public const REQUEST_KEY = 'show_delete_streamtoken';
 
+    private UiInterface $ui;
+
     public function __construct(
-        private readonly UiInterface $ui,
+        UiInterface $ui
     ) {
+        $this->ui = $ui;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface

--- a/src/Module/Application/Admin/User/ShowGenerateApikeyAction.php
+++ b/src/Module/Application/Admin/User/ShowGenerateApikeyAction.php
@@ -37,10 +37,12 @@ final class ShowGenerateApikeyAction extends AbstractUserAction
 
     public const REQUEST_KEY = 'show_generate_apikey';
 
+    private UiInterface $ui;
 
     public function __construct(
-        private readonly UiInterface $ui,
+        UiInterface $ui
     ) {
+        $this->ui = $ui;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface

--- a/src/Module/Application/Admin/User/ShowGenerateRsstokenAction.php
+++ b/src/Module/Application/Admin/User/ShowGenerateRsstokenAction.php
@@ -37,9 +37,12 @@ final class ShowGenerateRsstokenAction extends AbstractUserAction
 
     public const REQUEST_KEY = 'show_generate_rsstoken';
 
+    private UiInterface $ui;
+
     public function __construct(
-        private readonly UiInterface $ui,
+        UiInterface $ui
     ) {
+        $this->ui = $ui;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface

--- a/src/Module/Application/Admin/User/ShowGenerateStreamtokenAction.php
+++ b/src/Module/Application/Admin/User/ShowGenerateStreamtokenAction.php
@@ -37,9 +37,12 @@ final class ShowGenerateStreamtokenAction extends AbstractUserAction
 
     public const REQUEST_KEY = 'show_generate_streamtoken';
 
+    private UiInterface $ui;
+
     public function __construct(
-        private readonly UiInterface $ui,
+        UiInterface $ui
     ) {
+        $this->ui = $ui;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface

--- a/src/Module/Application/Search/SearchAction.php
+++ b/src/Module/Application/Search/SearchAction.php
@@ -54,7 +54,7 @@ final class SearchAction implements ApplicationActionInterface
         ModelFactoryInterface $modelFactory,
         MissingArtistFinderInterface $missingArtistFinder
     ) {
-        $this->requestParser   = $requestParser;
+        $this->requestParser       = $requestParser;
         $this->ui                  = $ui;
         $this->modelFactory        = $modelFactory;
         $this->missingArtistFinder = $missingArtistFinder;

--- a/src/Module/System/Core.php
+++ b/src/Module/System/Core.php
@@ -25,6 +25,7 @@ declare(strict_types=0);
 namespace Ampache\Module\System;
 
 use Ampache\Config\AmpConfig;
+use Ampache\Module\Util\RequestParser;
 use Exception;
 
 /**
@@ -191,6 +192,8 @@ class Core
      * @param string $name
      * @param string $type
      * @return bool
+     *
+     * @see RequestParser::verifyForm()
      */
     public static function form_verify($name, $type = 'post')
     {

--- a/src/Module/Util/RequestParser.php
+++ b/src/Module/Util/RequestParser.php
@@ -24,6 +24,8 @@ declare(strict_types=0);
 
 namespace Ampache\Module\Util;
 
+use Ampache\Module\System\Core;
+
 final class RequestParser implements RequestParserInterface
 {
     /**
@@ -36,5 +38,22 @@ final class RequestParser implements RequestParserInterface
         }
 
         return scrub_in($_REQUEST[$variable]);
+    }
+
+    /**
+     * Check if the form-submit is valid
+     *
+     * If the application expects a form-submit, check if it's actually
+     * a valid submit (by validating a session token).
+     * This method currently proxies the verification to a static method within
+     * the core-class to make it testable.
+     *
+     * @return bool True, if the form-submit is considered valid
+     *
+     * @see Core::form_verify()
+     */
+    public function verifyForm(string $formName): bool
+    {
+        return Core::form_verify($formName);
     }
 }

--- a/src/Module/Util/RequestParserInterface.php
+++ b/src/Module/Util/RequestParserInterface.php
@@ -28,4 +28,14 @@ interface RequestParserInterface
      * Return a $REQUEST variable instead of calling directly
      */
     public function getFromRequest(string $variable): string;
+
+    /**
+     * Check if the form-submit is valid
+     *
+     * If the application expects a form-submit, check if it's actually
+     * a valid submit (by validating a session token).
+     *
+     * @return bool True, if the form-submit is considered valid
+     */
+    public function verifyForm(string $formName): bool;
 }

--- a/src/Repository/Model/User.php
+++ b/src/Repository/Model/User.php
@@ -1593,6 +1593,14 @@ class User extends database_object
     }
 
     /**
+     * Returns the users internal username
+     */
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    /**
      * @deprecated inject dependency
      */
     private function getIpHistoryRepository(): IpHistoryRepositoryInterface

--- a/tests/Module/Application/Admin/User/ConfirmDeleteActionTest.php
+++ b/tests/Module/Application/Admin/User/ConfirmDeleteActionTest.php
@@ -1,0 +1,204 @@
+<?php
+
+/*
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Ampache\Module\Application\Admin\User;
+
+use Ampache\Config\ConfigContainerInterface;
+use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\GuiGatekeeperInterface;
+use Ampache\Module\Util\RequestParserInterface;
+use Ampache\Module\Util\UiInterface;
+use Ampache\Repository\Model\ModelFactoryInterface;
+use Ampache\Repository\Model\User;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+class ConfirmDeleteActionTest extends TestCase
+{
+    use UserAdminAccessTestTrait;
+
+    /** @var MockObject&RequestParserInterface */
+    private MockObject $requestParser;
+
+    /** @var MockObject&UiInterface */
+    private MockObject $ui;
+
+    /** @var MockObject&ModelFactoryInterface */
+    private MockObject $modelFactory;
+
+    /** @var MockObject&ConfigContainerInterface */
+    private MockObject $configContainer;
+
+    /** @var MockObject&GuiGatekeeperInterface */
+    private MockObject $gatekeeper;
+
+    /** @var MockObject&ServerRequestInterface  */
+    private MockObject $request;
+
+    private ConfirmDeleteAction $subject;
+
+    protected function setUp(): void
+    {
+        $this->requestParser   = $this->createMock(RequestParserInterface::class);
+        $this->ui              = $this->createMock(UiInterface::class);
+        $this->modelFactory    = $this->createMock(ModelFactoryInterface::class);
+        $this->configContainer = $this->createMock(ConfigContainerInterface::class);
+
+        $this->subject = new ConfirmDeleteAction(
+            $this->requestParser,
+            $this->ui,
+            $this->modelFactory,
+            $this->configContainer,
+        );
+
+        $this->gatekeeper = $this->createMock(GuiGatekeeperInterface::class);
+        $this->request    = $this->createMock(ServerRequestInterface::class);
+    }
+
+    protected function getValidationFormName(): string
+    {
+        return 'delete_user';
+    }
+
+    public function testHandleDeletes(): void
+    {
+        $userId   = 666;
+        $webPath  = 'some-path';
+        $userName = 'some-name';
+
+        $user = $this->createMock(User::class);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::DEMO_MODE)
+            ->willReturn(false);
+        $this->configContainer->expects(static::once())
+            ->method('getWebPath')
+            ->willReturn($webPath);
+
+        $this->requestParser->expects(static::once())
+            ->method('verifyForm')
+            ->with('delete_user')
+            ->willReturn(true);
+
+        $this->request->expects(static::once())
+            ->method('getQueryParams')
+            ->willReturn(['user_id' => (string) $userId]);
+
+        $this->modelFactory->expects(static::once())
+            ->method('createUser')
+            ->with($userId)
+            ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('getUsername')
+            ->willReturn($userName);
+        $user->expects(static::once())
+            ->method('delete')
+            ->willReturn(true);
+
+        $this->ui->expects(static::once())
+            ->method('showHeader');
+        $this->ui->expects(static::once())
+            ->method('showConfirmation')
+            ->with(
+                'No Problem',
+                sprintf('%s has been deleted', $userName),
+                sprintf('%s/admin/users.php', $webPath)
+            );
+        $this->ui->expects(static::once())
+            ->method('showQueryStats');
+        $this->ui->expects(static::once())
+            ->method('showFooter');
+
+        static::assertNull(
+            $this->subject->run($this->request, $this->gatekeeper)
+        );
+    }
+
+    public function testHandleErrorsOnDeletionFailure(): void
+    {
+        $userId  = 666;
+        $webPath = 'some-path';
+
+        $user = $this->createMock(User::class);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::DEMO_MODE)
+            ->willReturn(false);
+        $this->configContainer->expects(static::once())
+            ->method('getWebPath')
+            ->willReturn($webPath);
+
+        $this->requestParser->expects(static::once())
+            ->method('verifyForm')
+            ->with('delete_user')
+            ->willReturn(true);
+
+        $this->request->expects(static::once())
+            ->method('getQueryParams')
+            ->willReturn(['user_id' => (string) $userId]);
+
+        $this->modelFactory->expects(static::once())
+            ->method('createUser')
+            ->with($userId)
+            ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('delete')
+            ->willReturn(false);
+
+        $this->ui->expects(static::once())
+            ->method('showHeader');
+        $this->ui->expects(static::once())
+            ->method('showConfirmation')
+            ->with(
+                'There Was a Problem',
+                'You need at least one active Administrator account',
+                sprintf('%s/admin/users.php', $webPath)
+            );
+        $this->ui->expects(static::once())
+            ->method('showQueryStats');
+        $this->ui->expects(static::once())
+            ->method('showFooter');
+
+        static::assertNull(
+            $this->subject->run($this->request, $this->gatekeeper)
+        );
+    }
+}

--- a/tests/Module/Application/Admin/User/UserAdminAccessTestTrait.php
+++ b/tests/Module/Application/Admin/User/UserAdminAccessTestTrait.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ampache\Module\Application\Admin\User;
+
+use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\Application\Exception\AccessDeniedException;
+use Ampache\Module\Authorization\AccessLevelEnum;
+
+trait UserAdminAccessTestTrait
+{
+    public function testHandleThrowsIfAccessIsDenied(): void
+    {
+        static::expectException(AccessDeniedException::class);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(false);
+
+        $this->subject->run($this->request, $this->gatekeeper);
+    }
+
+    public function testHandleReturnsNullIfDemoMode(): void
+    {
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::DEMO_MODE)
+            ->willReturn(true);
+
+        static::assertNull(
+            $this->subject->run($this->request, $this->gatekeeper)
+        );
+    }
+
+    public function testFormValidationErrorsIfInvalid(): void
+    {
+        static::expectException(AccessDeniedException::class);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::DEMO_MODE)
+            ->willReturn(false);
+
+        $this->requestParser->expects(static::once())
+            ->method('verifyForm')
+            ->with($this->getValidationFormName())
+            ->willReturn(false);
+
+        $this->subject->run($this->request, $this->gatekeeper);
+    }
+
+    /**
+     * Returns the name of the form to verify after submit
+     */
+    abstract protected function getValidationFormName(): string;
+}


### PR DESCRIPTION
Also:
- Add a method in RequestParser to proxy the Core::form_verify-call (which helps in making this handler testable)
- Add a test-trait for repetetive tests within the user admin access context