### PR TITLE
Remove proxy methods from User

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -18281,11 +18281,6 @@ parameters:
 			path: src/Module/Util/VaInfo.php
 
 		-
-			message: "#^Parameter \\#1 \\$emailAddress of static method Ampache\\\\Repository\\\\Model\\\\User\\:\\:get_from_email\\(\\) expects string, string\\|false given\\.$#"
-			count: 1
-			path: src/Module/Util/VaInfo.php
-
-		-
 			message: "#^Parameter \\#1 \\$filename of static method Ampache\\\\Module\\\\System\\\\Core\\:\\:conv_lc_file\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Module/Util/VaInfo.php
@@ -27707,7 +27702,7 @@ parameters:
 
 		-
 			message: "#^Unsafe call to private method Ampache\\\\Repository\\\\Model\\\\User\\:\\:getUserRepository\\(\\) through static\\:\\:\\.$#"
-			count: 10
+			count: 5
 			path: src/Repository/Model/User.php
 
 		-

--- a/src/Module/Api/ApiHandler.php
+++ b/src/Module/Api/ApiHandler.php
@@ -41,6 +41,7 @@ use Ampache\Module\Api\Output\ApiOutputInterface;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\Check\NetworkCheckerInterface;
 use Ampache\Module\System\LegacyLogger;
+use Ampache\Repository\UserRepositoryInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -62,12 +63,15 @@ final class ApiHandler implements ApiHandlerInterface
 
     private ContainerInterface $dic;
 
+    private UserRepositoryInterface $userRepository;
+
     public function __construct(
         RequestParserInterface $requestParser,
         StreamFactoryInterface $streamFactory,
         LoggerInterface $logger,
         ConfigContainerInterface $configContainer,
         NetworkCheckerInterface $networkChecker,
+        UserRepositoryInterface $userRepository,
         ContainerInterface $dic
     ) {
         $this->requestParser   = $requestParser;
@@ -76,6 +80,7 @@ final class ApiHandler implements ApiHandlerInterface
         $this->configContainer = $configContainer;
         $this->networkChecker  = $networkChecker;
         $this->dic             = $dic;
+        $this->userRepository  = $userRepository;
     }
 
     public function handle(
@@ -84,6 +89,7 @@ final class ApiHandler implements ApiHandlerInterface
         ApiOutputInterface $output
     ): ?ResponseInterface {
         $gatekeeper = new Gatekeeper(
+            $this->userRepository,
             $request,
             $this->logger
         );

--- a/src/Module/Api/Method/Api4/UserCreate4Method.php
+++ b/src/Module/Api/Method/Api4/UserCreate4Method.php
@@ -28,6 +28,7 @@ namespace Ampache\Module\Api\Method\Api4;
 use Ampache\Repository\Model\Catalog;
 use Ampache\Repository\Model\User;
 use Ampache\Module\Api\Api4;
+use Ampache\Repository\UserRepositoryInterface;
 
 /**
  * Class UserCreate4Method
@@ -72,12 +73,15 @@ final class UserCreate4Method
 
             return true;
         }
-        if (User::id_from_username($username) > 0) {
+
+        $userRepository = self::getUserRepository();
+
+        if ($userRepository->idByUsername($username) > 0) {
             Api4::message('error', 'username already exists: ' . $username, '400', $input['api_format']);
 
             return false;
         }
-        if (User::id_from_email($email) > 0) {
+        if ($userRepository->idByEmail($email) > 0) {
             Api4::message('error', 'email already exists: ' . $email, '400', $input['api_format']);
 
             return false;
@@ -86,4 +90,14 @@ final class UserCreate4Method
 
         return false;
     } // user_create
+
+    /**
+     * @todo Inject by constructor
+     */
+    private static function getUserRepository(): UserRepositoryInterface
+    {
+        global $dic;
+
+        return $dic->get(UserRepositoryInterface::class);
+    }
 }

