### PR TITLE
Prevent the playback from temporarily updating media properties

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3746,42 +3746,7 @@ parameters:
 			path: src/Module/Api/Output/XmlOutput.php
 
 		-
-			message: "#^Binary operation \"\\+\" between \\(float\\|int\\) and string results in an error\\.$#"
-			count: 1
-			path: src/Module/Api/SubsonicApiApplication.php
-
-		-
-			message: "#^Binary operation \"\\<\\<\" between string and 16 results in an error\\.$#"
-			count: 1
-			path: src/Module/Api/SubsonicApiApplication.php
-
-		-
-			message: "#^Binary operation \"\\<\\<\" between string and 24 results in an error\\.$#"
-			count: 1
-			path: src/Module/Api/SubsonicApiApplication.php
-
-		-
-			message: "#^Binary operation \"\\<\\<\" between string and 8 results in an error\\.$#"
-			count: 1
-			path: src/Module/Api/SubsonicApiApplication.php
-
-		-
-			message: "#^Cannot access property \\$id on Ampache\\\\Repository\\\\Model\\\\User\\|null\\.$#"
-			count: 1
-			path: src/Module/Api/SubsonicApiApplication.php
-
-		-
 			message: "#^Parameter \\#1 \\$callback of function call_user_func expects callable\\(\\)\\: mixed, array\\{'Ampache\\\\\\\\Module\\\\\\\\Api\\\\\\\\Subsonic_Api', non\\-falsy\\-string\\} given\\.$#"
-			count: 1
-			path: src/Module/Api/SubsonicApiApplication.php
-
-		-
-			message: "#^Parameter \\#1 \\$key of function array_key_exists expects int\\|string, string\\|false given\\.$#"
-			count: 1
-			path: src/Module/Api/SubsonicApiApplication.php
-
-		-
-			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/Module/Api/SubsonicApiApplication.php
 
@@ -4361,27 +4326,7 @@ parameters:
 			path: src/Module/Api/Subsonic_Api.php
 
 		-
-			message: "#^Cannot access offset 0 on array\\|bool\\.$#"
-			count: 2
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
-			message: "#^Cannot access offset 1 on non\\-empty\\-array\\|true\\.$#"
-			count: 1
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
 			message: "#^Cannot cast array\\<int, string\\>\\|string\\|null to string\\.$#"
-			count: 1
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
-			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
-			message: "#^Method Ampache\\\\Module\\\\Api\\\\Subsonic_Xml_Data\\:\\:_getAlbumId\\(\\) has parameter \\$album_id with no type specified\\.$#"
 			count: 1
 			path: src/Module/Api/Subsonic_Xml_Data.php
 
@@ -4396,17 +4341,7 @@ parameters:
 			path: src/Module/Api/Subsonic_Xml_Data.php
 
 		-
-			message: "#^Method Ampache\\\\Module\\\\Api\\\\Subsonic_Xml_Data\\:\\:_getArtistId\\(\\) has parameter \\$artist_id with no type specified\\.$#"
-			count: 1
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
 			message: "#^Method Ampache\\\\Module\\\\Api\\\\Subsonic_Xml_Data\\:\\:_getCatalogData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
-			message: "#^Method Ampache\\\\Module\\\\Api\\\\Subsonic_Xml_Data\\:\\:_getSongId\\(\\) has parameter \\$song_id with no type specified\\.$#"
 			count: 1
 			path: src/Module/Api/Subsonic_Xml_Data.php
 
@@ -4612,51 +4547,6 @@ parameters:
 
 		-
 			message: "#^Method Ampache\\\\Module\\\\Api\\\\Subsonic_Xml_Data\\:\\:addUsers\\(\\) has parameter \\$users with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
