### PR TITLE
Bugfix: anti-spam feature for reset password was too strict

### DIFF
--- a/src/Module/User/NewPasswordSender.php
+++ b/src/Module/User/NewPasswordSender.php
@@ -66,7 +66,8 @@ final class NewPasswordSender implements NewPasswordSenderInterface
         }
 
         $time        = time();
-        $reset_limit = ($time - 3600) > (User::get_user_data($client->id, 'password_reset')['password_reset'] ?? $time); // don't let a user spam resets
+        $wait_between_reset = 3600; // in seconds
+        $reset_limit = ($time - $wait_between_reset) > (User::get_user_data($client->id, 'password_reset')['password_reset'] ?? ($time - ($wait_between_reset + 100))); // don't let a user spam resets
         if ($client->email == $email && Mailer::is_mail_enabled() && $reset_limit) {
             $newpassword = $this->passwordGenerator->generate();
             $mailer      = new Mailer();


### PR DESCRIPTION
Mail for reset password was never sent for user using it for the first time : if there was no key for the "reset_password" in "user_data", the default value was "now", so the anti spam feature stopped the password reset.