### PR TITLE
Move User::count() into UserRepository

### DIFF
--- a/src/Module/Application/Admin/User/ShowDeleteApikeyAction.php
+++ b/src/Module/Application/Admin/User/ShowDeleteApikeyAction.php
@@ -37,9 +37,12 @@ final class ShowDeleteApikeyAction extends AbstractUserAction
 
     public const REQUEST_KEY = 'show_delete_apikey';
 
+    private UiInterface $ui;
+
     public function __construct(
-        private readonly UiInterface $ui,
+        UiInterface $ui
     ) {
+        $this->ui = $ui;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface

--- a/src/Module/Application/Admin/User/ShowDeleteAvatarAction.php
+++ b/src/Module/Application/Admin/User/ShowDeleteAvatarAction.php
@@ -37,9 +37,12 @@ final class ShowDeleteAvatarAction extends AbstractUserAction
 
     public const REQUEST_KEY = 'show_delete_avatar';
 
+    private UiInterface $ui;
+
     public function __construct(
-        private readonly UiInterface $ui,
+        UiInterface $ui
     ) {
+        $this->ui = $ui;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface

--- a/src/Module/Application/Admin/User/ShowDeleteRsstokenAction.php
+++ b/src/Module/Application/Admin/User/ShowDeleteRsstokenAction.php
@@ -37,9 +37,12 @@ final class ShowDeleteRsstokenAction extends AbstractUserAction
 
     public const REQUEST_KEY = 'show_delete_rsstoken';
 
+    private UiInterface $ui;
+
     public function __construct(
-        private readonly UiInterface $ui,
+        UiInterface $ui
     ) {
+        $this->ui = $ui;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface

--- a/src/Module/Application/Admin/User/ShowDeleteStreamtokenAction.php
+++ b/src/Module/Application/Admin/User/ShowDeleteStreamtokenAction.php
@@ -37,9 +37,12 @@ final class ShowDeleteStreamtokenAction extends AbstractUserAction
 
     public const REQUEST_KEY = 'show_delete_streamtoken';
 
+    private UiInterface $ui;
+
     public function __construct(
-        private readonly UiInterface $ui,
+        UiInterface $ui
     ) {
+        $this->ui = $ui;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface

--- a/src/Module/Application/Admin/User/ShowGenerateApikeyAction.php
+++ b/src/Module/Application/Admin/User/ShowGenerateApikeyAction.php
@@ -37,10 +37,12 @@ final class ShowGenerateApikeyAction extends AbstractUserAction
 
     public const REQUEST_KEY = 'show_generate_apikey';
 
+    private UiInterface $ui;
 
     public function __construct(
-        private readonly UiInterface $ui,
+        UiInterface $ui
     ) {
+        $this->ui = $ui;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface

--- a/src/Module/Application/Admin/User/ShowGenerateRsstokenAction.php
+++ b/src/Module/Application/Admin/User/ShowGenerateRsstokenAction.php
@@ -37,9 +37,12 @@ final class ShowGenerateRsstokenAction extends AbstractUserAction
 
     public const REQUEST_KEY = 'show_generate_rsstoken';
 
+    private UiInterface $ui;
+
     public function __construct(
-        private readonly UiInterface $ui,
+        UiInterface $ui
     ) {
+        $this->ui = $ui;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface

--- a/src/Module/Application/Admin/User/ShowGenerateStreamtokenAction.php
+++ b/src/Module/Application/Admin/User/ShowGenerateStreamtokenAction.php
@@ -37,9 +37,12 @@ final class ShowGenerateStreamtokenAction extends AbstractUserAction
 
     public const REQUEST_KEY = 'show_generate_streamtoken';
 
+    private UiInterface $ui;
+
     public function __construct(
-        private readonly UiInterface $ui,
+        UiInterface $ui
     ) {
+        $this->ui = $ui;
     }
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface

--- a/src/Module/Application/Search/SearchAction.php
+++ b/src/Module/Application/Search/SearchAction.php
@@ -54,7 +54,7 @@ final class SearchAction implements ApplicationActionInterface
         ModelFactoryInterface $modelFactory,
         MissingArtistFinderInterface $missingArtistFinder
     ) {
-        $this->requestParser   = $requestParser;
+        $this->requestParser       = $requestParser;
         $this->ui                  = $ui;
         $this->modelFactory        = $modelFactory;
         $this->missingArtistFinder = $missingArtistFinder;

--- a/src/Module/System/Dba.php
+++ b/src/Module/System/Dba.php
@@ -237,6 +237,46 @@ class Dba
     }
 
     /**
+     * Returns the value from a single column
+     *
+     * Returns just the first column of a db-query result
+     * (or null, if the query fails). Useful, e.g. for count-results
+     *
+     * @param string $query
+     * @param list<scalar> $parameter
+     * @param bool $finish
+     *
+     * @return null|string
+     */
+    public static function fetch_single_column(
+        string $query,
+        array $parameter = [],
+        bool $finish = true
+    ): ?string {
+        $resource = self::query(
+            $query,
+            $parameter
+        );
+
+        if (!$resource) {
+            return null;
+        }
+
+        /** @var PDOStatement $resource */
+        $result = $resource->fetch(PDO::FETCH_COLUMN);
+
+        if ($result === false) {
+            if ($finish === true) {
+                self::finish($resource);
+            }
+
+            return null;
+        }
+
+        return (string) $result;
+    }
+
+    /**
      * @param $resource
      * @param string $class
      * @param bool $finish

--- a/src/Module/Util/Graph.php
+++ b/src/Module/Util/Graph.php
@@ -32,7 +32,6 @@ use CpChart;
 use CpChart\Data;
 use Ampache\Module\System\Dba;
 use Ampache\Repository\Model\Plugin;
-use Ampache\Repository\Model\User;
 
 class Graph
 {
@@ -248,11 +247,13 @@ class Graph
         $end_date = null,
         $zoom = 'day'
     ) {
+        $userRepository = $this->getUserRepository();
+
         $values = $this->get_all_pts($fct, $MyData, $user_id, $object_type, $object_id, $start_date, $end_date, $zoom);
-        $ustats = User::count();
+        $ustats = $userRepository->getStatistics();
         // Only display other users if the graph is not for a specific user and user count is small
         if ($user_id < 1 && $ustats['users'] < 10) {
-            $userArray = $this->getUserRepository()->getValidArray();
+            $userArray = $userRepository->getValidArray();
             foreach ($userArray as $validUser) {
                 $user_values = $this->get_all_type_pts($fct, $validUser['id'], $object_type, $object_id, $start_date, $end_date,
                     $zoom);

--- a/src/Repository/Model/Catalog.php
+++ b/src/Repository/Model/Catalog.php
@@ -52,6 +52,7 @@ use Ampache\Repository\LabelRepositoryInterface;
 use Ampache\Repository\LicenseRepositoryInterface;
 use Ampache\Repository\Model\Metadata\Repository\Metadata;
 use Ampache\Repository\SongRepositoryInterface;
+use Ampache\Repository\UserRepositoryInterface;
 use Exception;
 use PDOStatement;
 use RecursiveDirectoryIterator;
@@ -1170,7 +1171,7 @@ abstract class Catalog extends database_object
     public static function get_stats($catalog_id = null)
     {
         $counts         = ($catalog_id) ? self::count_catalog($catalog_id) : self::get_server_counts(0);
-        $counts         = array_merge(User::count(), $counts);
+        $counts         = array_merge(self::getUserRepository()->getStatistics(), $counts);
         $counts['tags'] = ($catalog_id) ? 0 : self::count_tags();
 
         $counts['formatted_size'] = Ui::format_bytes($counts['size'], 2, 2);
@@ -4616,5 +4617,15 @@ abstract class Catalog extends database_object
         global $dic;
 
         return $dic->get(UtilityFactoryInterface::class);
+    }
+
+    /**
+     * @deprecated Inject by constructor
+     */
+    private static function getUserRepository(): UserRepositoryInterface
+    {
+        global $dic;
+
+        return $dic->get(UserRepositoryInterface::class);
     }
 }

--- a/src/Repository/Model/User.php
+++ b/src/Repository/Model/User.php
@@ -208,29 +208,6 @@ class User extends database_object
     }
 
     /**
-     * count
-     *
-     * This returns the number of user accounts that exist.
-     */
-    public static function count()
-    {
-        $sql              = 'SELECT COUNT(`id`) FROM `user`';
-        $db_results       = Dba::read($sql);
-        $row              = Dba::fetch_row($db_results);
-        $results          = array();
-        $results['users'] = $row[0] ?? 0;
-
-        $time                 = time();
-        $last_seen            = $time - 1200;
-        $sql                  = "SELECT COUNT(DISTINCT `session`.`username`) FROM `session` INNER JOIN `user` ON `session`.`username` = `user`.`username` WHERE `session`.`expire` > ? AND `user`.`last_seen` > ?";
-        $db_results           = Dba::read($sql, array($time, $last_seen));
-        $row                  = Dba::fetch_row($db_results);
-        $results['connected'] = $row[0] ?? 0;
-
-        return $results;
-    }
-
-    /**
      * has_info
      * This function returns the information for this object
      * @return array

--- a/src/Repository/UserRepositoryInterface.php
+++ b/src/Repository/UserRepositoryInterface.php
@@ -132,4 +132,13 @@ interface UserRepositoryInterface
      * Get the current hashed user password
      */
     public function retrievePasswordFromUser(int $userId): string;
+
+    /**
+     * Returns statistical data related to user accounts and active users
+     *
+     * @param int $timePeriod Time period to consider sessions `active` (in seconds)
+     *
+     * @return array{users: int, connected: int}
+     */
+    public function getStatistics(int $timePeriod = 1200): array;
 }


### PR DESCRIPTION
The method returns statistical data related to users and sessions and is not directly related to a User instance.
Also add a dba-method to retrieve just the first column of a result.