### PR TITLE
Provice a non-static database access

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,6 +106,7 @@
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-mockery": "^1.1",
         "phpunit/phpunit": "^10",
+        "seec/phpunit-consecutive-params": "^1.1",
         "squizlabs/php_codesniffer": "^3.5",
         "szymach/c-pchart": "^3.0"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11091,7 +11091,7 @@ parameters:
 			path: src/Module/Catalog/Update/UpdateCatalog.php
 
 		-
-			message: "#^Method Ampache\\\\Module\\\\Catalog\\\\Update\\\\UpdateCatalog\\:\\:lookupCatalogs\\(\\) should return PDOStatement but returns bool\\|PDOStatement\\.$#"
+			message: "#^Method Ampache\\\\Module\\\\Catalog\\\\Update\\\\UpdateCatalog\\:\\:lookupCatalogs\\(\\) should return PDOStatement but returns PDOStatement\\|false\\.$#"
 			count: 1
 			path: src/Module/Catalog/Update/UpdateCatalog.php
 
@@ -14792,6 +14792,11 @@ parameters:
 
 		-
 			message: "#^Method Ampache\\\\Module\\\\System\\\\Dba\\:\\:finish\\(\\) has parameter \\$resource with no type specified\\.$#"
+			count: 1
+			path: src/Module/System/Dba.php
+
+		-
+			message: "#^Method Ampache\\\\Module\\\\System\\\\Dba\\:\\:insert_id\\(\\) should return string\\|null but returns string\\|false\\.$#"
 			count: 1
 			path: src/Module/System/Dba.php
 

--- a/public/templates/show_add_shout.inc.php
+++ b/public/templates/show_add_shout.inc.php
@@ -24,11 +24,12 @@ use Ampache\Config\AmpConfig;
 use Ampache\Module\Authorization\Access;
 use Ampache\Module\System\Core;
 use Ampache\Module\Util\Ui;
+use Ampache\Repository\Model\Shoutbox;
 
 /** @var string $data */
 /** @var Ampache\Repository\Model\library_item $object */
 /** @var string $object_type */
