### PR TITLE
Streamline the user-loading within the user-admin application

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6571,11 +6571,6 @@ parameters:
 			path: src/Module/Application/Admin/Shout/ShowEditAction.php
 
 		-
-			message: "#^Property Ampache\\\\Module\\\\Application\\\\Admin\\\\Shout\\\\ShowEditAction\\:\\:\\$configContainer is never read, only written\\.$#"
-			count: 1
-			path: src/Module/Application/Admin/Shout/ShowEditAction.php
-
-		-
 			message: "#^Parameter \\#1 \\$current of method Ampache\\\\Module\\\\System\\\\InstallationHelperInterface\\:\\:generate_config\\(\\) expects array, array\\|false given\\.$#"
 			count: 1
 			path: src/Module/Application/Admin/System/GenerateConfigAction.php
@@ -6734,11 +6729,6 @@ parameters:
 			message: "#^Method Ampache\\\\Module\\\\Application\\\\Batch\\\\DefaultAction\\:\\:getMediaFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Module/Application/Batch/DefaultAction.php
-
-		-
-			message: "#^Property Ampache\\\\Module\\\\Application\\\\Exception\\\\AccessDeniedException\\:\\:\\$message has no type specified\\.$#"
-			count: 1
-			path: src/Module/Application/Exception/AccessDeniedException.php
 
 		-
 			message: "#^Comparison operation \"\\=\\=\" between \\(array\\<int, string\\>\\|string\\) and int\\|string results in an error\\.$#"
@@ -7867,11 +7857,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$searchresult of static method Ampache\\\\Module\\\\Authentication\\\\Ldap\\\\Ldap\\:\\:clean_search_results\\(\\) expects array, array\\<int\\|string, array\\|int\\>\\|false given\\.$#"
-			count: 1
-			path: src/Module/Authentication/Ldap/Ldap.php
-
-		-
-			message: "#^Parameter \\#2 \\$callback of function array_filter expects callable\\(int\\|string\\)\\: mixed, string given\\.$#"
 			count: 1
 			path: src/Module/Authentication/Ldap/Ldap.php
 