--- a/src/Module/Api/Method/Api5/UserCreate5Method.php
+++ b/src/Module/Api/Method/Api5/UserCreate5Method.php
@@ -28,6 +28,7 @@ namespace Ampache\Module\Api\Method\Api5;
 use Ampache\Repository\Model\Catalog;
 use Ampache\Repository\Model\User;
 use Ampache\Module\Api\Api5;
+use Ampache\Repository\UserRepositoryInterface;
 
 /**
  * Class UserCreate5Method
@@ -72,13 +73,16 @@ final class UserCreate5Method
 
             return true;
         }
-        if (User::id_from_username($username) > 0) {
+
+        $userRepository = self::getUserRepository();
+
+        if ($userRepository->idByUsername($username) > 0) {
             /* HINT: Requested object string/id/type ("album", "myusername", "some song title", 1298376) */
             Api5::error(sprintf(T_('Bad Request: %s'), $username), '4710', self::ACTION, 'username', $input['api_format']);
 
             return false;
         }
-        if (User::id_from_email($email) > 0) {
+        if ($userRepository->idByEmail($email) > 0) {
             /* HINT: Requested object string/id/type ("album", "myusername", "some song title", 1298376) */
             Api5::error(sprintf(T_('Bad Request: %s'), $email), '4710', self::ACTION, 'email', $input['api_format']);
 
@@ -87,5 +91,15 @@ final class UserCreate5Method
         Api5::error(T_('Bad Request'), '4710', self::ACTION, 'system', $input['api_format']);
 
         return false;
+    }
+
+    /**
+     * @todo Inject by constructor
+     */
+    private static function getUserRepository(): UserRepositoryInterface
+    {
+        global $dic;
+
+        return $dic->get(UserRepositoryInterface::class);
     }
 }

--- a/src/Module/Api/Method/RegisterMethod.php
+++ b/src/Module/Api/Method/RegisterMethod.php
@@ -30,6 +30,7 @@ use Ampache\Module\User\Registration;
 use Ampache\Repository\Model\Catalog;
 use Ampache\Repository\Model\User;
 use Ampache\Module\Api\Api;
+use Ampache\Repository\UserRepositoryInterface;
 
 /**
  * Class RegisterMethod
@@ -90,13 +91,15 @@ final class RegisterMethod
             return true;
         }
 
-        if (User::id_from_username($username) > 0) {
+        $userRepository = static::getUserRepository();
+
+        if ($userRepository->idByUsername($username) > 0) {
             /* HINT: Requested object string/id/type ("album", "myusername", "some song title", 1298376) */
             Api::error(sprintf(T_('Bad Request: %s'), $username), '4710', self::ACTION, 'username', $input['api_format']);
 
             return false;
         }
-        if (User::id_from_email($email) > 0) {
+        if ($userRepository->idByEmail($email) > 0) {
             /* HINT: Requested object string/id/type ("album", "myusername", "some song title", 1298376) */
             Api::error(sprintf(T_('Bad Request: %s'), $email), '4710', self::ACTION, 'email', $input['api_format']);
 
@@ -105,5 +108,15 @@ final class RegisterMethod
         Api::error(T_('Bad Request'), '4710', self::ACTION, 'system', $input['api_format']);
 
         return false;
+    }
+
+    /**
+     * @todo Inject by constructor
+     */
+    private static function getUserRepository(): UserRepositoryInterface
+    {
+        global $dic;
+
+        return $dic->get(UserRepositoryInterface::class);
     }
 }

--- a/src/Module/Api/Method/UserCreateMethod.php
+++ b/src/Module/Api/Method/UserCreateMethod.php
@@ -28,6 +28,7 @@ namespace Ampache\Module\Api\Method;
 use Ampache\Repository\Model\Catalog;
 use Ampache\Repository\Model\User;
 use Ampache\Module\Api\Api;
+use Ampache\Repository\UserRepositoryInterface;
 
 /**
  * Class UserCreateMethod
@@ -74,13 +75,16 @@ final class UserCreateMethod
 
             return true;
         }
-        if (User::id_from_username($username) > 0) {
+
+        $userRepository = self::getUserRepository();
+
+        if ($userRepository->idByUsername($username) > 0) {
             /* HINT: Requested object string/id/type ("album", "myusername", "some song title", 1298376) */
             Api::error(sprintf(T_('Bad Request: %s'), $username), '4710', self::ACTION, 'username', $input['api_format']);
 
             return false;
         }
