### PR TITLE
Rework podcast-feed and -episode loading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
         "nyholm/psr7-server": "^1.0",
         "oomphinc/composer-installers-extender": "^2.0",
         "openid/php-openid": "^3",
+        "php-curl-class/php-curl-class": "^9.18",
         "php-di/php-di": "^6.0",
         "phpmailer/phpmailer": "6.5.*",
         "pklauzinski/jscroll": "2.*",

--- a/composer_old.json
+++ b/composer_old.json
@@ -77,6 +77,7 @@
         "nyholm/psr7-server": "^1.0",
         "oomphinc/composer-installers-extender": "^2.0",
         "openid/php-openid": "^3",
+        "php-curl-class/php-curl-class": "^9.18",
         "php-di/php-di": "^6.0",
         "php-tmdb/api": "2.*",
         "phpmailer/phpmailer": "6.5.*",

--- a/src/Config/ConfigContainer.php
+++ b/src/Config/ConfigContainer.php
@@ -123,6 +123,14 @@ final class ConfigContainer implements ConfigContainerInterface
         return $this->isFeatureEnabled(ConfigurationKeyEnum::DEMO_MODE);
     }
 
+    /**
+     * Returns the current Ampache version
+     */
+    public function getVersion(): string
+    {
+        return $this->configuration[ConfigurationKeyEnum::VERSION] ?? '';
+    }
+
     public function getConfigFilePath(): string
     {
         return __DIR__ . '/../../config/ampache.cfg.php';

--- a/src/Config/ConfigContainerInterface.php
+++ b/src/Config/ConfigContainerInterface.php
@@ -97,6 +97,11 @@ interface ConfigContainerInterface
     public function isDemoMode(): bool;
 
     /**
+     * Returns the current Ampache version
+     */
+    public function getVersion(): string;
+
+    /**
      * Returns the path to the ampache config file
      */
     public function getConfigFilePath(): string;

--- a/src/Config/ConfigurationKeyEnum.php
+++ b/src/Config/ConfigurationKeyEnum.php
@@ -201,4 +201,8 @@ final class ConfigurationKeyEnum
     public const WAVEFORM                              = 'waveform';
     public const WEB_PATH                              = 'web_path';
     public const WRITE_TAGS                            = 'write_tags';
+    public const PROXY_HOST                            = 'proxy_host';
+    public const PROXY_PORT                            = 'proxy_port';
+    public const PROXY_USER                            = 'proxy_user';
+    public const PROXY_PASS                            = 'proxy_pass';
 }

--- a/src/Config/ConfigurationKeyEnum.php
+++ b/src/Config/ConfigurationKeyEnum.php
@@ -145,6 +145,10 @@ final class ConfigurationKeyEnum
     public const PODCAST_NEW_DOWNLOAD                  = 'podcast_new_download';
     public const PODCAST                               = 'podcast';
     public const POPULAR_THRESHOLD                     = 'popular_threshold';
+    public const PROXY_HOST                            = 'proxy_host';
+    public const PROXY_PASS                            = 'proxy_pass';
+    public const PROXY_PORT                            = 'proxy_port';
+    public const PROXY_USER                            = 'proxy_user';
     public const RADIO                                 = 'live_stream';
     public const RATE_LIMIT                            = 'rate_limit';
     public const RATING_FILE_TAG_USER                  = 'rating_file_tag_user';
@@ -202,8 +206,4 @@ final class ConfigurationKeyEnum
     public const WAVEFORM                              = 'waveform';
     public const WEB_PATH                              = 'web_path';
     public const WRITE_TAGS                            = 'write_tags';
-    public const PROXY_HOST                            = 'proxy_host';
-    public const PROXY_PORT                            = 'proxy_port';
-    public const PROXY_USER                            = 'proxy_user';
-    public const PROXY_PASS                            = 'proxy_pass';
 }

--- a/src/Module/Podcast/PodcastEpisodeDownloaderInterface.php
+++ b/src/Module/Podcast/PodcastEpisodeDownloaderInterface.php
@@ -29,8 +29,7 @@ use Ampache\Repository\Model\Podcast_Episode;
 interface PodcastEpisodeDownloaderInterface
 {
     /**
-     * gather
-     * download the podcast episode to your catalog
+     * Download the podcast-episodes files and perform media info update
      */
     public function fetch(Podcast_Episode $episode): void;
 }