--- a/src/Module/Api/Json4_Data.php
+++ b/src/Module/Api/Json4_Data.php
@@ -62,7 +62,7 @@ class Json4_Data
 {
     // This is added so that we don't pop any webservers
     private static ?int $limit  = 5000;
-    private static int $offset = 0;
+    private static int $offset  = 0;
 
     /**
      * constructor

--- a/src/Module/Api/Json5_Data.php
+++ b/src/Module/Api/Json5_Data.php
@@ -66,7 +66,7 @@ class Json5_Data
 {
     // This is added so that we don't pop any webservers
     private static ?int $limit  = 5000;
-    private static int $offset = 0;
+    private static int $offset  = 0;
 
     /**
      * set_offset

--- a/src/Module/Api/Json_Data.php
+++ b/src/Module/Api/Json_Data.php
@@ -66,7 +66,7 @@ class Json_Data
 {
     // This is added so that we don't pop any webservers
     private static ?int $limit  = 5000;
-    private static int $offset = 0;
+    private static int $offset  = 0;
 
     /**
      * set_offset

--- a/src/Module/Application/Admin/Shout/ShowEditAction.php
+++ b/src/Module/Application/Admin/Shout/ShowEditAction.php
@@ -42,18 +42,14 @@ final class ShowEditAction implements ApplicationActionInterface
 
     private UiInterface $ui;
 
-    private ConfigContainerInterface $configContainer;
-
     private ModelFactoryInterface $modelFactory;
 
     public function __construct(
         UiInterface $ui,
-        ConfigContainerInterface $configContainer,
         ModelFactoryInterface $modelFactory
     ) {
-        $this->ui              = $ui;
-        $this->configContainer = $configContainer;
-        $this->modelFactory    = $modelFactory;
+        $this->ui           = $ui;
+        $this->modelFactory = $modelFactory;
     }
 
     public function run(ServerRequestInterface $request, GuiGatekeeperInterface $gatekeeper): ?ResponseInterface

--- a/src/Module/Application/Admin/User/ConfirmDeleteAction.php
+++ b/src/Module/Application/Admin/User/ConfirmDeleteAction.php
@@ -28,6 +28,7 @@ namespace Ampache\Module\Application\Admin\User;
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
 use Ampache\Module\Application\Exception\AccessDeniedException;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Util\RequestParserInterface;
 use Ampache\Module\Util\UiInterface;
 use Ampache\Repository\Model\ModelFactoryInterface;
@@ -71,8 +72,13 @@ final class ConfirmDeleteAction extends AbstractUserAction
             throw new AccessDeniedException();
         }
 
-        $userId      = (int) $request->getQueryParams()['user_id'];
-        $user        = $this->modelFactory->createUser($userId);
+        $userId = (int) $request->getQueryParams()['user_id'];
+        $user   = $this->modelFactory->createUser($userId);
+
+        if ($user->isNew()) {
+            throw new ObjectNotFoundException($userId);
+        }
+
         $redirectUrl = sprintf('%s/admin/users.php', $this->configContainer->getWebPath());
 
         $this->ui->showHeader();

--- a/src/Module/Application/Admin/User/ConfirmDisableAction.php
+++ b/src/Module/Application/Admin/User/ConfirmDisableAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,13 +23,12 @@
  *
  */
 
-declare(strict_types=1);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
 use Ampache\Module\Application\Exception\AccessDeniedException;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\User\UserStateTogglerInterface;
 use Ampache\Module\Util\RequestParserInterface;
 use Ampache\Module\Util\UiInterface;
@@ -35,6 +36,9 @@ use Ampache\Repository\Model\ModelFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Disables a user
+ */
 final class ConfirmDisableAction extends AbstractUserAction
 {
     public const REQUEST_KEY = 'confirm_disable';
@@ -73,8 +77,12 @@ final class ConfirmDisableAction extends AbstractUserAction
             throw new AccessDeniedException();
         }
 
-        $user_id = (int)$request->getQueryParams()['user_id'];
-        $user    = $this->modelFactory->createUser($user_id);
+        $userId = (int)$request->getQueryParams()['user_id'];
+        $user   = $this->modelFactory->createUser($userId);
+
+        if ($user->isNew()) {
+            throw new ObjectNotFoundException($userId);
+        }
 
         $this->ui->showHeader();
         if ($this->userStateToggler->disable($user) === true) {

--- a/src/Module/Application/Admin/User/ConfirmEnableAction.php
+++ b/src/Module/Application/Admin/User/ConfirmEnableAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,13 +23,12 @@
  *
  */
 
-declare(strict_types=0);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
 use Ampache\Module\Application\Exception\AccessDeniedException;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\User\UserStateTogglerInterface;
 use Ampache\Module\Util\RequestParserInterface;
 use Ampache\Module\Util\UiInterface;
@@ -76,8 +77,12 @@ final class ConfirmEnableAction extends AbstractUserAction
             throw new AccessDeniedException();
         }
 
-        $user_id = (int)($request->getQueryParams()['user_id'] ?? 0);
-        $user    = $this->modelFactory->createUser($user_id);
+        $userId = (int)($request->getQueryParams()['user_id'] ?? 0);
+        $user   = $this->modelFactory->createUser($userId);
+
+        if ($user->isNew()) {
+            throw new ObjectNotFoundException($userId);
+        }
 
         $this->userStateToggler->enable($user);
 

--- a/src/Module/Application/Admin/User/DeleteApiKeyAction.php
+++ b/src/Module/Application/Admin/User/DeleteApiKeyAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,12 +23,11 @@
  *
  */
 
-declare(strict_types=1);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Util\RequestParserInterface;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Module\Application\Exception\AccessDeniedException;
@@ -34,6 +35,9 @@ use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Deletes an api-key from a user
+ */
 final class DeleteApiKeyAction extends AbstractUserAction
 {
     public const REQUEST_KEY = 'delete_apikey';
@@ -71,6 +75,10 @@ final class DeleteApiKeyAction extends AbstractUserAction
         $userId = (int) ($request->getQueryParams()['user_id'] ?? 0);
         $user   = $this->modelFactory->createUser($userId);
 
+        if ($user->isNew()) {
+            throw new ObjectNotFoundException($userId);
+        }
+
         $user->deleteApiKey();
 
         $this->ui->showHeader();
@@ -79,7 +87,6 @@ final class DeleteApiKeyAction extends AbstractUserAction
             T_('API key has been deleted'),
             'admin/users.php'
         );
-
         $this->ui->showQueryStats();
         $this->ui->showFooter();
 

--- a/src/Module/Application/Admin/User/DeleteAvatarAction.php
+++ b/src/Module/Application/Admin/User/DeleteAvatarAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,12 +23,11 @@
  *
  */
 
-declare(strict_types=0);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Util\RequestParserInterface;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Module\Application\Exception\AccessDeniedException;
@@ -34,6 +35,9 @@ use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Deletes a user avatar
+ */
 final class DeleteAvatarAction extends AbstractUserAction
 {
     public const REQUEST_KEY = 'delete_avatar';
@@ -70,6 +74,10 @@ final class DeleteAvatarAction extends AbstractUserAction
 
         $userId = (int) ($request->getQueryParams()['user_id'] ?? 0);
         $user   = $this->modelFactory->createUser($userId);
+
+        if ($user->isNew()) {
+            throw new ObjectNotFoundException($userId);
+        }
 
         $user->deleteAvatar();
 

--- a/src/Module/Application/Admin/User/DeleteRssTokenAction.php
+++ b/src/Module/Application/Admin/User/DeleteRssTokenAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,19 +23,21 @@
  *
  */
 
-declare(strict_types=0);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
 use Ampache\Module\Application\Exception\AccessDeniedException;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Util\RequestParserInterface;
 use Ampache\Module\Util\UiInterface;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Deletes the users rss-token
+ */
 final class DeleteRssTokenAction extends AbstractUserAction
 {
     public const REQUEST_KEY = 'delete_rsstoken';
@@ -71,6 +75,10 @@ final class DeleteRssTokenAction extends AbstractUserAction
         $userId = (int) ($request->getQueryParams()['user_id'] ?? 0);
         $user   = $this->modelFactory->createUser($userId);
 
+        if ($user->isNew()) {
+            throw new ObjectNotFoundException($userId);
+        }
+
         $user->deleteRssToken();
 
         $this->ui->showHeader();
@@ -79,7 +87,6 @@ final class DeleteRssTokenAction extends AbstractUserAction
             T_('Token has been deleted'),
             'admin/users.php',
         );
-
         $this->ui->showQueryStats();
         $this->ui->showFooter();
 

--- a/src/Module/Application/Admin/User/DeleteStreamTokenAction.php
+++ b/src/Module/Application/Admin/User/DeleteStreamTokenAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,12 +23,11 @@
  *
  */
 
-declare(strict_types=0);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Util\RequestParserInterface;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Module\Application\Exception\AccessDeniedException;
@@ -34,6 +35,9 @@ use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Deletes the users stream-token
+ */
 final class DeleteStreamTokenAction extends AbstractUserAction
 {
     public const REQUEST_KEY = 'delete_streamtoken';
@@ -71,6 +75,10 @@ final class DeleteStreamTokenAction extends AbstractUserAction
         $userId = (int) ($request->getQueryParams()['user_id'] ?? 0);
         $user   = $this->modelFactory->createUser($userId);
 
+        if ($user->isNew()) {
+            throw new ObjectNotFoundException($userId);
+        }
+
         $user->deleteStreamToken();
 
         $this->ui->showHeader();
@@ -79,7 +87,6 @@ final class DeleteStreamTokenAction extends AbstractUserAction
             T_('Token has been deleted'),
             'admin/users.php'
         );
-
         $this->ui->showQueryStats();
         $this->ui->showFooter();
 

--- a/src/Module/Application/Admin/User/EnableAction.php
+++ b/src/Module/Application/Admin/User/EnableAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,26 +23,24 @@
  *
  */
 
-declare(strict_types=0);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
-use Ampache\Module\System\LegacyLogger;
-use Ampache\Repository\Model\ModelFactoryInterface;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Util\UiInterface;
+use Ampache\Repository\Model\ModelFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Log\LoggerInterface;
 
+/**
+ * Renders the user-enable confirmation
+ */
 final class EnableAction extends AbstractUserAction
 {
     public const REQUEST_KEY = 'enable';
 
     private UiInterface $ui;
-
-    private LoggerInterface $logger;
 
     private ModelFactoryInterface $modelFactory;
 
@@ -48,12 +48,10 @@ final class EnableAction extends AbstractUserAction
 
     public function __construct(
         UiInterface $ui,
-        LoggerInterface $logger,
         ModelFactoryInterface $modelFactory,
         ConfigContainerInterface $configContainer
     ) {
         $this->ui              = $ui;
-        $this->logger          = $logger;
         $this->modelFactory    = $modelFactory;
         $this->configContainer = $configContainer;
     }
@@ -64,29 +62,25 @@ final class EnableAction extends AbstractUserAction
             return null;
         }
 
-        $this->ui->showHeader();
-
         $userId = (int)($request->getQueryParams()['user_id'] ?? 0);
-        if ($userId < 1) {
-            $this->logger->warning(
-                'Requested a user that does not exist',
-                [LegacyLogger::CONTEXT_TYPE => __CLASS__]
-            );
-            echo T_('You have requested an object that does not exist');
-        } else {
-            $user = $this->modelFactory->createUser($userId);
-            $this->ui->showConfirmation(
-                T_('Are You Sure?'),
-                /* HINT: User Fullname */
-                sprintf(T_('This will enable the user "%s"'), $user->fullname),
-                sprintf(
-                    'admin/users.php?action=confirm_enable&amp;user_id=%s',
-                    $userId
-                ),
-                1,
-                'enable_user'
-            );
+        $user   = $this->modelFactory->createUser($userId);
+
+        if ($user->isNew()) {
+            throw new ObjectNotFoundException($userId);
         }
+
+        $this->ui->showHeader();
+        $this->ui->showConfirmation(
+            T_('Are You Sure?'),
+            /* HINT: User Fullname */
+            sprintf(T_('This will enable the user "%s"'), $user->getFullDisplayName()),
+            sprintf(
+                'admin/users.php?action=confirm_enable&amp;user_id=%s',
+                $userId
+            ),
+            1,
+            'enable_user'
+        );
         $this->ui->showQueryStats();
         $this->ui->showFooter();
 

--- a/src/Module/Application/Admin/User/GenerateApiKeyAction.php
+++ b/src/Module/Application/Admin/User/GenerateApiKeyAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,13 +23,12 @@
  *
  */
 
-declare(strict_types=1);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
 use Ampache\Module\Application\Exception\AccessDeniedException;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\User\Authorization\UserKeyGeneratorInterface;
 use Ampache\Module\Util\RequestParserInterface;
 use Ampache\Module\Util\UiInterface;
@@ -36,7 +37,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * Generate an api-key for a user
+ * Generates an api-key for a user
  */
 final class GenerateApiKeyAction extends AbstractUserAction
 {
@@ -78,6 +79,10 @@ final class GenerateApiKeyAction extends AbstractUserAction
 
         $userId = (int) ($request->getQueryParams()['user_id'] ?? 0);
         $user   = $this->modelFactory->createUser($userId);
+
+        if ($user->isNew()) {
+            throw new ObjectNotFoundException($userId);
+        }
 
         $this->userKeyGenerator->generateApikey($user);
 

--- a/src/Module/Application/Admin/User/GenerateRssTokenAction.php
+++ b/src/Module/Application/Admin/User/GenerateRssTokenAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,12 +23,11 @@
  *
  */
 
-declare(strict_types=1);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Util\RequestParserInterface;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Module\Application\Exception\AccessDeniedException;
@@ -35,6 +36,9 @@ use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Generates a rss-token for a user
+ */
 final class GenerateRssTokenAction extends AbstractUserAction
 {
     public const REQUEST_KEY = 'generate_rsstoken';
@@ -75,6 +79,10 @@ final class GenerateRssTokenAction extends AbstractUserAction
 
         $userId = (int) ($request->getQueryParams()['user_id'] ?? 0);
         $user   = $this->modelFactory->createUser($userId);
+
+        if ($user->isNew()) {
+            throw new ObjectNotFoundException($userId);
+        }
 
         $this->userKeyGenerator->generateRssToken($user);
 

--- a/src/Module/Application/Admin/User/GenerateStreamTokenAction.php
+++ b/src/Module/Application/Admin/User/GenerateStreamTokenAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,12 +23,11 @@
  *
  */
 
-declare(strict_types=1);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Util\RequestParserInterface;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Module\Application\Exception\AccessDeniedException;
@@ -35,6 +36,9 @@ use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Generates a stream token for a user
+ */
 final class GenerateStreamTokenAction extends AbstractUserAction
 {
     public const REQUEST_KEY = 'generate_streamtoken';
@@ -75,6 +79,10 @@ final class GenerateStreamTokenAction extends AbstractUserAction
 
         $userId = (int) ($request->getQueryParams()['user_id'] ?? 0);
         $user   = $this->modelFactory->createUser($userId);
+
+        if ($user->isNew()) {
+            throw new ObjectNotFoundException($userId);
+        }
 
         $this->userKeyGenerator->generateStreamToken($user);
 

--- a/src/Module/Application/Admin/User/ShowDeleteAction.php
+++ b/src/Module/Application/Admin/User/ShowDeleteAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,26 +23,24 @@
  *
  */
 
-declare(strict_types=0);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
-use Ampache\Module\System\LegacyLogger;
-use Ampache\Repository\Model\ModelFactoryInterface;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Util\UiInterface;
+use Ampache\Repository\Model\ModelFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Log\LoggerInterface;
 
+/**
+ * Renders the user-delete confirmation
+ */
 final class ShowDeleteAction extends AbstractUserAction
 {
     public const REQUEST_KEY = 'delete';
 
     private UiInterface $ui;
-
-    private LoggerInterface $logger;
 
     private ModelFactoryInterface $modelFactory;
 
@@ -48,12 +48,10 @@ final class ShowDeleteAction extends AbstractUserAction
 
     public function __construct(
         UiInterface $ui,
-        LoggerInterface $logger,
         ModelFactoryInterface $modelFactory,
         ConfigContainerInterface $configContainer
     ) {
         $this->ui              = $ui;
-        $this->logger          = $logger;
         $this->modelFactory    = $modelFactory;
         $this->configContainer = $configContainer;
     }
@@ -64,29 +62,25 @@ final class ShowDeleteAction extends AbstractUserAction
             return null;
         }
 
-        $this->ui->showHeader();
-
         $userId = (int)($request->getQueryParams()['user_id'] ?? 0);
-        if ($userId < 1) {
-            $this->logger->warning(
-                'Requested a user that does not exist',
-                [LegacyLogger::CONTEXT_TYPE => __CLASS__]
-            );
-            echo T_('You have requested an object that does not exist');
-        } else {
-            $user = $this->modelFactory->createUser($userId);
-            $this->ui->showConfirmation(
-                T_('Are You Sure?'),
-                /* HINT: User Fullname */
-                sprintf(T_('This will permanently delete the user "%s"'), $user->fullname),
-                sprintf(
-                    'admin/users.php?action=confirm_delete&amp;user_id=%s',
-                    $userId
-                ),
-                1,
-                'delete_user'
-            );
+        $user   = $this->modelFactory->createUser($userId);
+
+        if ($user->isNew()) {
+            throw new ObjectNotFoundException($userId);
         }
+
+        $this->ui->showHeader();
+        $this->ui->showConfirmation(
+            T_('Are You Sure?'),
+            /* HINT: User Fullname */
+            sprintf(T_('This will permanently delete the user "%s"'), $user->getFullDisplayName()),
+            sprintf(
+                'admin/users.php?action=confirm_delete&amp;user_id=%s',
+                $userId
+            ),
+            1,
+            'delete_user'
+        );
         $this->ui->showQueryStats();
         $this->ui->showFooter();
 

--- a/src/Module/Application/Admin/User/ShowEditAction.php
+++ b/src/Module/Application/Admin/User/ShowEditAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,17 +23,19 @@
  *
  */
 
-declare(strict_types=1);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Renders the users edit view
+ */
 final class ShowEditAction extends AbstractUserAction
 {
     public const REQUEST_KEY = 'show_edit';
@@ -60,6 +64,10 @@ final class ShowEditAction extends AbstractUserAction
 
         $userId = (int)($request->getQueryParams()['user_id'] ?? 0);
         $user   = $this->modelFactory->createUser($userId);
+
+        if ($user->isNew()) {
+            throw new ObjectNotFoundException($userId);
+        }
 
         $user->format();
 

--- a/src/Module/Application/Admin/User/ShowPreferencesAction.php
+++ b/src/Module/Application/Admin/User/ShowPreferencesAction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,10 +23,9 @@
  *
  */
 
-declare(strict_types=1);
-
 namespace Ampache\Module\Application\Admin\User;
 
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Util\UiInterface;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\PreferenceRepositoryInterface;
@@ -56,9 +57,12 @@ final class ShowPreferencesAction extends AbstractUserAction
 
     protected function handle(ServerRequestInterface $request): ?ResponseInterface
     {
-        $user = $this->modelFactory->createUser(
-            (int) ($request->getQueryParams()['user_id'] ?? 0)
-        );
+        $userId = (int) ($request->getQueryParams()['user_id'] ?? 0);
+        $user   = $this->modelFactory->createUser($userId);
+
+        if ($user->isNew()) {
+            throw new ObjectNotFoundException($userId);
+        }
 
         $this->ui->showHeader();
         $this->ui->show(

--- a/src/Module/Application/ApplicationRunner.php
+++ b/src/Module/Application/ApplicationRunner.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace Ampache\Module\Application;
 
 use Ampache\Module\Application\Exception\AccessDeniedException;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Authorization\GatekeeperFactoryInterface;
 use Ampache\Module\System\LegacyLogger;
 use Ampache\Module\Util\UiInterface;
@@ -115,7 +116,7 @@ final class ApplicationRunner
                     LegacyLogger::CONTEXT_TYPE => sprintf(
                         '"%s" for "%s"',
                         __CLASS__,
-                        $e->getFile()
+                        get_class($handler)
                     )
                 ]
             );
@@ -123,6 +124,20 @@ final class ApplicationRunner
             $this->ui->accessDenied($message);
 
             return;
+        } catch (ObjectNotFoundException $e) {
+            $this->logger->warning(
+                'Requested an object that does not exist',
+                [
+                    LegacyLogger::CONTEXT_TYPE => sprintf(
+                        '"%s" for "%s"',
+                        __CLASS__,
+                        get_class($handler)
+                    ),
+                    'objectId' => $e->getObjectId()
+                ]
+            );
+
+            $this->ui->showObjectNotFound();
         } catch (Throwable $e) {
             $this->logger->critical(
                 $e->getMessage(),

--- a/src/Module/Application/Exception/ObjectNotFoundException.php
+++ b/src/Module/Application/Exception/ObjectNotFoundException.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 /**
@@ -21,13 +20,34 @@ declare(strict_types=1);
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
  */
 
 namespace Ampache\Module\Application\Exception;
 
-final class AccessDeniedException extends ApplicationException
+/**
+ * Thrown if users try to load items which don't exist
+ */
+final class ObjectNotFoundException extends ApplicationException
 {
     /** @var string */
-    protected $message = 'Access denied';
+    protected $message = 'Object not found';
+
+    /** @var int|string $objectId */
+    private $objectId;
+
+    /**
+     * @param int|string $objectId The requested objectId
+     */
+    public function __construct($objectId)
+    {
+        $this->objectId = $objectId;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getObjectId()
+    {
+        return $this->objectId;
+    }
 }

--- a/src/Module/Authentication/Ldap/Ldap.php
+++ b/src/Module/Authentication/Ldap/Ldap.php
@@ -75,7 +75,7 @@ class Ldap
      * array_filter_key
      *
      * @param array $array
-     * @param string $callback
+     * @param callable-string $callback
      * @return array
      */
     private static function array_filter_key($array, $callback)

--- a/src/Module/Util/Ui.php
+++ b/src/Module/Util/Ui.php
@@ -79,6 +79,17 @@ class Ui implements UiInterface
         }
     }
 
+    public function showObjectNotFound(): void
+    {
+        $this->showHeader();
+        echo T_('You have requested an object that does not exist');
+        $this->showQueryStats();
+        $this->showFooter();
+    }
+
+    /**
+     * Displays the default error page
+     */
     public function accessDenied(string $error = 'Access Denied'): void
     {
         // Clear any buffered crap
@@ -87,6 +98,9 @@ class Ui implements UiInterface
         require_once self::find_template('show_denied.inc.php');
     }
 
+    /**
+     * Displays an error page when you can't write the config
+     */
     public function permissionDenied(string $fileName): void
     {
         // Clear any buffered crap

--- a/src/Module/Util/UiInterface.php
+++ b/src/Module/Util/UiInterface.php
@@ -49,6 +49,8 @@ interface UiInterface
 
     public function showBoxBottom(): void;
 
+    public function showObjectNotFound(): void;
+
     /**
      * Displays the default error page
      */

--- a/src/Repository/Model/User.php
+++ b/src/Repository/Model/User.php
@@ -1512,6 +1512,14 @@ class User extends database_object
     }
 
     /**
+     * Returns `true` if the user does not exist
+     */
+    public function isNew(): bool
+    {
+        return $this->getId() === 0;
+    }
+
+    /**
      * Returns a concatenated version of several names
      *
      * In some cases (e.g. admin backend), we want to be as verbose as possible,

--- a/tests/Module/Application/Admin/User/ConfirmDeleteActionTest.php
+++ b/tests/Module/Application/Admin/User/ConfirmDeleteActionTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/*
+declare(strict_types=1);
+
+/**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
  * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
@@ -21,12 +23,11 @@
  *
  */
 
-declare(strict_types=1);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Util\RequestParserInterface;
@@ -139,6 +140,45 @@ class ConfirmDeleteActionTest extends TestCase
         );
     }
 
+    public function testHandleErrorsIfUserWasNotFound(): void
+    {
+        $userId = 666;
+
+        $user = $this->createMock(User::class);
+
+        static::expectException(ObjectNotFoundException::class);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::DEMO_MODE)
+            ->willReturn(false);
+
+        $this->requestParser->expects(static::once())
+            ->method('verifyForm')
+            ->with('delete_user')
+            ->willReturn(true);
+
+        $this->request->expects(static::once())
+            ->method('getQueryParams')
+            ->willReturn(['user_id' => (string) $userId]);
+
+        $this->modelFactory->expects(static::once())
+            ->method('createUser')
+            ->with($userId)
+            ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(true);
+
+        $this->subject->run($this->request, $this->gatekeeper);
+    }
+
     public function testHandleErrorsOnDeletionFailure(): void
     {
         $userId  = 666;
@@ -175,6 +215,9 @@ class ConfirmDeleteActionTest extends TestCase
 
         $user->expects(static::once())
             ->method('delete')
+            ->willReturn(false);
+        $user->expects(static::once())
+            ->method('isNew')
             ->willReturn(false);
 
         $this->ui->expects(static::once())

--- a/tests/Module/Application/Admin/User/DeleteApiKeyActionTest.php
+++ b/tests/Module/Application/Admin/User/DeleteApiKeyActionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,14 +23,11 @@
  *
  */
 
-declare(strict_types=1);
-
-namespace Module\Application\Admin\User;
+namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
-use Ampache\Module\Application\Admin\User\DeleteApiKeyAction;
-use Ampache\Module\Application\Admin\User\UserAdminAccessTestTrait;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Util\RequestParserInterface;
@@ -74,6 +73,47 @@ class DeleteApiKeyActionTest extends TestCase
         );
     }
 
+    public function testRunErrorsIfUserWasNotFound(): void
+    {
+        $userId = 666;
+
+        $user = $this->createMock(User::class);
+
+        static::expectException(ObjectNotFoundException::class);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::DEMO_MODE)
+            ->willReturn(false);
+
+        $this->requestParser->expects(static::once())
+            ->method('verifyForm')
+            ->with($this->getValidationFormName())
+            ->willReturn(true);
+
+        $this->request->expects(static::once())
+            ->method('getQueryParams')
+            ->willReturn(['user_id' => (string) $userId]);
+
+        $this->modelFactory->expects(static::once())
+            ->method('createUser')
+            ->with($userId)
+            ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(true);
+
+        static::assertNull(
+            $this->subject->run($this->request, $this->gatekeeper)
+        );
+    }
+
     public function testRunDeletesApiKey(): void
     {
         $userId = 666;
@@ -106,6 +146,9 @@ class DeleteApiKeyActionTest extends TestCase
 
         $user->expects(static::once())
             ->method('deleteApiKey');
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(false);
 
         $this->ui->expects(static::once())
             ->method('showHeader');

--- a/tests/Module/Application/Admin/User/DeleteAvatarActionTest.php
+++ b/tests/Module/Application/Admin/User/DeleteAvatarActionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,15 +23,11 @@
  *
  */
 
-declare(strict_types=1);
-
-namespace Module\Application\Admin\User;
+namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
-use Ampache\Module\Application\Admin\User\DeleteApiKeyAction;
-use Ampache\Module\Application\Admin\User\DeleteAvatarAction;
-use Ampache\Module\Application\Admin\User\UserAdminAccessTestTrait;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Util\RequestParserInterface;
@@ -75,6 +73,45 @@ class DeleteAvatarActionTest extends TestCase
         );
     }
 
+    public function testRunErrorsIfUserWasNotFound(): void
+    {
+        $userId = 666;
+
+        $user = $this->createMock(User::class);
+
+        static::expectException(ObjectNotFoundException::class);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::DEMO_MODE)
+            ->willReturn(false);
+
+        $this->requestParser->expects(static::once())
+            ->method('verifyForm')
+            ->with($this->getValidationFormName())
+            ->willReturn(true);
+
+        $this->request->expects(static::once())
+            ->method('getQueryParams')
+            ->willReturn(['user_id' => (string) $userId]);
+
+        $this->modelFactory->expects(static::once())
+            ->method('createUser')
+            ->with($userId)
+            ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(true);
+
+        $this->subject->run($this->request, $this->gatekeeper);
+    }
+
     public function testRunDeletesAvatar(): void
     {
         $userId = 666;
@@ -107,6 +144,9 @@ class DeleteAvatarActionTest extends TestCase
 
         $user->expects(static::once())
             ->method('deleteAvatar');
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(false);
 
         $this->ui->expects(static::once())
             ->method('showHeader');

--- a/tests/Module/Application/Admin/User/DeleteRssTokenActionTest.php
+++ b/tests/Module/Application/Admin/User/DeleteRssTokenActionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,16 +23,11 @@
  *
  */
 
-declare(strict_types=1);
-
-namespace Module\Application\Admin\User;
+namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
-use Ampache\Module\Application\Admin\User\DeleteApiKeyAction;
-use Ampache\Module\Application\Admin\User\DeleteAvatarAction;
-use Ampache\Module\Application\Admin\User\DeleteRssTokenAction;
-use Ampache\Module\Application\Admin\User\UserAdminAccessTestTrait;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Util\RequestParserInterface;
@@ -76,6 +73,45 @@ class DeleteRssTokenActionTest extends TestCase
         );
     }
 