-/** @var int[] $shouts */
+/** @var Traversable<Shoutbox> $shouts */
 ?>
 <div>
 <?php if (Access::check('interface', 25)) { ?>
@@ -70,7 +71,9 @@ $boxtitle = T_('Post to Shoutbox');
 $boxtitle = $object->get_fullname() . ' ' . T_('Shoutbox');
 Ui::show_box_top($boxtitle, 'box box_add_shout'); ?>
 <?php
-if (count($shouts)) {
+$shouts = iterator_to_array($shouts);
+
+if (count($shouts) !== []) {
     require_once Ui::find_template('show_shoutbox.inc.php');
 } ?>
 <?php Ui::show_box_bottom(); ?>

--- a/public/templates/show_shoutbox.inc.php
+++ b/public/templates/show_shoutbox.inc.php
@@ -20,17 +20,16 @@
  *
  */
 
-use Ampache\Repository\Model\Shoutbox;
 use Ampache\Module\Util\Ui;
+use Ampache\Repository\Model\Shoutbox;
 
-/** @var int[] $shouts */
+/** @var list<Shoutbox> $shouts */
 
 Ui::show_box_top(T_('Shoutbox')); ?>
 <div id="shoutbox">
 <?php
-  foreach ($shouts as $shout_id) {
-      $shout = new Shoutbox($shout_id); ?>
-<div id="shout<?php echo $shout->id; ?>" class="shout">
+  foreach ($shouts as $shout) {?>
+<div id="shout<?php echo $shout->getId(); ?>" class="shout">
     <?php echo $shout->get_display(true, true); ?>
 </div>
 <?php

--- a/src/Application/Api/Ajax/Handler/SongAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/SongAjaxHandler.php
@@ -87,8 +87,7 @@ final class SongAjaxHandler implements AjaxHandlerInterface
                     $shouts = $this->shoutRepository->getBy($type, $songid);
                     echo "<script>\r\n";
                     echo "shouts = {};\r\n";
-                    foreach ($shouts as $shoutsid) {
-                        $shout = new Shoutbox($shoutsid);
+                    foreach ($shouts as $shout) {
                         $key   = (int)$shout->data;
                         $time  = (int)$media->time;
                         echo "if (typeof shouts['" . $key . "'] === 'undefined') { shouts['" . $key . "'] = new Array(); }\r\n";

--- a/src/Config/service_definition.php
+++ b/src/Config/service_definition.php
@@ -31,6 +31,8 @@ use Ampache\Config\Init\InitializationHandlerDatabaseUpdate;
 use Ampache\Config\Init\InitializationHandlerEnvironment;
 use Ampache\Config\Init\InitializationHandlerGetText;
 use Ampache\Config\Init\InitializationHandlerGlobals;
+use Ampache\Module\Database\DatabaseConnectionInterface;
+use Ampache\Module\Database\DbaDatabaseConnection;
 use Ampache\Module\Util\EnvironmentInterface;
 use getID3;
 use MusicBrainz\HttpAdapters\RequestsHttpAdapter;
@@ -49,6 +51,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\UploadedFileFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
 use SpotifyWebAPI\SpotifyWebAPI;
+
 use function DI\autowire;
 use function DI\factory;
 
@@ -89,4 +92,5 @@ return [
     ServerRequestFactoryInterface::class => autowire(Psr17Factory::class),
     PhpTalInterface::class => autowire(PHPTAL::class),
     SapiEmitter::class => autowire(SapiEmitter::class),
+    DatabaseConnectionInterface::class => autowire(DbaDatabaseConnection::class),
 ];

--- a/src/Module/Application/Shout/ShowAddShoutAction.php
+++ b/src/Module/Application/Shout/ShowAddShoutAction.php
@@ -77,7 +77,7 @@ final class ShowAddShoutAction implements ApplicationActionInterface
         $object->format();
 
         $data = '';
-        if (get_class($object) == Song::class) {
+        if (get_class($object) === Song::class) {
             $data = $this->requestParser->getFromRequest('offset');
         }
         $object_type = ObjectTypeToClassNameMapper::reverseMap(get_class($object));

--- a/src/Module/Database/DatabaseConnectionInterface.php
+++ b/src/Module/Database/DatabaseConnectionInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -17,32 +18,27 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
  */
 
-namespace Ampache\Repository;
+namespace Ampache\Module\Database;
 
-use Ampache\Repository\Model\Shoutbox;
-use Traversable;
+use Ampache\Module\Database\Exception\DatabaseException;
+use PDOStatement;
 
-interface ShoutRepositoryInterface
+interface DatabaseConnectionInterface
 {
     /**
-     * Returns all shout-box items for the provided object-type and -id
+     * Executes the provided sql query
      *
-     * @return Traversable<Shoutbox>
+     * If the query fails, a DatabaseException will be thrown
+     *
+     * @param list<mixed> $params
+     *
+     * @throws DatabaseException
      */
-    public function getBy(
-        string $objectType,
-        int $objectId
-    ): Traversable;
-
-    /**
-     * Cleans out orphaned shout-box items
-     */
-    public function collectGarbage(?string $objectType = null, ?int $objectId = null): void;
-
-    /**
-     * this function deletes the shout-box entry
-     */
-    public function delete(int $shoutBoxId): void;
+    public function query(
+        string $sql,
+        array $params = []
+    ): PDOStatement;
 }

--- a/src/Module/Database/DbaDatabaseConnection.php
+++ b/src/Module/Database/DbaDatabaseConnection.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -19,30 +20,40 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace Ampache\Repository;
+declare(strict_types=1);
 
-use Ampache\Repository\Model\Shoutbox;
-use Traversable;
+namespace Ampache\Module\Database;
 
-interface ShoutRepositoryInterface
+use Ampache\Module\Database\Exception\QueryFailedException;
+use Ampache\Module\System\Dba;
+use PDOStatement;
+
+/**
+ * Provides non-static access to the database
+ *
+ * @see Dba
+ */
+final class DbaDatabaseConnection implements DatabaseConnectionInterface
 {
     /**
-     * Returns all shout-box items for the provided object-type and -id
+     * Executes the provided sql query
      *
-     * @return Traversable<Shoutbox>
+     * If the query fails, a DatabaseException will be thrown
+     *
+     * @param list<mixed> $params
+     *
+     * @throws QueryFailedException
      */
-    public function getBy(
-        string $objectType,
-        int $objectId
-    ): Traversable;
+    public function query(
+        string $sql,
+        array $params = []
+    ): PDOStatement {
+        $result = Dba::query($sql, $params);
 
-    /**
-     * Cleans out orphaned shout-box items
-     */
-    public function collectGarbage(?string $objectType = null, ?int $objectId = null): void;
+        if ($result === false) {
+            throw new QueryFailedException();
+        }
 
-    /**
-     * this function deletes the shout-box entry
-     */
-    public function delete(int $shoutBoxId): void;
+        return $result;
+    }
 }

--- a/src/Module/Database/Exception/DatabaseException.php
+++ b/src/Module/Database/Exception/DatabaseException.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -19,30 +20,16 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace Ampache\Repository;
+declare(strict_types=1);
 
-use Ampache\Repository\Model\Shoutbox;
-use Traversable;
+namespace Ampache\Module\Database\Exception;
 
-interface ShoutRepositoryInterface
+use Exception;
+
+/**
+ * Base exception class for database related exceptions
+ */
+abstract class DatabaseException extends Exception
 {
-    /**
-     * Returns all shout-box items for the provided object-type and -id
-     *
-     * @return Traversable<Shoutbox>
-     */
-    public function getBy(
-        string $objectType,
-        int $objectId
-    ): Traversable;
 
-    /**
-     * Cleans out orphaned shout-box items
-     */
-    public function collectGarbage(?string $objectType = null, ?int $objectId = null): void;
-
-    /**
-     * this function deletes the shout-box entry
-     */
-    public function delete(int $shoutBoxId): void;
 }

--- a/src/Module/Database/Exception/QueryFailedException.php
+++ b/src/Module/Database/Exception/QueryFailedException.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -19,30 +20,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace Ampache\Repository;
+declare(strict_types=1);
 
-use Ampache\Repository\Model\Shoutbox;
-use Traversable;
+namespace Ampache\Module\Database\Exception;
 
-interface ShoutRepositoryInterface
+/**
+ * This exception indicates a failure in a database query execution
+ */
+final class QueryFailedException extends DatabaseException
 {
-    /**
-     * Returns all shout-box items for the provided object-type and -id
-     *
-     * @return Traversable<Shoutbox>
-     */
-    public function getBy(
-        string $objectType,
-        int $objectId
-    ): Traversable;
 
-    /**
-     * Cleans out orphaned shout-box items
-     */
-    public function collectGarbage(?string $objectType = null, ?int $objectId = null): void;
-
-    /**
-     * this function deletes the shout-box entry
-     */
-    public function delete(int $shoutBoxId): void;
 }

--- a/src/Module/System/Dba.php
+++ b/src/Module/System/Dba.php
@@ -48,7 +48,7 @@ class Dba
      * query
      * @param string $sql
      * @param array $params
-     * @return PDOStatement|bool
+     * @return PDOStatement|false
      */
     public static function query($sql, $params = array())
     {
@@ -68,7 +68,7 @@ class Dba
      * _query
      * @param string $sql
      * @param array $params
-     * @return PDOStatement|bool
+     * @return PDOStatement|false
      */
     private static function _query($sql, $params)
     {
@@ -120,7 +120,7 @@ class Dba
      * read
      * @param string $sql
      * @param array $params
-     * @return PDOStatement|bool
+     * @return PDOStatement|false
      */
     public static function read($sql, $params = array())
     {
@@ -131,7 +131,7 @@ class Dba
      * write
      * @param string $sql
      * @param array $params
-     * @return PDOStatement|bool
+     * @return PDOStatement|false
      */
     public static function write($sql, $params = array())
     {
@@ -496,7 +496,7 @@ class Dba
      *
      * This is called by the class to return the database handle
      * for the specified database, if none is found it connects
-     * @return mixed|PDO|null
+     * @return PDO|null
      */
     public static function dbh()
     {
@@ -506,17 +506,18 @@ class Dba
         }
 
         // Assign the Handle name that we are going to store
-        $handle = 'dbh_' . $database;
+        $handle = sprintf('dbh_%s', $database);
 
-        if (is_object(AmpConfig::get($handle))) {
-            return AmpConfig::get($handle);
-        } else {
-            $dbh = self::_connect();
-            self::_setup_dbh($dbh, $database);
-            AmpConfig::set($handle, $dbh, true);
+        /** * @var null|PDO $connection */
+        $connection = AmpConfig::get($handle);
 
-            return $dbh;
+        if ($connection === null) {
+            $connection = self::_connect();
+            self::_setup_dbh($connection, $database);
+            AmpConfig::set($handle, $connection, true);
         }
+
+        return $connection;
     }
 
     /**
@@ -548,7 +549,7 @@ class Dba
     public static function insert_id()
     {
         $dbh = self::dbh();
-        if ($dbh) {
+        if ($dbh !== null) {
             return $dbh->lastInsertId();
         }
 

--- a/tests/Repository/ShoutRepositoryTest.php
+++ b/tests/Repository/ShoutRepositoryTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Ampache\Repository;
+
+use Ampache\Module\Database\DatabaseConnectionInterface;
+use Ampache\Repository\Model\ModelFactoryInterface;
+use Ampache\Repository\Model\Shoutbox;
+use PDOStatement;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use SEEC\PhpUnit\Helper\ConsecutiveParams;
+
+class ShoutRepositoryTest extends TestCase
+{
+    use ConsecutiveParams;
+
+    private DatabaseConnectionInterface&MockObject $connection;
+
+    private LoggerInterface&MockObject $logger;
+
+    private ModelFactoryInterface&MockObject $modelFactory;
+
+    private ShoutRepository $subject;
+
+    protected function setUp(): void
+    {
+        $this->connection   = $this->createMock(DatabaseConnectionInterface::class);
+        $this->logger       = $this->createMock(LoggerInterface::class);
+        $this->modelFactory = $this->createMock(ModelFactoryInterface::class);
+
+        $this->subject = new ShoutRepository(
+            $this->connection,
+            $this->logger,
+            $this->modelFactory
+        );
+    }
+
+    public function testGetByYieldsData(): void
+    {
+        $objectType = 'some-object-type';
+        $objectId   = 42;
+        $shoutBoxId = 666;
+
+        $shoutBox  = $this->createMock(Shoutbox::class);
+        $statement = $this->createMock(PDOStatement::class);
+
+        $this->connection->expects(static::once())
+            ->method('query')
+            ->with(
+                'SELECT `id` FROM `user_shout` WHERE `object_type` = ? AND `object_id` = ? ORDER BY `sticky`, `date` DESC',
+                [$objectType, $objectId]
+            )
+            ->willReturn($statement);
+
+        $statement->expects(static::exactly(2))
+            ->method('fetchColumn')
+            ->willReturn((string) $shoutBoxId, false);
+
+        $this->modelFactory->expects(static::once())
+            ->method('createShoutbox')
+            ->with($shoutBoxId)
+            ->willReturn($shoutBox);
+
+        static::assertSame(
+            [$shoutBox],
+            iterator_to_array($this->subject->getBy($objectType, $objectId))
+        );
+    }
+
+    public function testDeleteDeletesItem(): void
+    {
+        $shoutBoxId = 666;
+
+        $this->connection->expects(static::once())
+            ->method('query')
+            ->with(
+                'DELETE FROM `user_shout` WHERE `id` = ?',
+                [$shoutBoxId]
+            );
+
+        $this->subject->delete($shoutBoxId);
+    }
+
+    public function testCollectGarbageDeletesDefaults(): void
+    {
+        $types = ['song', 'album', 'artist', 'label'];
+
+        $query = <<<SQL
+            DELETE FROM
+                `user_shout`
+            USING
+                `user_shout`
+            LEFT JOIN
+                `%1\$s`
+            ON
+                `%1\$s`.`id` = `user_shout`.`object_id`
+            WHERE
+                `%1\$s`.`id` IS NULL
+            AND
+                `user_shout`.`object_type` = ?
+        SQL;
+
+        $params = [];
+
+        foreach ($types as $type) {
+            $params[] = [
+                sprintf($query, $type),
+                [$type]
+            ];
+        }
+
+        $this->connection->expects(static::exactly(count($types)))
+            ->method('query')
+            ->with(...$this->withConsecutive(...$params));
+
+        $this->subject->collectGarbage();
+    }
+
+    public function testCollectGarbageFailsWithUnsupportedType(): void
+    {
+        $this->logger->expects(static::once())
+            ->method('critical')
+            ->with('Garbage collect on type `snafu` is not supported.');
+
+        $this->subject->collectGarbage('snafu');
+    }
+
+    public function testCollectGarbageDeletesDataForACertainType(): void
+    {
+        $type   = 'song';
+        $typeId = 666;
+
+        $this->connection->expects(static::once())
+            ->method('query')
+            ->with(
+                'DELETE FROM `user_shout` WHERE `object_type` = ? AND `object_id` = ?',
+                [$type, $typeId]
+            );
+
+        $this->subject->collectGarbage($type, $typeId);
+    }
+}


### PR DESCRIPTION
Static methods are hard to test/not testable, therfor we need a solution for quering the database using non-static methods.

The DatabaseConnection-class will provide non-static methods - currently only `query` is available. More methods will follow on a on-demand basis.

Use the new DatabaseConnection within the ShoutRepository and add tests for all existing methods.