--- a/src/Module/Util/UtilityFactory.php
+++ b/src/Module/Util/UtilityFactory.php
@@ -27,6 +27,7 @@ namespace Ampache\Module\Util;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Repository\UserRepositoryInterface;
+use Curl\Curl;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -76,5 +77,13 @@ final class UtilityFactory implements UtilityFactoryInterface
             $filePattern,
             $isLocal
         );
+    }
+
+    /**
+     * Returns a new Curl instance
+     */
+    public function createCurl(): Curl
+    {
+        return new Curl();
     }
 }

--- a/src/Module/Util/WebFetcher/Exception/FetchFailedException.php
+++ b/src/Module/Util/WebFetcher/Exception/FetchFailedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -18,29 +20,12 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
  */
 
-namespace Ampache\Module\Util;
+namespace Ampache\Module\Util\WebFetcher\Exception;
 
-use Curl\Curl;
+use Exception;
 
-interface UtilityFactoryInterface
+final class FetchFailedException extends Exception
 {
-    public function createMailer(): MailerInterface;
-
-    public function createVaInfo(
-        string $file,
-        array $gatherTypes = [],
-        ?string $encoding = null,
-        ?string $encodingId3v1 = null,
-        string $dirPattern = '',
-        string $filePattern = '',
-        bool $isLocal = true
-    ): VaInfoInterface;
-
-    /**
-     * Returns a new Curl instance
-     */
-    public function createCurl(): Curl;
 }

--- a/src/Module/Util/WebFetcher/WebFetcher.php
+++ b/src/Module/Util/WebFetcher/WebFetcher.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Module\Util\WebFetcher;
+
+use Ampache\Config\ConfigContainerInterface;
+use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\System\LegacyLogger;
+use Ampache\Module\Util\UtilityFactoryInterface;
+use Ampache\Module\Util\WebFetcher\Exception\FetchFailedException;
+use Curl\Curl;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Provides functionality for downloading web-content
+ */
+final class WebFetcher implements WebFetcherInterface
+{
+    private ConfigContainerInterface $config;
+
+    private UtilityFactoryInterface $utilityFactory;
+
+    private LoggerInterface $logger;
+
+    public function __construct(
+        ConfigContainerInterface $config,
+        UtilityFactoryInterface $utilityFactory,
+        LoggerInterface $logger
+    ) {
+        $this->config         = $config;
+        $this->utilityFactory = $utilityFactory;
+        $this->logger         = $logger;
+    }
+
+    /**
+     * Fetches and returns the uris content
+     *
+     * @throws FetchFailedException
+     */
+    public function fetch(string $uri): string
+    {
+        $curl = $this->setupCurl();
+
+        $this->logger->debug(
+            sprintf('Fetching url: %s', $uri),
+            [LegacyLogger::CONTEXT_TYPE => self::class]
+        );
+
+        $curl->get($uri);
+        $curl->close();
+
+        if ($curl->error) {
+            throw new Exception\FetchFailedException(
+                sprintf('Error fetching url: %s', $uri)
+            );
+        }
+
+        return (string) $curl->rawResponse;
+    }
+
+    /**
+     * Fetches the uris content and saves it directly to a file
+     *
+     * @throws FetchFailedException
+     */
+    public function fetchToFile(
+        string $uri,
+        string $destinationFilePath
+    ): void {
+        $curl = $this->setupCurl();
+        $curl->setReferer($uri);
+
+        $result = $curl->download($uri, $destinationFilePath);
+
+        $curl->close();
+        if ($result) {
+            $this->logger->debug(
+                sprintf('Download to file completed: %s', $destinationFilePath),
+                [LegacyLogger::CONTEXT_TYPE => self::class]
+            );
+        } else {
+            throw new Exception\FetchFailedException(
+                sprintf('Error downloading to file: %s', $destinationFilePath)
+            );
+        }
+    }
+
+    /**
+     * Sets up the curl session with configured defaults
+     */
+    private function setupCurl(): Curl
+    {
+        $proxyHost = $this->config->get(ConfigurationKeyEnum::PROXY_HOST);
+        $proxyPort = $this->config->get(ConfigurationKeyEnum::PROXY_PORT);
+        $proxyUser = $this->config->get(ConfigurationKeyEnum::PROXY_USER);
+        $proxyPass = $this->config->get(ConfigurationKeyEnum::PROXY_PASS);
+
+        $curl = $this->utilityFactory->createCurl();
+        $curl->setFollowLocation();
+        $curl->setUserAgent(sprintf('Ampache/%s', $this->config->getVersion()));
+
+        if ($proxyHost && $proxyPort) {
+            if ($proxyUser === '') {
+                $proxyUser = null;
+            }
+            if ($proxyPass === '') {
+                $proxyPass = null;
+            }
+            $curl->setProxy($proxyHost, $proxyPort, $proxyUser, $proxyPass);
+        }
+
+        return $curl;
+    }
+}