+    public function testRunErrorsIfUserWasNotFound(): void
+    {
+        $userId = 666;
+
+        $user = $this->createMock(User::class);
+
+        static::expectException(ObjectNotFoundException::class);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::DEMO_MODE)
+            ->willReturn(false);
+
+        $this->requestParser->expects(static::once())
+            ->method('verifyForm')
+            ->with($this->getValidationFormName())
+            ->willReturn(true);
+
+        $this->request->expects(static::once())
+            ->method('getQueryParams')
+            ->willReturn(['user_id' => (string) $userId]);
+
+        $this->modelFactory->expects(static::once())
+            ->method('createUser')
+            ->with($userId)
+            ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(true);
+
+        $this->subject->run($this->request, $this->gatekeeper);
+    }
+
     public function testRunDeletesRssToken(): void
     {
         $userId = 666;
@@ -108,6 +144,9 @@ class DeleteRssTokenActionTest extends TestCase
 
         $user->expects(static::once())
             ->method('deleteRssToken');
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(false);
 
         $this->ui->expects(static::once())
             ->method('showHeader');

--- a/tests/Module/Application/Admin/User/DeleteStreamTokenActionTest.php
+++ b/tests/Module/Application/Admin/User/DeleteStreamTokenActionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,14 +23,11 @@
  *
  */
 
-declare(strict_types=1);
-
-namespace Module\Application\Admin\User;
+namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
-use Ampache\Module\Application\Admin\User\DeleteStreamTokenAction;
-use Ampache\Module\Application\Admin\User\UserAdminAccessTestTrait;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Util\RequestParserInterface;
@@ -74,6 +73,45 @@ class DeleteStreamTokenActionTest extends TestCase
         );
     }
 