-			message: "#^Parameter \\#1 \\$catalog_id of static method Ampache\\\\Repository\\\\Model\\\\Catalog\\:\\:create_from_id\\(\\) expects int, string given\\.$#"
-			count: 1
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
-			message: "#^Parameter \\#1 \\$episode_id of static method Ampache\\\\Module\\\\Api\\\\Subsonic_Xml_Data\\:\\:_isPodcastEpisode\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
-			message: "#^Parameter \\#1 \\$object_id of static method Ampache\\\\Module\\\\Api\\\\Subsonic_Xml_Data\\:\\:_cleanId\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
-			message: "#^Parameter \\#1 \\$object_id of static method Ampache\\\\Module\\\\Api\\\\Subsonic_Xml_Data\\:\\:_getAmpacheId\\(\\) expects string, int given\\.$#"
-			count: 3
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
-			message: "#^Parameter \\#1 \\$song_id of static method Ampache\\\\Module\\\\Api\\\\Subsonic_Xml_Data\\:\\:_isSong\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|bool given\\.$#"
-			count: 2
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
-			message: "#^Parameter \\#1 \\$video_id of static method Ampache\\\\Module\\\\Api\\\\Subsonic_Xml_Data\\:\\:_isVideo\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method SimpleXMLElement\\:\\:addAttribute\\(\\) expects string, int\\|string given\\.$#"
-			count: 1
-			path: src/Module/Api/Subsonic_Xml_Data.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method SimpleXMLElement\\:\\:addAttribute\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Module/Api/Subsonic_Xml_Data.php
 
@@ -9771,11 +9661,6 @@ parameters:
 			path: src/Module/Song/Tag/SongTagWriter.php
 
 		-
-			message: "#^Method Ampache\\\\Module\\\\Song\\\\Tag\\\\SongTagWriter\\:\\:search_txxx\\(\\) has parameter \\$description with no type specified\\.$#"
-			count: 1
-			path: src/Module/Song/Tag/SongTagWriter.php
-
-		-
 			message: "#^Method Ampache\\\\Module\\\\Song\\\\Tag\\\\SongTagWriter\\:\\:search_txxx\\(\\) has parameter \\$ndata with no type specified\\.$#"
 			count: 1
 			path: src/Module/Song/Tag/SongTagWriter.php
@@ -14161,11 +14046,6 @@ parameters:
 			path: src/Repository/Model/Artist.php
 
 		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Artist\\:\\:is_upload\\(\\) has parameter \\$artist_id with no type specified\\.$#"
-			count: 1
-			path: src/Repository/Model/Artist.php
-
-		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Artist\\:\\:migrate\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Repository/Model/Artist.php
@@ -15662,11 +15542,6 @@ parameters:
 
 		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Query\\:\\:get_saved\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/Query.php
-
-		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Query\\:\\:get_state\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/Query.php
 

--- a/src/Module/Application/Playback/PlayAction.php
+++ b/src/Module/Application/Playback/PlayAction.php
@@ -620,10 +620,14 @@ final class PlayAction implements ApplicationActionInterface
                 );
                 $cache_file   = true;
                 $original     = true;
-                $media->file  = $file_target;
-                $media->size  = Core::get_filesize($file_target);
-                $media->type  = $cache_target;
                 $transcode_to = null;
+
+                $streamConfiguration = [
+                    'file_path' => $file_target,
+                    'file_name' => $media->f_file,
+                    'file_size' => Core::get_filesize($file_target),
+                    'file_type' => $cache_target,
+                ];
             } else {
                 // Build up the catalog for our current object
                 $catalog = Catalog::create_from_id($mediaCatalogId);
@@ -647,8 +651,8 @@ final class PlayAction implements ApplicationActionInterface
                     return null;
                 }
 
-                $media = $catalog->prepare_media($media);
-                if ($media == null) {
+                $streamConfiguration = $catalog->prepare_media($media);
+                if ($streamConfiguration === null) {
                     return null;
                 }
             }
@@ -665,7 +669,7 @@ final class PlayAction implements ApplicationActionInterface
         // load the cache file or the local file
         $stream_file = ($cache_file && $file_target)
             ? $file_target