--- a/src/Module/Util/WebFetcher/WebFetcherInterface.php
+++ b/src/Module/Util/WebFetcher/WebFetcherInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -18,29 +20,25 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
  */
 
-namespace Ampache\Module\Util;
+namespace Ampache\Module\Util\WebFetcher;
 
-use Curl\Curl;
+use Ampache\Module\Util\WebFetcher\Exception\FetchFailedException;
 
-interface UtilityFactoryInterface
+interface WebFetcherInterface
 {
-    public function createMailer(): MailerInterface;
-
-    public function createVaInfo(
-        string $file,
-        array $gatherTypes = [],
-        ?string $encoding = null,
-        ?string $encodingId3v1 = null,
-        string $dirPattern = '',
-        string $filePattern = '',
-        bool $isLocal = true
-    ): VaInfoInterface;
+    /**
+     * Fetches and returns the uris content
+     *
+     * @throws FetchFailedException
+     */
+    public function fetch(string $uri): string;
 
     /**
-     * Returns a new Curl instance
+     * Fetches the uris content and saves it directly to a file
+     *
+     * @throws FetchFailedException
      */
-    public function createCurl(): Curl;
+    public function fetchToFile(string $uri, string $destinationFilePath): void;
 }

--- a/src/Module/Util/service_definition.php
+++ b/src/Module/Util/service_definition.php
@@ -29,8 +29,9 @@ use Ampache\Module\Util\FileSystem\FileNameConverter;
 use Ampache\Module\Util\FileSystem\FileNameConverterInterface;
 use Ampache\Module\Util\Rss\AmpacheRss;
 use Ampache\Module\Util\Rss\AmpacheRssInterface;
-
 use Ampache\Module\Util\Rss\RssPodcastBuilder;
+use Ampache\Module\Util\WebFetcher\WebFetcher;
+use Ampache\Module\Util\WebFetcher\WebFetcherInterface;
 
 use function DI\autowire;
 
@@ -50,4 +51,5 @@ return [
             'rssPodcastBuilder',
             autowire(RssPodcastBuilder::class)
         ),
+    WebFetcherInterface::class => autowire(WebFetcher::class),
 ];

--- a/src/Repository/Model/Catalog.php
+++ b/src/Repository/Model/Catalog.php
@@ -3469,6 +3469,7 @@ abstract class Catalog extends database_object
         if (!$items) {
             return array($string);
         }
+
         return array_map('trim', $items);
     }
 

--- a/src/Repository/Model/Podcast_Episode.php
+++ b/src/Repository/Model/Podcast_Episode.php
@@ -403,6 +403,21 @@ class Podcast_Episode extends database_object implements Media, library_item, Ga
         return $this->f_description;
     }
 
