### PR TITLE
Submit the current browse-id when deleting items from playlists

### DIFF
--- a/public/templates/show_playlist_media_row.inc.php
+++ b/public/templates/show_playlist_media_row.inc.php
@@ -100,7 +100,7 @@ if (!isset($libitem->enabled) || $libitem->enabled || Access::check('interface',
         }
     }
     if (isset($playlist) && $playlist->has_access()) {
-        echo Ajax::button('?page=playlist&action=delete_track&playlist_id=' . $playlist->id . '&track_id=' . $object['track_id'], 'delete', T_('Delete'), 'track_del_' . $object['track_id']); ?>
+        echo Ajax::button('?page=playlist&action=delete_track&playlist_id=' . $playlist->id . '&browse_id=' . $browse->getId() . '&track_id=' . $object['track_id'], 'delete', T_('Delete'), 'track_del_' . $object['track_id']); ?>
     </td>
     <td class="cel_drag">
         <?php echo Ui::get_icon('drag', T_('Reorder')); ?>

--- a/src/Application/Api/Ajax/Handler/PlaylistAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/PlaylistAjaxHandler.php
@@ -61,9 +61,10 @@ final class PlaylistAjaxHandler implements AjaxHandlerInterface
                     $playlist->regenerate_track_numbers();
                 }
 
+                $browse_id  = $_REQUEST['browse_id'] ?? 0;
                 $object_ids = $playlist->get_items();
                 ob_start();
-                $browse = new Browse();
+                $browse = new Browse((int) $browse_id);
                 $browse->set_type('playlist_media');
                 $browse->add_supplemental_object('playlist', $playlist->id);
                 $browse->save_objects($object_ids);


### PR DESCRIPTION
The action builds a new browse instance having a higher id than the original browse instance. This is the reason why the UI item cannot be updated with the content of the response.

Related to #3651