-            : $media->file;
+            : $streamConfiguration['file_path'];
 
         /* If we don't have a file, or the file is not readable */
         if (!$stream_file || !Core::is_readable(Core::conv_lc_file((string)$stream_file))) {
@@ -684,10 +688,10 @@ final class PlayAction implements ApplicationActionInterface
         // Format the media name
         $media_name = (!empty($stream_name))
             ? $stream_name
-            : $media->get_stream_name() . "." . $media->type;
+            : $media->get_stream_name() . "." . $streamConfiguration['file_type'];
         $transcode_to = ($transcode_cfg == 'never' || $cache_file || ($is_download && !$transcode_to))
             ? null
-            : Stream::get_transcode_format((string)$media->type, $transcode_to, $player, $type);
+            : Stream::get_transcode_format($streamConfiguration['file_type'], $transcode_to, $player, $type);
 
         header('Access-Control-Allow-Origin: *');
 
@@ -704,8 +708,8 @@ final class PlayAction implements ApplicationActionInterface
                 [LegacyLogger::CONTEXT_TYPE => __CLASS__]
             );
             // STUPID IE
-            $media_name = str_replace(array('?', '/', '\\'), "_", $media->f_file);
-            $headers    = $this->browser->getDownloadHeaders($media_name, $media->mime, false, (string)$media->size);
+            $media_name = str_replace(array('?', '/', '\\'), "_", $streamConfiguration['file_name']);
+            $headers    = $this->browser->getDownloadHeaders($media_name, $media->mime, false, (string)$streamConfiguration['file_size']);
 
             foreach ($headers as $headerName => $value) {
                 header(sprintf('%s: %s', $headerName, $value));
@@ -762,7 +766,7 @@ final class PlayAction implements ApplicationActionInterface
             [LegacyLogger::CONTEXT_TYPE => __CLASS__]
         );
         $this->logger->debug(
-            'Media type {' . $media->type . '}',
+            'Media type {' . $streamConfiguration['file_type'] . '}',
             [LegacyLogger::CONTEXT_TYPE => __CLASS__]
         );
 
@@ -773,7 +777,7 @@ final class PlayAction implements ApplicationActionInterface
             );
         }
         // transcode_to should only have an effect if the media is the wrong format
-        $transcode_to = ($transcode_cfg == 'never' || $transcode_to == $media->type)
+        $transcode_to = ($transcode_cfg == 'never' || $transcode_to == $streamConfiguration['file_type'])
             ? null
             : $transcode_to;
 
@@ -827,7 +831,7 @@ final class PlayAction implements ApplicationActionInterface
             } else {
                 if ($transcode_cfg != 'never') {
                     $this->logger->notice(
-                        'Transcoding is not enforced for ' . $media->type,
+                        'Transcoding is not enforced for ' . $streamConfiguration['file_type'],
                         [LegacyLogger::CONTEXT_TYPE => __CLASS__]
                     );
                 } else {
@@ -892,10 +896,10 @@ final class PlayAction implements ApplicationActionInterface
             // Content-length guessing if required by the player.
             // Otherwise it shouldn't be used as we are not really sure about final length when transcoding
             $transcode_settings = Stream::get_transcode_settings_for_media(
-                (string) $media->type,
+                $streamConfiguration['file_type'],
                 $transcode_to,
                 $player,
-                (string) $media->type,
+                $streamConfiguration['file_type'],
                 $troptions
             );
             $transcode_to = $transcode_settings['format'];
@@ -922,7 +926,7 @@ final class PlayAction implements ApplicationActionInterface
                 $maxbitrate  = 0;
             }
         } else {
-            $stream_size = (int)$media->size;
+            $stream_size = $streamConfiguration['file_size'];
         }
 
         if (!is_resource($filepointer)) {
@@ -946,9 +950,9 @@ final class PlayAction implements ApplicationActionInterface
         if ($range_values > 0 && ($start > 0 || $end > 0)) {
             // Calculate stream size from byte range
             if ($range_values >= 2) {
-                $end = (int)min($end, $media->size - 1);
+                $end = (int)min($end, $streamConfiguration['file_size'] - 1);
             } else {
-                $end = $media->size - 1;
+                $end = $streamConfiguration['file_size'] - 1;
             }
             $stream_size = (int)($end - ((int)$start)) + 1;
 
@@ -959,12 +963,12 @@ final class PlayAction implements ApplicationActionInterface
                 );
             } elseif (!$transcode) {
                 $this->logger->debug(
-                    'Content-Range header received, skipping ' . $start . ' bytes out of ' . $media->size,
+                    'Content-Range header received, skipping ' . $start . ' bytes out of ' . $streamConfiguration['file_size'],
                     [LegacyLogger::CONTEXT_TYPE => __CLASS__]
                 );
                 fseek($filepointer, (int)$start);
 
-                $range = $start . '-' . $end . '/' . $media->size;
+                $range = $start . '-' . $end . '/' . $streamConfiguration['file_size'];
                 header('HTTP/1.1 206 Partial Content');
                 header('Content-Range: bytes ' . $range);
             }