+    public function getSource(): string
+    {
+        return (string) $this->source;
+    }
+
+    public function getFile(): string
+    {
+        return (string) $this->file;
+    }
+
+    public function getPodcastId(): int
+    {
+        return $this->podcast;
+    }
+
     /**
      * display_art
      * @param int $thumb

--- a/tests/Config/ConfigContainerTest.php
+++ b/tests/Config/ConfigContainerTest.php
@@ -269,6 +269,18 @@ class ConfigContainerTest extends MockeryTestCase
         );
     }
 
+    public function testGetVersionReturnsVersion(): void
+    {
+        $value = 'some-value';
+
+        $this->assertSame(
+            $value,
+            $this->createSubject([
+                ConfigurationKeyEnum::VERSION => $value
+            ])->getVersion()
+        );
+    }
+
     private function createSubject(array $configuration = []): ConfigContainerInterface
     {
         return new ConfigContainer($configuration);

--- a/tests/Module/Podcast/PodcastEpisodeDownloaderTest.php
+++ b/tests/Module/Podcast/PodcastEpisodeDownloaderTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Module\Podcast;
+
+use Ampache\Module\Podcast\Exception\PodcastFolderException;
+use Ampache\Module\System\LegacyLogger;
+use Ampache\Module\Util\WebFetcher\WebFetcherInterface;
+use Ampache\Repository\Model\ModelFactoryInterface;
+use Ampache\Repository\Model\Podcast;
+use Ampache\Repository\Model\Podcast_Episode;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class PodcastEpisodeDownloaderTest extends TestCase
+{
+    private PodcastFolderProviderInterface&MockObject $podcastFolderProvider;
+
+    private WebFetcherInterface&MockObject $webFetcher;
+
+    private ModelFactoryInterface&MockObject $modelFactory;
+
+    private LoggerInterface&MockObject $logger;
+
+    private PodcastEpisodeDownloader $subject;
+
+    protected function setUp(): void
+    {
+        $this->podcastFolderProvider = $this->createMock(PodcastFolderProviderInterface::class);
+        $this->webFetcher            = $this->createMock(WebFetcherInterface::class);
+        $this->modelFactory          = $this->createMock(ModelFactoryInterface::class);
+        $this->logger                = $this->createMock(LoggerInterface::class);
+
+        $this->subject = new PodcastEpisodeDownloader(
+            $this->podcastFolderProvider,
+            $this->webFetcher,
+            $this->modelFactory,
+            $this->logger,
+        );
+    }
+
+    public function testFetchFailsIfEpisodeHasNoSourceUrl(): void
+    {
+        $episode = $this->createMock(Podcast_Episode::class);
+
+        $episodeId = 666;
+
+        $episode->expects(static::once())
+            ->method('getId')
+            ->willReturn($episodeId);
+
+        $this->logger->expects(static::once())
+            ->method('warning')
+            ->with(
+                sprintf('Cannot download podcast episode %d, empty source.', $episodeId),
+                [LegacyLogger::CONTEXT_TYPE => PodcastEpisodeDownloader::class]
+            );
+
+        $this->subject->fetch($episode);
+    }
+
+    public function testFetchFailsIfPodcastBaseUrlDoesNotExist(): void
+    {
+        $episode = $this->createMock(Podcast_Episode::class);
+        $podcast = $this->createMock(Podcast::class);
+
+        $episodeId    = 666;
+        $source       = 'some-source';
+        $podcastId    = 42;
+        $errorMessage = 'some-error-message';
+
+        $this->logger->expects(static::once())
+            ->method('error')
+            ->with(
+                sprintf(
+                    'Podcast folder error: %s. Check your catalog directory and permissions',
+                    $errorMessage
+                ),
+                [LegacyLogger::CONTEXT_TYPE => PodcastEpisodeDownloader::class]
+            );
+
+        $episode->expects(static::once())
+            ->method('getId')
+            ->willReturn($episodeId);
+        $episode->expects(static::once())
+            ->method('getSource')
+            ->willReturn($source);
+        $episode->expects(static::once())
+            ->method('getPodcastId')
+            ->willReturn($podcastId);
+
+        $this->modelFactory->expects(static::once())
+            ->method('createPodcast')
+            ->willReturn($podcast);
+
+        $this->podcastFolderProvider->expects(static::once())
+            ->method('getBaseFolder')
+            ->with($podcast)
+            ->willThrowException(new PodcastFolderException($errorMessage));
+
+        $this->subject->fetch($episode);
+    }
+}

--- a/tests/Module/Util/UtilityFactoryTest.php
+++ b/tests/Module/Util/UtilityFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
  *
@@ -21,28 +23,24 @@
  *
  */
 
-declare(strict_types=1);
-
 namespace Ampache\Module\Util;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\MockeryTestCase;
 use Ampache\Repository\UserRepositoryInterface;