+    public function testRunErrorsIfUserWasNotFound(): void
+    {
+        $userId = 666;
+
+        $user = $this->createMock(User::class);
+
+        static::expectException(ObjectNotFoundException::class);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::DEMO_MODE)
+            ->willReturn(false);
+
+        $this->requestParser->expects(static::once())
+            ->method('verifyForm')
+            ->with($this->getValidationFormName())
+            ->willReturn(true);
+
+        $this->request->expects(static::once())
+            ->method('getQueryParams')
+            ->willReturn(['user_id' => (string) $userId]);
+
+        $this->modelFactory->expects(static::once())
+            ->method('createUser')
+            ->with($userId)
+            ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(true);
+
+        $this->subject->run($this->request, $this->gatekeeper);
+    }
+
     public function testRunDeletesStreamToken(): void
     {
         $userId = 666;
@@ -106,6 +144,9 @@ class DeleteStreamTokenActionTest extends TestCase
 
         $user->expects(static::once())
             ->method('deleteStreamToken');
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(false);
 
         $this->ui->expects(static::once())
             ->method('showHeader');

--- a/tests/Module/Application/Admin/User/DisableActionTest.php
+++ b/tests/Module/Application/Admin/User/DisableActionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,29 +23,24 @@
  *
  */
 
-declare(strict_types=1);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
 use Ampache\MockeryTestCase;
-use Ampache\Module\System\LegacyLogger;
-use Ampache\Repository\Model\ModelFactoryInterface;
-use Ampache\Repository\Model\User;
 use Ampache\Module\Application\Exception\AccessDeniedException;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Util\UiInterface;
+use Ampache\Repository\Model\ModelFactoryInterface;
+use Ampache\Repository\Model\User;
 use Mockery\MockInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Log\LoggerInterface;
 
 class DisableActionTest extends MockeryTestCase
 {
     private MockInterface&UiInterface $ui;
-
-    private MockInterface&LoggerInterface $logger;
 
     private MockInterface&ModelFactoryInterface $modelFactory;
 
@@ -54,13 +51,11 @@ class DisableActionTest extends MockeryTestCase
     public function setUp(): void
     {
         $this->ui              = $this->mock(UiInterface::class);
-        $this->logger          = $this->mock(LoggerInterface::class);
         $this->modelFactory    = $this->mock(ModelFactoryInterface::class);
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
 
         $this->subject = new DisableAction(
             $this->ui,
-            $this->logger,
             $this->modelFactory,
             $this->configContainer
         );
@@ -107,19 +102,15 @@ class DisableActionTest extends MockeryTestCase
         );
     }
 
-    public function testRunErrorsIfUserIdIsLesserThenOne(): void
+    public function testRunErrorsIfUserWasNotFound(): void
     {
         $request    = $this->mock(ServerRequestInterface::class);
         $gatekeeper = $this->mock(GuiGatekeeperInterface::class);
+        $user       = $this->createMock(User::class);
 
-        $userId   = -1;
+        $userId = -1;
 
-        $this->logger->shouldReceive('warning')
-            ->with(
-                'Requested a user that does not exist',
-                [LegacyLogger::CONTEXT_TYPE => $this->subject::class]
-            )
-            ->once();
+        static::expectException(ObjectNotFoundException::class);
 
         $request->shouldReceive('getQueryParams')
             ->withNoArgs()
@@ -136,23 +127,18 @@ class DisableActionTest extends MockeryTestCase
             ->once()
             ->andReturnFalse();
 
-        $this->ui->shouldReceive('showHeader')
-            ->withNoArgs()
-            ->once();
-        $this->ui->shouldReceive('showQueryStats')
-            ->withNoArgs()
-            ->once();
-        $this->ui->shouldReceive('showFooter')
-            ->withNoArgs()
-            ->once();
+        $this->modelFactory->shouldReceive('createUser')
+            ->with($userId)
+            ->once()
+            ->andReturn($user);
 
-        static::expectOutputString('You have requested an object that does not exist');
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(true);
 
-        $this->assertNull(
-            $this->subject->run(
-                $request,
-                $gatekeeper
-            )
+        $this->subject->run(
+            $request,
+            $gatekeeper
         );
     }
 
@@ -160,12 +146,10 @@ class DisableActionTest extends MockeryTestCase
     {
         $request    = $this->mock(ServerRequestInterface::class);
         $gatekeeper = $this->mock(GuiGatekeeperInterface::class);
-        $user       = $this->mock(User::class);
+        $user       = $this->createMock(User::class);
 
         $userId   = 42;
         $username = 'some-name';
-
-        $user->fullname = $username;
 
         $request->shouldReceive('getQueryParams')
             ->withNoArgs()
@@ -186,6 +170,13 @@ class DisableActionTest extends MockeryTestCase
             ->with(ConfigurationKeyEnum::DEMO_MODE)
             ->once()
             ->andReturnFalse();
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(false);
+        $user->expects(static::once())
+            ->method('getFullDisplayName')
+            ->willReturn($username);
 
         $this->ui->shouldReceive('showHeader')
             ->withNoArgs()

--- a/tests/Module/Application/Admin/User/EnableActionTest.php
+++ b/tests/Module/Application/Admin/User/EnableActionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,29 +23,24 @@
  *
  */
 
-declare(strict_types=1);
-
 namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
 use Ampache\MockeryTestCase;
-use Ampache\Module\System\LegacyLogger;
-use Ampache\Repository\Model\ModelFactoryInterface;
-use Ampache\Repository\Model\User;
 use Ampache\Module\Application\Exception\AccessDeniedException;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Util\UiInterface;
+use Ampache\Repository\Model\ModelFactoryInterface;
+use Ampache\Repository\Model\User;
 use Mockery\MockInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Log\LoggerInterface;
 
 class EnableActionTest extends MockeryTestCase
 {
     private MockInterface&UiInterface $ui;
-
-    private MockInterface&LoggerInterface $logger;
 
     private MockInterface&ModelFactoryInterface $modelFactory;
 
@@ -54,13 +51,11 @@ class EnableActionTest extends MockeryTestCase
     public function setUp(): void
     {
         $this->ui              = $this->mock(UiInterface::class);
-        $this->logger          = $this->mock(LoggerInterface::class);
         $this->modelFactory    = $this->mock(ModelFactoryInterface::class);
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
 
         $this->subject = new EnableAction(
             $this->ui,
-            $this->logger,
             $this->modelFactory,
             $this->configContainer
         );
@@ -111,8 +106,20 @@ class EnableActionTest extends MockeryTestCase
     {
         $request    = $this->mock(ServerRequestInterface::class);
         $gatekeeper = $this->mock(GuiGatekeeperInterface::class);
+        $user       = $this->createMock(User::class);
 
         $userId = -1;
+
+        static::expectException(ObjectNotFoundException::class);
+
+        $this->modelFactory->shouldReceive('createUser')
+            ->with($userId)
+            ->once()
+            ->andReturn($user);
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(true);
 
         $request->shouldReceive('getQueryParams')
             ->withNoArgs()
@@ -128,25 +135,6 @@ class EnableActionTest extends MockeryTestCase
             ->with(ConfigurationKeyEnum::DEMO_MODE)
             ->once()
             ->andReturnFalse();
-
-        $this->ui->shouldReceive('showHeader')
-            ->withNoArgs()
-            ->once();
-        $this->ui->shouldReceive('showQueryStats')
-            ->withNoArgs()
-            ->once();
-        $this->ui->shouldReceive('showFooter')
-            ->withNoArgs()
-            ->once();
-
-        static::expectOutputString('You have requested an object that does not exist');
-
-        $this->logger->shouldReceive('warning')
-            ->with(
-                'Requested a user that does not exist',
-                [LegacyLogger::CONTEXT_TYPE => $this->subject::class]
-            )
-            ->once();
 
         $this->assertNull(
             $this->subject->run(
@@ -165,8 +153,6 @@ class EnableActionTest extends MockeryTestCase
         $userId   = 42;
         $username = 'some-name';
 
-        $user->fullname = $username;
-
         $request->shouldReceive('getQueryParams')
             ->withNoArgs()
             ->once()
@@ -176,6 +162,15 @@ class EnableActionTest extends MockeryTestCase
             ->with($userId)
             ->once()
             ->andReturn($user);
+
+        $user->shouldReceive('getFullDisplayName')
+            ->withNoArgs()
+            ->once()
+            ->andReturn($username);
+        $user->shouldReceive('isNew')
+            ->withNoArgs()
+            ->once()
+            ->andReturn(false);
 
         $gatekeeper->shouldReceive('mayAccess')
             ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)

--- a/tests/Module/Application/Admin/User/GenerateApiKeyActionTest.php
+++ b/tests/Module/Application/Admin/User/GenerateApiKeyActionTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/*
+declare(strict_types=1);
+
+/**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
  * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
@@ -21,14 +23,11 @@
  *
  */
 
-declare(strict_types=1);
-
-namespace Module\Application\Admin\User;
+namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
-use Ampache\Module\Application\Admin\User\GenerateApiKeyAction;
-use Ampache\Module\Application\Admin\User\UserAdminAccessTestTrait;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\User\Authorization\UserKeyGeneratorInterface;
@@ -80,6 +79,45 @@ class GenerateApiKeyActionTest extends TestCase
         );
     }
 
+    public function testRunErrorsIfUserWasNotFound(): void
+    {
+        $userId = 666;
+
+        $user = $this->createMock(User::class);
+
+        static::expectException(ObjectNotFoundException::class);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::DEMO_MODE)
+            ->willReturn(false);
+
+        $this->requestParser->expects(static::once())
+            ->method('verifyForm')
+            ->with($this->getValidationFormName())
+            ->willReturn(true);
+
+        $this->request->expects(static::once())
+            ->method('getQueryParams')
+            ->willReturn(['user_id' => (string) $userId]);
+
+        $this->modelFactory->expects(static::once())
+            ->method('createUser')
+            ->with($userId)
+            ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(true);
+
+        $this->subject->run($this->request, $this->gatekeeper);
+    }
+
     public function testRunGeneratesApiKey(): void
     {
         $userId = 666;
@@ -109,6 +147,10 @@ class GenerateApiKeyActionTest extends TestCase
             ->method('createUser')
             ->with($userId)
             ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(false);
 
         $this->userKeyGenerator->expects(static::once())
             ->method('generateApikey')

--- a/tests/Module/Application/Admin/User/GenerateRssTokenActionTest.php
+++ b/tests/Module/Application/Admin/User/GenerateRssTokenActionTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/*
+declare(strict_types=1);
+
+/**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
  * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
@@ -21,14 +23,11 @@
  *
  */
 
-declare(strict_types=1);
-
-namespace Module\Application\Admin\User;
+namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
-use Ampache\Module\Application\Admin\User\GenerateRssTokenAction;
-use Ampache\Module\Application\Admin\User\UserAdminAccessTestTrait;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\User\Authorization\UserKeyGeneratorInterface;
@@ -80,6 +79,45 @@ class GenerateRssTokenActionTest extends TestCase
         );
     }
 
+    public function testRunErrorsIUserWasNotFound(): void
+    {
+        $userId = 666;
+
+        $user = $this->createMock(User::class);
+
+        static::expectException(ObjectNotFoundException::class);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::DEMO_MODE)
+            ->willReturn(false);
+
+        $this->requestParser->expects(static::once())
+            ->method('verifyForm')
+            ->with($this->getValidationFormName())
+            ->willReturn(true);
+
+        $this->request->expects(static::once())
+            ->method('getQueryParams')
+            ->willReturn(['user_id' => (string) $userId]);
+
+        $this->modelFactory->expects(static::once())
+            ->method('createUser')
+            ->with($userId)
+            ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(true);
+
+        $this->subject->run($this->request, $this->gatekeeper);
+    }
+
     public function testRunGeneratesRssToken(): void
     {
         $userId = 666;
@@ -109,6 +147,10 @@ class GenerateRssTokenActionTest extends TestCase
             ->method('createUser')
             ->with($userId)
             ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(false);
 
         $this->userKeyGenerator->expects(static::once())
             ->method('generateRssToken')

--- a/tests/Module/Application/Admin/User/GenerateStreamTokenActionTest.php
+++ b/tests/Module/Application/Admin/User/GenerateStreamTokenActionTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/*
+declare(strict_types=1);
+
+/**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
  * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
@@ -21,14 +23,11 @@
  *
  */
 
-declare(strict_types=1);
-
-namespace Module\Application\Admin\User;
+namespace Ampache\Module\Application\Admin\User;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
-use Ampache\Module\Application\Admin\User\GenerateStreamTokenAction;
-use Ampache\Module\Application\Admin\User\UserAdminAccessTestTrait;
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\User\Authorization\UserKeyGeneratorInterface;
@@ -80,6 +79,45 @@ class GenerateStreamTokenActionTest extends TestCase
         );
     }
 
+    public function testRunErrorsIfUserWasNotFound(): void
+    {
+        $userId = 666;
+
+        $user = $this->createMock(User::class);
+
+        static::expectException(ObjectNotFoundException::class);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::DEMO_MODE)
+            ->willReturn(false);
+
+        $this->requestParser->expects(static::once())
+            ->method('verifyForm')
+            ->with($this->getValidationFormName())
+            ->willReturn(true);
+
+        $this->request->expects(static::once())
+            ->method('getQueryParams')
+            ->willReturn(['user_id' => (string) $userId]);
+
+        $this->modelFactory->expects(static::once())
+            ->method('createUser')
+            ->with($userId)
+            ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(true);
+
+        $this->subject->run($this->request, $this->gatekeeper);
+    }
+
     public function testRunGeneratesRssToken(): void
     {
         $userId = 666;
@@ -109,6 +147,10 @@ class GenerateStreamTokenActionTest extends TestCase
             ->method('createUser')
             ->with($userId)
             ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(false);
 
         $this->userKeyGenerator->expects(static::once())
             ->method('generateStreamToken')

--- a/tests/Module/Application/Admin/User/ShowPreferencesActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowPreferencesActionTest.php
@@ -2,8 +2,30 @@
 
 declare(strict_types=1);
 
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 namespace Ampache\Module\Application\Admin\User;
 
+use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Util\UiInterface;
@@ -37,6 +59,37 @@ class ShowPreferencesActionTest extends TestCase
         );
     }
 