@@ -1042,8 +1046,8 @@ final class PlayAction implements ApplicationActionInterface
         } else {
             // output file might not be the same type
             $mime = ($type == 'video')
-                ? Video::type_to_mime($media->type)
-                : Song::type_to_mime($media->type);
+                ? Video::type_to_mime($streamConfiguration['file_type'])
+                : Song::type_to_mime($streamConfiguration['file_type']);
         }
 
         // Close sql connection

--- a/src/Module/Beets/Catalog.php
+++ b/src/Module/Beets/Catalog.php
@@ -95,13 +95,23 @@ abstract class Catalog extends \Ampache\Repository\Model\Catalog
     /**
      *
      * @param Song|Podcast_Episode|Video $media
-     * @return Song|Podcast_Episode|Video
+     * @return array{
+     *   file_path: string,
+     *   file_name: string,
+     *   file_size: int,
+     *   file_type: string
+     * }
      */
-    public function prepare_media($media)
+    public function prepare_media($media): array
     {
         debug_event(self::class, 'Play: Started remote stream - ' . $media->file, 5);
 
-        return $media;
+        return [
+            'file_path' => (string) $media->file,
+            'file_name' => $media->f_file,
+            'file_size' => $media->size,
+            'file_type' => $media->type
+        ];
     }
 
     /**

--- a/src/Module/Catalog/Catalog_Seafile.php
+++ b/src/Module/Catalog/Catalog_Seafile.php
@@ -647,10 +647,19 @@ class Catalog_Seafile extends Catalog
 
     /**
      * @param Song|Podcast_Episode|Video $media
-     * @return Song|Podcast_Episode|Video
+     * @return array{
+     *    file_path: string,
+     *    file_name: string,
+     *    file_size: int,
+     *    file_type: string
+     * }
      */