+use Curl\Curl;
 use Mockery\MockInterface;
 use Psr\Log\LoggerInterface;
 
 class UtilityFactoryTest extends MockeryTestCase
 {
-    /** @var UserRepositoryInterface|MockInterface */
-    private MockInterface $userRepository;
+    private MockInterface&UserRepositoryInterface $userRepository;
 
-    /** @var ConfigContainerInterface|MockInterface */
-    private MockInterface $configContainer;
+    private MockInterface&ConfigContainerInterface $configContainer;
 
-    /** @var LoggerInterface|MockInterface */
-    private MockInterface $logger;
+    private MockInterface&LoggerInterface $logger;
 
-    private ?UtilityFactory $subject;
+    private UtilityFactory $subject;
 
     public function setUp(): void
     {
@@ -62,6 +60,14 @@ class UtilityFactoryTest extends MockeryTestCase
         $this->assertInstanceOf(
             Mailer::class,
             $this->subject->createMailer()
+        );
+    }
+
+    public function testCreateCurlReturnsNewInstance(): void
+    {
+        static::assertInstanceOf(
+            Curl::class,
+            $this->subject->createCurl()
         );
     }
 }

--- a/tests/Module/Util/WebFetcher/WebFetcherTest.php
+++ b/tests/Module/Util/WebFetcher/WebFetcherTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Module\Util\WebFetcher;
+
+use Ampache\Config\ConfigContainerInterface;
+use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\System\LegacyLogger;
+use Ampache\Module\Util\UtilityFactoryInterface;
+use Ampache\Module\Util\WebFetcher\Exception\FetchFailedException;
+use Curl\Curl;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use SEEC\PhpUnit\Helper\ConsecutiveParams;
+
+class WebFetcherTest extends TestCase
+{
+    use ConsecutiveParams;
+
+    private ConfigContainerInterface&MockObject $config;
+
+    private UtilityFactoryInterface&MockObject $utilityFactory;
+
+    private LoggerInterface&MockObject $logger;
+
+    private WebFetcher $subject;
+
+    protected function setUp(): void
+    {
+        $this->config         = $this->createMock(ConfigContainerInterface::class);
+        $this->utilityFactory = $this->createMock(UtilityFactoryInterface::class);
+        $this->logger         = $this->createMock(LoggerInterface::class);
+
+        $this->subject = new WebFetcher(
+            $this->config,
+            $this->utilityFactory,
+            $this->logger
+        );
+    }
+
+    public function testFetchFetchesWithProxy(): void
+    {
+        $uri       = 'some-uri';
+        $result    = 'some-result';
+        $version   = '4.5.6';
+        $proxyUser = 'some-proxy-user';
+        $proxyPass = 'some-proxy-pass';
+        $proxyHost = 'some-proxy-host';
+        $proxyPort = 'some-proxy-port';
+
+        $curl = $this->createMock(Curl::class);
+
+        $this->utilityFactory->expects(static::once())
+            ->method('createCurl')
+            ->willReturn($curl);
+
+        $curl->expects(static::once())
+            ->method('setFollowLocation');
+        $curl->expects(static::once())
+            ->method('setUserAgent')
+            ->with(sprintf('Ampache/%s', $version));
+        $curl->expects(static::once())
+            ->method('setProxy')
+            ->with($proxyHost, $proxyPort, $proxyUser, $proxyPass);
+        $curl->expects(static::once())
+            ->method('get')
+            ->with($uri);
+        $curl->expects(static::once())
+            ->method('close');
+
+        $this->config->expects(static::once())
+            ->method('getVersion')
+            ->willReturn($version);
+        $this->config->expects(static::exactly(4))
+            ->method('get')
+            ->with(...self::withConsecutive(
+                [ConfigurationKeyEnum::PROXY_HOST],
+                [ConfigurationKeyEnum::PROXY_PORT],
+                [ConfigurationKeyEnum::PROXY_USER],
+                [ConfigurationKeyEnum::PROXY_PASS],
+            ))
+            ->willReturn($proxyHost, $proxyPort, $proxyUser, $proxyPass);
+
+        $this->logger->expects(static::once())
+            ->method('debug')
+            ->with(
+                sprintf('Fetching url: %s', $uri),
+                [LegacyLogger::CONTEXT_TYPE => WebFetcher::class]
+            );
+
+        $curl->rawResponse = $result;
+
+        static::assertSame(
+            $result,
+            $this->subject->fetch($uri)
+        );
+    }
+
+    public function testFetchFails(): void
+    {
+        $uri       = 'some-uri';
+        $version   = '4.5.6';
+        $proxyHost = 'some-proxy-host';
+        $proxyPort = 'some-proxy-port';
+
+        $curl = $this->createMock(Curl::class);
+
+        static::expectException(FetchFailedException::class);
+        static::expectExceptionMessage(sprintf('Error fetching url: %s', $uri));
+
+        $this->utilityFactory->expects(static::once())
+            ->method('createCurl')
+            ->willReturn($curl);
+
+        $curl->expects(static::once())
+            ->method('setFollowLocation');
+        $curl->expects(static::once())
+            ->method('setUserAgent')
+            ->with(sprintf('Ampache/%s', $version));
+        $curl->expects(static::once())
+            ->method('setProxy')
+            ->with($proxyHost, $proxyPort, null, null);
+        $curl->expects(static::once())
+            ->method('get')
+            ->with($uri);
+        $curl->expects(static::once())
+            ->method('close');
+
+        $this->config->expects(static::once())
+            ->method('getVersion')
+            ->willReturn($version);
+        $this->config->expects(static::exactly(4))
+            ->method('get')
+            ->with(...self::withConsecutive(
+                [ConfigurationKeyEnum::PROXY_HOST],
+                [ConfigurationKeyEnum::PROXY_PORT],
+                [ConfigurationKeyEnum::PROXY_USER],
+                [ConfigurationKeyEnum::PROXY_PASS],
+            ))
+            ->willReturn($proxyHost, $proxyPort, '', '');
+
+        $this->logger->expects(static::once())
+            ->method('debug')
+            ->with(
+                sprintf('Fetching url: %s', $uri),
+                [LegacyLogger::CONTEXT_TYPE => WebFetcher::class]
+            );
+
+        $curl->error = true;
+
+        $this->subject->fetch($uri);
+    }
+
+    public function testFetchToFileThrowsIfFetchErrors(): void
+    {
+        $uri                 = 'some-uri';
+        $destinationFilePath = 'some-path';
+        $version             = '1.2.3';
+
+        $curl = $this->createMock(Curl::class);
+
+        static::expectException(FetchFailedException::class);
+        static::expectExceptionMessage(sprintf('Error downloading to file: %s', $destinationFilePath));
+
+        $this->config->expects(static::once())
+            ->method('getVersion')
+            ->willReturn($version);
+
+        $this->utilityFactory->expects(static::once())
+            ->method('createCurl')
+            ->willReturn($curl);
+
+        $curl->expects(static::once())
+            ->method('setFollowLocation');
+        $curl->expects(static::once())
+            ->method('setUserAgent')
+            ->with(sprintf('Ampache/%s', $version));
+        $curl->expects(static::once())
+            ->method('setReferer')
+            ->with($uri);
+        $curl->expects(static::once())
+            ->method('download')
+            ->with($uri, $destinationFilePath)
+            ->willReturn(false);
+        $curl->expects(static::once())
+            ->method('close');
+
+        $this->subject->fetchToFile($uri, $destinationFilePath);
+    }
+
+    public function testFetchToFileDownloads(): void
+    {
+        $uri                 = 'some-uri';
+        $destinationFilePath = 'some-path';
+        $version             = '1.2.3';
+
+        $curl = $this->createMock(Curl::class);
+
+        $this->config->expects(static::once())
+            ->method('getVersion')
+            ->willReturn($version);
+
+        $this->utilityFactory->expects(static::once())
+            ->method('createCurl')
+            ->willReturn($curl);
+
+        $curl->expects(static::once())
+            ->method('setFollowLocation');
+        $curl->expects(static::once())
+            ->method('setUserAgent')
+            ->with(sprintf('Ampache/%s', $version));
+        $curl->expects(static::once())
+            ->method('setReferer')
+            ->with($uri);
+        $curl->expects(static::once())
+            ->method('download')
+            ->with($uri, $destinationFilePath)
+            ->willReturn(true);
+        $curl->expects(static::once())
+            ->method('close');
+
+        $this->logger->expects(static::once())
+            ->method('debug')
+            ->with(
+                sprintf('Download to file completed: %s', $destinationFilePath),
+                [LegacyLogger::CONTEXT_TYPE => WebFetcher::class]
+            );
+
+        $this->subject->fetchToFile($uri, $destinationFilePath);
+    }
+}


### PR DESCRIPTION
- Use curl for both, loading the feed and downloading the episodes
- Respect proxy-settings when downloading episodes

Maybe we should consider adding "curl" as a required php-module (instead of optional) as certain locations rely on at least `curl_init` being available.