+    public function testRunErrorsIfUserWasNotFound(): void
+    {
+        $request    = $this->createMock(ServerRequestInterface::class);
+        $gatekeeper = $this->createMock(GuiGatekeeperInterface::class);
+        $user       = $this->createMock(User::class);
+
+        $userId = 666;
+
+        static::expectException(ObjectNotFoundException::class);
+
+        $gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_ADMIN)
+            ->willReturn(true);
+
+        $request->expects(static::once())
+            ->method('getQueryParams')
+            ->willReturn(['user_id' => (string) $userId]);
+
+        $this->modelFactory->expects(static::once())
+            ->method('createUser')
+            ->with($userId)
+            ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(true);
+
+        $this->subject->run($request, $gatekeeper);
+    }
+
     public function testShowsPreferences(): void
     {
         $request    = $this->createMock(ServerRequestInterface::class);
@@ -59,6 +112,10 @@ class ShowPreferencesActionTest extends TestCase
             ->method('createUser')
             ->with($userId)
             ->willReturn($user);
+
+        $user->expects(static::once())
+            ->method('isNew')
+            ->willReturn(false);
 
         $this->ui->expects(static::once())
             ->method('showHeader');

--- a/tests/Module/Application/Exception/ObjectNotFoundExceptionTest.php
+++ b/tests/Module/Application/Exception/ObjectNotFoundExceptionTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 /**
@@ -21,13 +20,28 @@ declare(strict_types=1);
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
  */
 
 namespace Ampache\Module\Application\Exception;
 
-final class AccessDeniedException extends ApplicationException
+use PHPUnit\Framework\TestCase;
+
+class ObjectNotFoundExceptionTest extends TestCase
 {
-    /** @var string */
-    protected $message = 'Access denied';
+    private int $objectId = 666;
+
+    private ObjectNotFoundException $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new ObjectNotFoundException($this->objectId);
+    }
+
+    public function testGetObjectIdReturnsValue(): void
+    {
+        static::assertSame(
+            $this->objectId,
+            $this->subject->getObjectId()
+        );
+    }
 }


### PR DESCRIPTION
Use a central catch-block and the new ObjectNotFoundException to streamline the error handling in case of ivalid user-ids have been provided within the request