-    public function prepare_media($media)
+    public function prepare_media($media): array
     {
+        $stream_path = (string) $media->file;
+        $stream_name = $media->f_file;
+        $size        = $media->size;
+
         if ($this->seafile->prepare()) {
             set_time_limit(0);
 
@@ -660,16 +669,21 @@ class Catalog_Seafile extends Catalog
 
             $tempfile = $this->seafile->download($file);
 
-            $media->file   = $tempfile;
-            $media->f_file = $fileinfo['filename'];
+            $stream_path = $tempfile;
+            $stream_name = $fileinfo['filename'];
 
             // in case this didn't get set for some reason
-            if ($media->size == 0) {
-                $media->size = Core::get_filesize($tempfile);
+            if ($size == 0) {
+                $size = Core::get_filesize($tempfile);
             }
         }
 
-        return $media;
+        return [
+            'file_path' => $stream_path,
+            'file_name' => $stream_name,
+            'file_size' => $size,
+            'file_type' => $media->type
+        ];
     }
 
     /**

--- a/src/Module/Catalog/Catalog_dropbox.php
+++ b/src/Module/Catalog/Catalog_dropbox.php
@@ -711,25 +711,40 @@ class Catalog_dropbox extends Catalog
 
     /**
      * @param Song|Podcast_Episode|Video $media
-     * @return Song|Podcast_Episode|Video
+     *
+     * @return array{
+     *  file_path: string,
+     *  file_name: string,
+     *  file_size: int,
+     *  file_type: string
+     * }
      */
-    public function prepare_media($media)
+    public function prepare_media($media): array
     {
         $app     = new DropboxApp($this->apikey, $this->secret, $this->authtoken);
         $dropbox = new Dropbox($app);
+
+        $file = (string) $media->file;
+
         try {
             set_time_limit(0);
             $meta    = $dropbox->getMetadata((string)$media->file);
             $outfile = sys_get_temp_dir() . '/' . $meta->getName();
 
             // Download File
-            $this->download($dropbox, $media->file, null, $outfile);
-            $media->file = $outfile;
+            $this->download($dropbox, $file, null, $outfile);
+
+            $file = $outfile;
         } catch (DropboxClientException $e) {
             debug_event('dropbox.catalog', 'File not found on Dropbox: ' . $media->file, 5);
         }
 
-        return $media;
+        return [
+            'file_path' => $file,
+            'file_name' => $media->f_file,
+            'file_size' => $media->size,
+            'file_type' => $media->type
+        ];
     }
 
     /**

--- a/src/Module/Catalog/Catalog_local.php
+++ b/src/Module/Catalog/Catalog_local.php
@@ -1110,11 +1110,21 @@ class Catalog_local extends Catalog
 
     /**
      * @param Song|Podcast_Episode|Video $media
-     * @return Song|Podcast_Episode|Video
+     * @return array{
+     *  file_path: string,
+     *  file_name: string,
+     *  file_size: int,
+     *  file_type: string
+     * }
      */
-    public function prepare_media($media)
+    public function prepare_media($media): array
     {
-        return $media;
+        return [
+            'file_path' => (string) $media->file,
+            'file_name' => $media->f_file,
+            'file_size' => $media->size,
+            'file_type' => $media->type
+        ];
     }
 
     /**

--- a/src/Module/Catalog/Catalog_remote.php
+++ b/src/Module/Catalog/Catalog_remote.php
@@ -505,10 +505,14 @@ class Catalog_remote extends Catalog
 
     /**
      * @param Song|Podcast_Episode|Video $media
-     * @return null
-     * @throws Exception
+     * @return null|array{
+     *   file_path: string,
+     *   file_name: string,
+     *   file_size: int,
+     *   file_type: string
+     *  }
      */
-    public function prepare_media($media)
+    public function prepare_media($media): ?array
     {
         return null;
     }

--- a/src/Module/Catalog/Catalog_subsonic.php
+++ b/src/Module/Catalog/Catalog_subsonic.php
@@ -535,9 +535,14 @@ class Catalog_subsonic extends Catalog
 
     /**
      * @param Song|Podcast_Episode|Video $media
-     * @return null
+     * @return null|array{
+     *  file_path: string,
+     *  file_name: string,
+     *  file_size: int,
+     *  file_type: string
+     * }
      */
-    public function prepare_media($media)
+    public function prepare_media($media): ?array
     {
         return null;
     }

--- a/src/Repository/Model/Catalog.php
+++ b/src/Repository/Model/Catalog.php
@@ -285,9 +285,14 @@ abstract class Catalog extends database_object
 
     /**
      * @param Song|Podcast_Episode|Video $media
-     * @return Song|Podcast_Episode|Video|null
+     * @return null|array{
+     *  file_path: string,
+     *  file_name: string,
+     *  file_size: int,
+     *  file_type: string
+     * }
      */
-    abstract public function prepare_media($media);
+    abstract public function prepare_media($media): ?array;
 
     public function getId(): int
     {


### PR DESCRIPTION
Properties like `file`, `size` or `f_file` got temporarily overwritten by some catalog types during playback preparations. This should not happen as those properties represent the internal state of the object and are not meant to be some sort of `data storage` to carry some temporary information from place a to b.

I tested this with certain configuration but this surely somewhat experimental...