-        if (User::id_from_email($email) > 0) {
+        if ($userRepository->idByEmail($email) > 0) {
             /* HINT: Requested object string/id/type ("album", "myusername", "some song title", 1298376) */
             Api::error(sprintf(T_('Bad Request: %s'), $email), '4710', self::ACTION, 'email', $input['api_format']);
 
@@ -89,5 +93,15 @@ final class UserCreateMethod
         Api::error(T_('Bad Request'), '4710', self::ACTION, 'system', $input['api_format']);
 
         return false;
+    }
+
+    /**
+     * @todo Inject by constructor
+     */
+    private static function getUserRepository(): UserRepositoryInterface
+    {
+        global $dic;
+
+        return $dic->get(UserRepositoryInterface::class);
     }
 }

--- a/src/Module/Util/VaInfo.php
+++ b/src/Module/Util/VaInfo.php
@@ -1268,8 +1268,13 @@ final class VaInfo implements VaInfoInterface
                 default:
                     // look for set ratings using email address
                     foreach (preg_grep("/^rating:.*@.*/", array_keys($parsed)) as $user_rating) {
-                        $rating_user = User::get_from_email(array_map('trim', preg_split("/^rating:/", $user_rating))[1] ?? false);
-                        if ($rating_user instanceof User) {
+                        /**
+                         * @todo check functionality; looks like an array is used for a string
+                         */
+                        $rating_user = $this->userRepository->findByEmail(
+                            array_map('trim', preg_split("/^rating:/", $user_rating))[1] ?? ''
+                        );
+                        if ($rating_user !== null) {
                             $parsed['rating'][$rating_user->id] = floor($data[0] * 5 / 100);
                         }
                     }

--- a/src/Repository/Model/User.php
+++ b/src/Repository/Model/User.php
@@ -287,65 +287,6 @@ class User extends database_object
     } // get_from_username
 
     /**
-     * get_from_apikey
-     * This returns a built user from a username. This is a
-     * static function so it doesn't require an instance
-     * @param string $apikey
-     * @return User|null
-     */
-    public static function get_from_apikey($apikey)
-    {
-        return static::getUserRepository()->findByApiKey($apikey);
-    } // get_from_apikey
-
-    /**
-     * get_from_email
-     * This returns a built user from an email address. This is a
-     * static function so it doesn't require an instance
-     * @param string $emailAddress
-     * @return User|null $user
-     */
-    public static function get_from_email($emailAddress)
-    {
-        return static::getUserRepository()->findByEmail($emailAddress);
-    } // get_from_email
-
-    /**
-     * id_from_username
-     * This returns a built user from a username. This is a
-     * static function so it doesn't require an instance
-     * @param string $username
-     * @return int
-     */
-    public static function id_from_username($username)
-    {
-        return static::getUserRepository()->idByUsername($username);
-    } // id_from_username
-
-    /**
-     * id_from_email
-     * This returns a built user from an email address. This is a
-     * static function so it doesn't require an instance
-     * @param string $emailAddress
-     * @return int
-     */
-    public static function id_from_email($emailAddress)
-    {
-        return static::getUserRepository()->idByEmail($emailAddress);
-    } // id_from_email
-
-    /**
-     * id_from_token
-     * This returns a built user from a reset token.
-     * @param string $token
-     * @return int
-     */
-    public static function id_from_token($token)
-    {
-        return static::getUserRepository()->idByResetToken($token);
-    } // id_from_username
-
-    /**
      * get_user_catalogs
      * This returns the catalogs as an array of ids that this user is allowed to access
      * @param int $user_id

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -103,6 +103,7 @@ final class UserRepository implements UserRepositoryInterface
 
         return 0;
     }
+
     /**
      * This returns all valid users in database.
      *


### PR DESCRIPTION
Those static methods just proxy calls to the UserRepository. Those can now simply be replaced by calling the methods directly on the repo