### PR TITLE
Add rector for automated code-migrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,6 +107,7 @@
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-mockery": "^1.1",
         "phpunit/phpunit": "^10",
+        "rector/rector": "^0.18.12",
         "seec/phpunit-consecutive-params": "^1.1",
         "squizlabs/php_codesniffer": "^3.8",
         "szymach/c-pchart": "^3.0"
@@ -388,7 +389,9 @@
         "fix-cs": "vendor/bin/php-cs-fixer fix -v",
         "post-autoload-dump": [
             "@php resources/scripts/composer/check_tag_tools.php"
-        ]
+        ],
+        "rector:dry": "rector process -n",
+        "rector:fix": "rector process"
     },
     "scripts-descriptions": {
         "coverage": "Generates the code-coverage report into the build/coverage directory",
@@ -398,7 +401,9 @@
         "tests": "Executes the unit tests",
         "codestyle": "Performs code-style related checks",
         "syntax": "Performs php syntax checks",
-        "fix-cs": "Performs code-style corrections on the whole codebase"
+        "fix-cs": "Performs code-style corrections on the whole codebase",
+        "rector:dry": "Performs rector code-migrations dry run",
+        "rector:fix": "Applies pending rector code-migrations"
     },
     "suggest": {
         "szymach/c-pchart": "Enable graphical statistics",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,31 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$artist of method Ampache\\\\Repository\\\\SongRepositoryInterface\\:\\:getRandomByArtist\\(\\) expects Ampache\\\\Repository\\\\Model\\\\Artist, object given\\.$#"
-			count: 1
-			path: src/Application/Api/Ajax/Handler/DefaultAjaxHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$object_id of static method Ampache\\\\Repository\\\\Model\\\\Rating\\:\\:show\\(\\) expects int, string\\|false\\|null given\\.$#"
-			count: 2
-			path: src/Application/Api/Ajax/Handler/DefaultAjaxHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$object_id of static method Ampache\\\\Repository\\\\Model\\\\Userflag\\:\\:show\\(\\) expects int, string\\|false\\|null given\\.$#"
-			count: 1
-			path: src/Application/Api/Ajax/Handler/DefaultAjaxHandler.php
-
-		-
-			message: "#^Parameter \\#2 \\$type of static method Ampache\\\\Repository\\\\Model\\\\Rating\\:\\:show\\(\\) expects string, string\\|false\\|null given\\.$#"
-			count: 1
-			path: src/Application/Api/Ajax/Handler/DefaultAjaxHandler.php
-
-		-
-			message: "#^Parameter \\#2 \\$type of static method Ampache\\\\Repository\\\\Model\\\\Userflag\\:\\:show\\(\\) expects string, string\\|false\\|null given\\.$#"
-			count: 1
-			path: src/Application/Api/Ajax/Handler/DefaultAjaxHandler.php
-
-		-
 			message: "#^Parameter \\#1 \\$artist_id of static method Ampache\\\\Module\\\\Util\\\\Recommendation\\:\\:get_artists_like\\(\\) expects int, string given\\.$#"
 			count: 1
 			path: src/Application/Api/Ajax/Handler/IndexAjaxHandler.php

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
+use Rector\CodingStyle\Rector\Closure\StaticClosureRector;
+use Rector\CodingStyle\Rector\String_\SymplifyQuoteEscapeRector;
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/tests',
+    ]);
+
+    $rectorConfig->importNames();
+
+    // register a single rule
+    $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
+
+    // define sets of rules
+    $rectorConfig->sets([
+        SetList::CODE_QUALITY,
+        SetList::CODING_STYLE,
+        SetList::DEAD_CODE,
+        LevelSetList::UP_TO_PHP_74,
+    ]);
+
+    $rectorConfig->skip([
+        FlipTypeControlToUseExclusiveTypeRector::class,
+        StaticClosureRector::class,
+        SymplifyQuoteEscapeRector::class,
+    ]);
+};

--- a/tests/Config/Init/InitializationHandlerEnvironmentTest.php
+++ b/tests/Config/Init/InitializationHandlerEnvironmentTest.php
@@ -35,10 +35,9 @@ class InitializationHandlerEnvironmentTest extends MockeryTestCase
     /** @var MockInterface|EnvironmentInterface|null */
     private MockInterface $environment;
 
-    /** @var InitializationHandlerEnvironment|null */
     private InitializationHandlerEnvironment $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->environment = $this->mock(EnvironmentInterface::class);
 

--- a/tests/Gui/Album/AlbumViewAdapterTest.php
+++ b/tests/Gui/Album/AlbumViewAdapterTest.php
@@ -62,10 +62,9 @@ class AlbumViewAdapterTest extends MockeryTestCase
     /** @var Album|MockInterface|null */
     private MockInterface $album;
 
-    /** @var AlbumViewAdapter|null */
     private AlbumViewAdapter $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->modelFactory    = $this->mock(ModelFactoryInterface::class);
@@ -124,7 +123,7 @@ class AlbumViewAdapterTest extends MockeryTestCase
             ->andReturn($averageRating);
 
         $this->assertSame(
-            (string) $averageRating,
+            $averageRating,
             $this->subject->getAverageRating()
         );
     }

--- a/tests/Gui/GuiFactoryTest.php
+++ b/tests/Gui/GuiFactoryTest.php
@@ -73,10 +73,9 @@ class GuiFactoryTest extends MockeryTestCase
     /** @var MockInterface|VideoRepositoryInterface|null */
     private MockInterface $videoRepository;
 
-    /** @var GuiFactory|null */
     private GuiFactory $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer  = $this->mock(ConfigContainerInterface::class);
         $this->modelFactory     = $this->mock(ModelFactoryInterface::class);

--- a/tests/Gui/Playlist/NewPlaylistDialogAdapterTest.php
+++ b/tests/Gui/Playlist/NewPlaylistDialogAdapterTest.php
@@ -48,7 +48,7 @@ class NewPlaylistDialogAdapterTest extends MockeryTestCase
 
     private ?NewPlaylistDialogAdapter $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->playlistLoader   = $this->mock(PlaylistLoaderInterface::class);
         $this->ajaxUriRetriever = $this->mock(AjaxUriRetrieverInterface::class);

--- a/tests/Gui/Playlist/PlaylistViewAdapterTest.php
+++ b/tests/Gui/Playlist/PlaylistViewAdapterTest.php
@@ -58,10 +58,9 @@ class PlaylistViewAdapterTest extends MockeryTestCase
     /** @var Playlist|MockInterface|null */
     private MockInterface $playlist;
 
-    /** @var PlaylistViewAdapter|null */
     private PlaylistViewAdapter $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->modelFactory    = $this->mock(ModelFactoryInterface::class);
@@ -118,7 +117,7 @@ class PlaylistViewAdapterTest extends MockeryTestCase
             ->andReturn($averageRating);
 
         $this->assertSame(
-            (string) $averageRating,
+            $averageRating,
             $this->subject->getAverageRating()
         );
     }

--- a/tests/Gui/Song/SongViewAdapterTest.php
+++ b/tests/Gui/Song/SongViewAdapterTest.php
@@ -50,10 +50,9 @@ class SongViewAdapterTest extends MockeryTestCase
     /** @var Song|MockInterface|null */
     private MockInterface $song;
 
-    /** @var SongViewAdapter|null */
     private SongViewAdapter $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->modelFactory    = $this->mock(ModelFactoryInterface::class);
@@ -164,7 +163,7 @@ class SongViewAdapterTest extends MockeryTestCase
             ->andReturn($averageRating);
 
         $this->assertSame(
-            (string) $averageRating,
+            $averageRating,
             $this->subject->getAverageRating()
         );
     }
@@ -339,6 +338,7 @@ class SongViewAdapterTest extends MockeryTestCase
             $this->subject->getAlbumDiskLink()
         );
     }
+
     public function testGetYearReturnsValues(): void
     {
         $value = 666;

--- a/tests/Gui/Stats/StatsViewAdapterTest.php
+++ b/tests/Gui/Stats/StatsViewAdapterTest.php
@@ -46,7 +46,7 @@ class StatsViewAdapterTest extends MockeryTestCase
 
     private ?StatsViewAdapter $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->guiFactory      = $this->mock(GuiFactoryInterface::class);

--- a/tests/Gui/System/ConfigViewAdapterTest.php
+++ b/tests/Gui/System/ConfigViewAdapterTest.php
@@ -35,10 +35,9 @@ class ConfigViewAdapterTest extends MockeryTestCase
     /** @var MockInterface|ConfigContainerInterface|null */
     private MockInterface $configContainer;
 
-    /** @var ConfigViewAdapter|null */
     private ConfigViewAdapter $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
 

--- a/tests/Gui/System/UpdateViewAdapterTest.php
+++ b/tests/Gui/System/UpdateViewAdapterTest.php
@@ -37,7 +37,7 @@ class UpdateViewAdapterTest extends MockeryTestCase
 
     private ?UpdateViewAdapter $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
 

--- a/tests/Gui/TalFactoryTest.php
+++ b/tests/Gui/TalFactoryTest.php
@@ -38,10 +38,9 @@ class TalFactoryTest extends MockeryTestCase
     /** @var MockInterface|GuiFactoryInterface|null */
     private MockInterface $guiFactory;
 
-    /** @var TalFactory|null */
     private TalFactory $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->guiFactory      = $this->mock(GuiFactoryInterface::class);

--- a/tests/Gui/TalTranslationServiceTest.php
+++ b/tests/Gui/TalTranslationServiceTest.php
@@ -29,10 +29,9 @@ use Ampache\MockeryTestCase;
 
 class TalTranslationServiceTest extends MockeryTestCase
 {
-    /** @var TalTranslationService|null */
     private TalTranslationService $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->subject = new TalTranslationService();
     }

--- a/tests/Gui/TalViewTest.php
+++ b/tests/Gui/TalViewTest.php
@@ -44,10 +44,9 @@ class TalViewTest extends MockeryTestCase
     /** @var MockInterface|GuiFactoryInterface|null */
     private MockInterface $guiFactory;
 
-    /** @var TalView|null */
     private TalView $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->talFactory      = $this->mock(TalFactoryInterface::class);
         $this->configContainer = $this->mock(ConfigContainerInterface::class);

--- a/tests/Module/Album/Export/AlbumArtExporterTest.php
+++ b/tests/Module/Album/Export/AlbumArtExporterTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Album\Export;
 
+use Ampache\Module\Album\Export\Exception\AlbumArtExportException;
 use Ahc\Cli\IO\Interactor;
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
@@ -51,7 +52,7 @@ class AlbumArtExporterTest extends MockeryTestCase
 
     private ?AlbumArtExporter $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->modelFactory    = $this->mock(ModelFactoryInterface::class);
@@ -109,11 +110,10 @@ class AlbumArtExporterTest extends MockeryTestCase
         $songId   = 42;
         $file     = $fs_root->url() . '/some-file';
         $raw_mime = '/some-raw-mime.png';
-        $fileName = 'some-full-name';
 
         $album->id = $albumId;
 
-        $this->expectException(Exception\AlbumArtExportException::class);
+        $this->expectException(AlbumArtExportException::class);
         $this->expectExceptionMessage(
             'Unable to open `vfs:/folder.some-raw-mime.png` for writing',
         );

--- a/tests/Module/Album/Export/Writer/LinuxMetadataWriterTest.php
+++ b/tests/Module/Album/Export/Writer/LinuxMetadataWriterTest.php
@@ -31,7 +31,7 @@ class LinuxMetadataWriterTest extends MockeryTestCase
 {
     private ?LinuxMetadataWriter $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->subject = new LinuxMetadataWriter();
     }

--- a/tests/Module/Album/Export/Writer/WindowsMetadataWriterTest.php
+++ b/tests/Module/Album/Export/Writer/WindowsMetadataWriterTest.php
@@ -31,7 +31,7 @@ class WindowsMetadataWriterTest extends MockeryTestCase
 {
     private ?WindowsMetadataWriter $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->subject = new WindowsMetadataWriter();
     }

--- a/tests/Module/Api/Method/AlbumMethodTest.php
+++ b/tests/Module/Api/Method/AlbumMethodTest.php
@@ -48,7 +48,7 @@ class AlbumMethodTest extends MockeryTestCase
 
     private ?AlbumMethod $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->modelFactory  = $this->mock(ModelFactoryInterface::class);
         $this->streamFactory = $this->mock(StreamFactoryInterface::class);

--- a/tests/Module/Api/Method/AlbumsMethodTest.php
+++ b/tests/Module/Api/Method/AlbumsMethodTest.php
@@ -45,10 +45,9 @@ class AlbumsMethodTest extends MockeryTestCase
     /** @var MockInterface|ModelFactoryInterface|null */
     private MockInterface $modelFactory;
 
-    /** @var AlbumsMethod|null */
     private AlbumsMethod $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->streamFactory = $this->mock(StreamFactoryInterface::class);
         $this->modelFactory  = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Api/Output/ApiOutputFactoryTest.php
+++ b/tests/Module/Api/Output/ApiOutputFactoryTest.php
@@ -29,10 +29,9 @@ use Ampache\MockeryTestCase;
 
 class ApiOutputFactoryTest extends MockeryTestCase
 {
-    /** @var ApiOutputFactory|null */
     private ApiOutputFactory $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->subject = new ApiOutputFactory();
     }

--- a/tests/Module/Api/RefreshReordered/RefreshPlaylistMediasActionTest.php
+++ b/tests/Module/Api/RefreshReordered/RefreshPlaylistMediasActionTest.php
@@ -44,7 +44,7 @@ class RefreshPlaylistMediasActionTest extends MockeryTestCase
 
     private ?RefreshPlaylistMediasAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->requestParser = $this->mock(RequestParserInterface::class);
         $this->modelFactory  = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Application/Admin/Access/Lib/AccessListItemTest.php
+++ b/tests/Module/Application/Admin/Access/Lib/AccessListItemTest.php
@@ -40,7 +40,7 @@ class AccessListItemTest extends MockeryTestCase
 
     private AccessListItem $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->access       = $this->mock(Access::class);
         $this->modelFactory = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Application/Admin/Access/ShowActionTest.php
+++ b/tests/Module/Application/Admin/Access/ShowActionTest.php
@@ -49,7 +49,7 @@ class ShowActionTest extends MockeryTestCase
 
     private ShowAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui               = $this->mock(UiInterface::class);
         $this->accessRepository = $this->mock(AccessRepositoryInterface::class);
@@ -94,9 +94,7 @@ class ShowActionTest extends MockeryTestCase
         $this->ui->shouldReceive('show')
             ->with(
                 'show_access_list.inc.php',
-                Mockery::on(static function (array $context): bool {
-                    return current($context['list']) instanceof AccessListItemInterface;
-                })
+                Mockery::on(static fn (array $context): bool => current($context['list']) instanceof AccessListItemInterface)
             )
             ->once();
         $this->ui->shouldReceive('showQueryStats')

--- a/tests/Module/Application/Admin/Access/ShowAddActionTest.php
+++ b/tests/Module/Application/Admin/Access/ShowAddActionTest.php
@@ -40,7 +40,7 @@ class ShowAddActionTest extends MockeryTestCase
 
     private ?ShowAddAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->mock(UiInterface::class);
 

--- a/tests/Module/Application/Admin/Access/ShowAddAdvancedActionTest.php
+++ b/tests/Module/Application/Admin/Access/ShowAddAdvancedActionTest.php
@@ -40,7 +40,7 @@ class ShowAddAdvancedActionTest extends MockeryTestCase
 
     private ?ShowAddAdvancedAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->mock(UiInterface::class);
 

--- a/tests/Module/Application/Admin/Access/ShowDeleteRecordActionTest.php
+++ b/tests/Module/Application/Admin/Access/ShowDeleteRecordActionTest.php
@@ -50,7 +50,7 @@ class ShowDeleteRecordActionTest extends MockeryTestCase
 
     private ?ShowDeleteRecordAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui              = $this->mock(UiInterface::class);
         $this->configContainer = $this->mock(ConfigContainerInterface::class);

--- a/tests/Module/Application/Admin/Access/ShowEditRecordActionTest.php
+++ b/tests/Module/Application/Admin/Access/ShowEditRecordActionTest.php
@@ -48,7 +48,7 @@ class ShowEditRecordActionTest extends MockeryTestCase
 
     private ?ShowEditRecordAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui           = $this->mock(UiInterface::class);
         $this->modelFactory = $this->mock(ModelFactoryInterface::class);
@@ -103,9 +103,7 @@ class ShowEditRecordActionTest extends MockeryTestCase
         $this->ui->shouldReceive('show')
             ->with(
                 'show_edit_access.inc.php',
-                Mockery::on(static function (array $context): bool {
-                    return $context['access'] instanceof AccessListItemInterface;
-                })
+                Mockery::on(static fn (array $context): bool => $context['access'] instanceof AccessListItemInterface)
             )
             ->once();
         $this->ui->shouldReceive('showQueryStats')

--- a/tests/Module/Application/Admin/Export/ShowActionTest.php
+++ b/tests/Module/Application/Admin/Export/ShowActionTest.php
@@ -43,7 +43,7 @@ class ShowActionTest extends MockeryTestCase
 
     private ShowAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui            = $this->mock(UiInterface::class);
         $this->catalogLoader = $this->createMock(CatalogLoaderInterface::class);

--- a/tests/Module/Application/Admin/License/DeleteActionTest.php
+++ b/tests/Module/Application/Admin/License/DeleteActionTest.php
@@ -53,7 +53,7 @@ class DeleteActionTest extends MockeryTestCase
 
     private ?DeleteAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui                = $this->mock(UiInterface::class);
         $this->modelFactory      = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Application/Admin/License/EditActionTest.php
+++ b/tests/Module/Application/Admin/License/EditActionTest.php
@@ -53,7 +53,7 @@ class EditActionTest extends MockeryTestCase
 
     private ?EditAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui                = $this->mock(UiInterface::class);
         $this->configContainer   = $this->mock(ConfigContainerInterface::class);

--- a/tests/Module/Application/Admin/License/ShowActionTest.php
+++ b/tests/Module/Application/Admin/License/ShowActionTest.php
@@ -45,7 +45,7 @@ class ShowActionTest extends MockeryTestCase
 
     private ?ShowAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui           = $this->mock(UiInterface::class);
         $this->modelFactory = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Application/Admin/License/ShowCreateActionTest.php
+++ b/tests/Module/Application/Admin/License/ShowCreateActionTest.php
@@ -40,7 +40,7 @@ class ShowCreateActionTest extends MockeryTestCase
 
     private ?ShowCreateAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->mock(UiInterface::class);
 

--- a/tests/Module/Application/Admin/License/ShowEditActionTest.php
+++ b/tests/Module/Application/Admin/License/ShowEditActionTest.php
@@ -45,7 +45,7 @@ class ShowEditActionTest extends MockeryTestCase
 
     private ?ShowEditAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui           = $this->mock(UiInterface::class);
         $this->modelFactory = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Application/Admin/Mail/ShowActionTest.php
+++ b/tests/Module/Application/Admin/Mail/ShowActionTest.php
@@ -39,7 +39,7 @@ class ShowActionTest extends MockeryTestCase
 
     private ?ShowAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->mock(UiInterface::class);
 

--- a/tests/Module/Application/Admin/Modules/ShowActionTest.php
+++ b/tests/Module/Application/Admin/Modules/ShowActionTest.php
@@ -40,7 +40,7 @@ class ShowActionTest extends MockeryTestCase
 
     private ?ShowAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->mock(UiInterface::class);
 

--- a/tests/Module/Application/Admin/Shout/DeleteActionTest.php
+++ b/tests/Module/Application/Admin/Shout/DeleteActionTest.php
@@ -46,7 +46,7 @@ class DeleteActionTest extends MockeryTestCase
 
     private DeleteAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui              = $this->mock(UiInterface::class);
         $this->configContainer = $this->mock(ConfigContainerInterface::class);

--- a/tests/Module/Application/Admin/Shout/EditShoutActionTest.php
+++ b/tests/Module/Application/Admin/Shout/EditShoutActionTest.php
@@ -44,7 +44,7 @@ class EditShoutActionTest extends MockeryTestCase
 
     private EditShoutAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui              = $this->mock(UiInterface::class);
         $this->shoutRepository = $this->createMock(ShoutRepositoryInterface::class);

--- a/tests/Module/Application/Admin/Shout/ShowActionTest.php
+++ b/tests/Module/Application/Admin/Shout/ShowActionTest.php
@@ -45,7 +45,7 @@ class ShowActionTest extends MockeryTestCase
 
     private ?ShowAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui           = $this->mock(UiInterface::class);
         $this->modelFactory = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Application/Admin/System/GenerateConfigActionTest.php
+++ b/tests/Module/Application/Admin/System/GenerateConfigActionTest.php
@@ -60,7 +60,7 @@ class GenerateConfigActionTest extends MockeryTestCase
 
     private ?GenerateConfigAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer    = $this->mock(ConfigContainerInterface::class);
         $this->browser            = $this->mock(Horde_Browser::class);

--- a/tests/Module/Application/Admin/System/ResetDbCharsetActionTest.php
+++ b/tests/Module/Application/Admin/System/ResetDbCharsetActionTest.php
@@ -48,7 +48,7 @@ class ResetDbCharsetActionTest extends MockeryTestCase
 
     private ?ResetDbCharsetAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer        = $this->mock(ConfigContainerInterface::class);
         $this->ui                     = $this->mock(UiInterface::class);

--- a/tests/Module/Application/Admin/System/WriteConfigActionTest.php
+++ b/tests/Module/Application/Admin/System/WriteConfigActionTest.php
@@ -52,7 +52,7 @@ class WriteConfigActionTest extends MockeryTestCase
 
     private ?WriteConfigAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer    = $this->mock(ConfigContainerInterface::class);
         $this->installationHelper = $this->mock(InstallationHelperInterface::class);
@@ -120,9 +120,7 @@ class WriteConfigActionTest extends MockeryTestCase
 
         $this->installationHelper->shouldReceive('write_config')
             ->with(
-                Mockery::on(function (): bool {
-                    return true;
-                })
+                Mockery::on(static fn (): bool => true)
             )
             ->once()
             ->andReturnTrue();

--- a/tests/Module/Application/Admin/User/DisableActionTest.php
+++ b/tests/Module/Application/Admin/User/DisableActionTest.php
@@ -48,7 +48,7 @@ class DisableActionTest extends MockeryTestCase
 
     private DisableAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui              = $this->mock(UiInterface::class);
         $this->modelFactory    = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Application/Admin/User/EnableActionTest.php
+++ b/tests/Module/Application/Admin/User/EnableActionTest.php
@@ -48,7 +48,7 @@ class EnableActionTest extends MockeryTestCase
 
     private EnableAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui              = $this->mock(UiInterface::class);
         $this->modelFactory    = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Application/Admin/User/ShowActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowActionTest.php
@@ -44,7 +44,7 @@ class ShowActionTest extends MockeryTestCase
 
     private ?ShowAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui           = $this->mock(UiInterface::class);
         $this->modelFactory = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Application/Admin/User/ShowDeleteActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowDeleteActionTest.php
@@ -48,7 +48,7 @@ class ShowDeleteActionTest extends MockeryTestCase
 
     private ShowDeleteAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui              = $this->mock(UiInterface::class);
         $this->modelFactory    = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Application/Admin/User/ShowDeleteAvatarActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowDeleteAvatarActionTest.php
@@ -37,7 +37,7 @@ class ShowDeleteAvatarActionTest extends TestCase
 
     private ShowDeleteAvatarAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->createMock(UiInterface::class);
 

--- a/tests/Module/Application/Admin/User/ShowDeleteRssTokenActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowDeleteRssTokenActionTest.php
@@ -37,7 +37,7 @@ class ShowDeleteRssTokenActionTest extends TestCase
 
     private ShowDeleteRssTokenAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->createMock(UiInterface::class);
 

--- a/tests/Module/Application/Admin/User/ShowDeleteStreamTokenActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowDeleteStreamTokenActionTest.php
@@ -37,7 +37,7 @@ class ShowDeleteStreamTokenActionTest extends TestCase
 
     private ShowDeleteStreamTokenAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->createMock(UiInterface::class);
 

--- a/tests/Module/Application/Admin/User/ShowGenerateApiKeyActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowGenerateApiKeyActionTest.php
@@ -37,7 +37,7 @@ class ShowGenerateApiKeyActionTest extends TestCase
 
     private ShowGenerateApiKeyAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->createMock(UiInterface::class);
 

--- a/tests/Module/Application/Admin/User/ShowGenerateRssTokenActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowGenerateRssTokenActionTest.php
@@ -37,7 +37,7 @@ class ShowGenerateRssTokenActionTest extends TestCase
 
     private ShowGenerateRssTokenAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->createMock(UiInterface::class);
 

--- a/tests/Module/Application/Admin/User/ShowGenerateStreamTokenActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowGenerateStreamTokenActionTest.php
@@ -37,7 +37,7 @@ class ShowGenerateStreamTokenActionTest extends TestCase
 
     private ShowGenerateStreamTokenAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->createMock(UiInterface::class);
 

--- a/tests/Module/Application/Admin/User/ShowIpHistoryActionTest.php
+++ b/tests/Module/Application/Admin/User/ShowIpHistoryActionTest.php
@@ -52,7 +52,7 @@ class ShowIpHistoryActionTest extends MockeryTestCase
 
     private ShowIpHistoryAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui                  = $this->mock(UiInterface::class);
         $this->modelFactory        = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Application/Album/DeleteActionTest.php
+++ b/tests/Module/Application/Album/DeleteActionTest.php
@@ -45,7 +45,7 @@ class DeleteActionTest extends MockeryTestCase
 
     private DeleteAction $subject;
 
-    public function setup(): void
+    protected function setup(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->ui              = $this->mock(UiInterface::class);

--- a/tests/Module/Application/Album/ShowActionTest.php
+++ b/tests/Module/Application/Album/ShowActionTest.php
@@ -53,7 +53,7 @@ class ShowActionTest extends MockeryTestCase
 
     private ShowAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->modelFactory     = $this->mock(ModelFactoryInterface::class);
         $this->ui               = $this->mock(UiInterface::class);

--- a/tests/Module/Application/Album/UpdateFromTagsActionTest.php
+++ b/tests/Module/Application/Album/UpdateFromTagsActionTest.php
@@ -45,7 +45,7 @@ class UpdateFromTagsActionTest extends MockeryTestCase
 
     private UpdateFromTagsAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->modelFactory    = $this->mock(ModelFactoryInterface::class);
         $this->ui              = $this->mock(UiInterface::class);

--- a/tests/Module/Application/ApplicationRunnerTest.php
+++ b/tests/Module/Application/ApplicationRunnerTest.php
@@ -56,10 +56,9 @@ class ApplicationRunnerTest extends MockeryTestCase
     /** @var MockInterface|UiInterface|null  */
     private ?MockInterface $ui;
 
-    /** @var ApplicationRunner|null */
     private ApplicationRunner $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->dic               = $this->mock(ContainerInterface::class);
         $this->logger            = $this->mock(LoggerInterface::class);

--- a/tests/Module/Application/Artist/DeleteActionTest.php
+++ b/tests/Module/Application/Artist/DeleteActionTest.php
@@ -43,7 +43,7 @@ class DeleteActionTest extends MockeryTestCase
 
     private ?DeleteAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->ui              = $this->mock(UiInterface::class);

--- a/tests/Module/Application/Artist/ShowActionTest.php
+++ b/tests/Module/Application/Artist/ShowActionTest.php
@@ -57,7 +57,7 @@ class ShowActionTest extends MockeryTestCase
 
     private ?ShowAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->modelFactory    = $this->mock(ModelFactoryInterface::class);
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
@@ -145,7 +145,7 @@ class ShowActionTest extends MockeryTestCase
                 [
                     'artist' => $artist,
                     'object_type' => $objectType,
-                    'object_ids' => array(),
+                    'object_ids' => [],
                     'multi_object_ids' => $multi_object_ids,
                     'gatekeeper' => $gatekeeper,
                 ]
@@ -220,7 +220,7 @@ class ShowActionTest extends MockeryTestCase
                     'artist' => $artist,
                     'object_type' => $objectType,
                     'object_ids' => $object_ids,
-                    'multi_object_ids' => array(),
+                    'multi_object_ids' => [],
                     'gatekeeper' => $gatekeeper,
                 ]
             )

--- a/tests/Module/Application/Artist/ShowAllSongsActionTest.php
+++ b/tests/Module/Application/Artist/ShowAllSongsActionTest.php
@@ -46,7 +46,7 @@ class ShowAllSongsActionTest extends MockeryTestCase
 
     private ?ShowAllSongsAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->modelFactory   = $this->mock(ModelFactoryInterface::class);
         $this->ui             = $this->mock(UiInterface::class);
@@ -92,7 +92,7 @@ class ShowAllSongsActionTest extends MockeryTestCase
                     'artist' => $artist,
                     'object_type' => 'song',
                     'object_ids' => $songList,
-                    'multi_object_ids' => array(),
+                    'multi_object_ids' => [],
                     'gatekeeper' => $gatekeeper,
                 ]
             )

--- a/tests/Module/Application/Artist/UpdateFromTagsActionTest.php
+++ b/tests/Module/Application/Artist/UpdateFromTagsActionTest.php
@@ -46,7 +46,7 @@ class UpdateFromTagsActionTest extends MockeryTestCase
 
     private ?UpdateFromTagsAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->ui              = $this->mock(UiInterface::class);

--- a/tests/Module/Application/CookieDisclaimer/ShowActionTest.php
+++ b/tests/Module/Application/CookieDisclaimer/ShowActionTest.php
@@ -38,7 +38,7 @@ class ShowActionTest extends MockeryTestCase
 
     private ?ShowAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->mock(UiInterface::class);
 

--- a/tests/Module/Application/Label/DeleteActionTest.php
+++ b/tests/Module/Application/Label/DeleteActionTest.php
@@ -45,7 +45,7 @@ class DeleteActionTest extends MockeryTestCase
 
     private ?DeleteAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->ui              = $this->mock(UiInterface::class);

--- a/tests/Module/Application/Label/ShowAddLabelActionTest.php
+++ b/tests/Module/Application/Label/ShowAddLabelActionTest.php
@@ -44,7 +44,7 @@ class ShowAddLabelActionTest extends MockeryTestCase
 
     private ?ShowAddLabelAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->ui              = $this->mock(UiInterface::class);

--- a/tests/Module/Application/Playlist/DeletePlaylistActionTest.php
+++ b/tests/Module/Application/Playlist/DeletePlaylistActionTest.php
@@ -50,7 +50,7 @@ class DeletePlaylistActionTest extends MockeryTestCase
 
     private ?DeletePlaylistAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->responseFactory = $this->mock(ResponseFactoryInterface::class);
         $this->configContainer = $this->mock(ConfigContainerInterface::class);

--- a/tests/Module/Application/Preferences/AdminActionTest.php
+++ b/tests/Module/Application/Preferences/AdminActionTest.php
@@ -41,7 +41,7 @@ class AdminActionTest extends MockeryTestCase
 
     private AdminAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->mock(UiInterface::class);
 

--- a/tests/Module/Application/Preferences/ShowActionTest.php
+++ b/tests/Module/Application/Preferences/ShowActionTest.php
@@ -39,7 +39,7 @@ class ShowActionTest extends MockeryTestCase
 
     private ShowAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->mock(UiInterface::class);
 

--- a/tests/Module/Application/Preferences/UserActionTest.php
+++ b/tests/Module/Application/Preferences/UserActionTest.php
@@ -41,7 +41,7 @@ class UserActionTest extends MockeryTestCase
 
     private UserAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui = $this->mock(UiInterface::class);
 

--- a/tests/Module/Application/PrivateMessage/ConfirmDeleteActionTest.php
+++ b/tests/Module/Application/PrivateMessage/ConfirmDeleteActionTest.php
@@ -50,7 +50,7 @@ class ConfirmDeleteActionTest extends MockeryTestCase
 
     private ?ConfirmDeleteAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer          = $this->mock(ConfigContainerInterface::class);
         $this->ui                       = $this->mock(UiInterface::class);

--- a/tests/Module/Application/PrivateMessage/DeleteActionTest.php
+++ b/tests/Module/Application/PrivateMessage/DeleteActionTest.php
@@ -45,7 +45,7 @@ class DeleteActionTest extends MockeryTestCase
 
     private ?DeleteAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->ui              = $this->mock(UiInterface::class);

--- a/tests/Module/Application/PrivateMessage/SetIsReadActionTest.php
+++ b/tests/Module/Application/PrivateMessage/SetIsReadActionTest.php
@@ -50,7 +50,7 @@ class SetIsReadActionTest extends MockeryTestCase
 
     private ?SetIsReadAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer          = $this->mock(ConfigContainerInterface::class);
         $this->ui                       = $this->mock(UiInterface::class);

--- a/tests/Module/Application/PrivateMessage/ShowActionTest.php
+++ b/tests/Module/Application/PrivateMessage/ShowActionTest.php
@@ -51,7 +51,7 @@ class ShowActionTest extends MockeryTestCase
 
     private ?ShowAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui                       = $this->mock(UiInterface::class);
         $this->configContainer          = $this->mock(ConfigContainerInterface::class);

--- a/tests/Module/Application/PrivateMessage/ShowAddMessageActionTest.php
+++ b/tests/Module/Application/PrivateMessage/ShowAddMessageActionTest.php
@@ -56,7 +56,7 @@ class ShowAddMessageActionTest extends MockeryTestCase
 
     private ?ShowAddMessageAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer          = $this->mock(ConfigContainerInterface::class);
         $this->ui                       = $this->mock(UiInterface::class);

--- a/tests/Module/Application/Random/AdvancedActionTest.php
+++ b/tests/Module/Application/Random/AdvancedActionTest.php
@@ -42,7 +42,7 @@ class AdvancedActionTest extends MockeryTestCase
 
     private ?AdvancedAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui              = $this->mock(UiInterface::class);
         $this->videoRepository = $this->mock(VideoRepositoryInterface::class);
@@ -66,7 +66,7 @@ class AdvancedActionTest extends MockeryTestCase
                 'show_random.inc.php',
                 [
                     'videoRepository' => $this->videoRepository,
-                    'object_ids' => array()
+                    'object_ids' => []
                 ]
             )
             ->once();

--- a/tests/Module/Application/SmartPlaylist/DeletePlaylistActionTest.php
+++ b/tests/Module/Application/SmartPlaylist/DeletePlaylistActionTest.php
@@ -50,7 +50,7 @@ class DeletePlaylistActionTest extends MockeryTestCase
 
     private ?DeletePlaylistAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->responseFactory = $this->mock(ResponseFactoryInterface::class);
         $this->configContainer = $this->mock(ConfigContainerInterface::class);

--- a/tests/Module/Application/SmartPlaylist/ShowPlaylistActionTest.php
+++ b/tests/Module/Application/SmartPlaylist/ShowPlaylistActionTest.php
@@ -43,7 +43,7 @@ class ShowPlaylistActionTest extends MockeryTestCase
 
     private ?ShowAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui           = $this->mock(UiInterface::class);
         $this->modelFactory = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Application/SmartPlaylist/UpdatePlaylistActionTest.php
+++ b/tests/Module/Application/SmartPlaylist/UpdatePlaylistActionTest.php
@@ -43,7 +43,7 @@ class UpdatePlaylistActionTest extends MockeryTestCase
 
     private UpdatePlaylistAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui           = $this->mock(UiInterface::class);
         $this->modelFactory = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Application/Song/ShowSongActionTest.php
+++ b/tests/Module/Application/Song/ShowSongActionTest.php
@@ -56,10 +56,9 @@ class ShowSongActionTest extends MockeryTestCase
     /** @var LoggerInterface|MockInterface|null */
     private MockInterface $logger;
 
-    /** @var ShowSongAction|null */
     private ShowSongAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->ui           = $this->mock(UiInterface::class);
         $this->modelFactory = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/Application/TvShow/DeleteActionTest.php
+++ b/tests/Module/Application/TvShow/DeleteActionTest.php
@@ -43,7 +43,7 @@ class DeleteActionTest extends MockeryTestCase
 
     private ?DeleteAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->ui              = $this->mock(UiInterface::class);

--- a/tests/Module/Application/TvShowSeason/DeleteActionTest.php
+++ b/tests/Module/Application/TvShowSeason/DeleteActionTest.php
@@ -47,7 +47,7 @@ class DeleteActionTest extends MockeryTestCase
 
     private ?DeleteAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->ui              = $this->mock(UiInterface::class);

--- a/tests/Module/Application/Update/ShowActionTest.php
+++ b/tests/Module/Application/Update/ShowActionTest.php
@@ -54,7 +54,7 @@ class ShowActionTest extends MockeryTestCase
 
     private ?ShowAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->talFactory      = $this->mock(TalFactoryInterface::class);
         $this->guiFactory      = $this->mock(GuiFactoryInterface::class);

--- a/tests/Module/Application/Video/DeleteActionTest.php
+++ b/tests/Module/Application/Video/DeleteActionTest.php
@@ -47,7 +47,7 @@ class DeleteActionTest extends MockeryTestCase
 
     private ?DeleteAction $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->ui              = $this->mock(UiInterface::class);

--- a/tests/Module/Art/Collector/DbCollectorModuleTest.php
+++ b/tests/Module/Art/Collector/DbCollectorModuleTest.php
@@ -31,10 +31,9 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 class DbCollectorModuleTest extends MockeryTestCase
 {
-    /** @var DbCollectorModule|null */
     private ?DbCollectorModule $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->subject = new DbCollectorModule();
     }

--- a/tests/Module/Authentication/AuthenticationManagerTest.php
+++ b/tests/Module/Authentication/AuthenticationManagerTest.php
@@ -41,10 +41,9 @@ class AuthenticationManagerTest extends MockeryTestCase
 
     private string $authenticatorName = 'some-authenticator';
 
-    /** @var AuthenticationManager|null */
     private ?AuthenticationManager $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = Mockery::mock(ConfigContainerInterface::class);
         $this->authenticator   = Mockery::mock(AuthenticatorInterface::class);

--- a/tests/Module/Authorization/AccessListManagerTest.php
+++ b/tests/Module/Authorization/AccessListManagerTest.php
@@ -40,7 +40,7 @@ class AccessListManagerTest extends MockeryTestCase
 
     private ?AccessListManager $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->accessRepository = $this->mock(AccessRepositoryInterface::class);
 

--- a/tests/Module/Authorization/GatekeeperFactoryTest.php
+++ b/tests/Module/Authorization/GatekeeperFactoryTest.php
@@ -36,7 +36,7 @@ class GatekeeperFactoryTest extends MockeryTestCase
 
     private ?GatekeeperFactory $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->privilegeChecker = $this->mock(PrivilegeCheckerInterface::class);
 

--- a/tests/Module/Authorization/GuiGatekeeperTest.php
+++ b/tests/Module/Authorization/GuiGatekeeperTest.php
@@ -36,7 +36,7 @@ class GuiGatekeeperTest extends MockeryTestCase
 
     private ?GuiGatekeeper $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->privilegeChecker = $this->mock(PrivilegeCheckerInterface::class);
 

--- a/tests/Module/Broadcast/WebSocketFactoryTest.php
+++ b/tests/Module/Broadcast/WebSocketFactoryTest.php
@@ -30,10 +30,9 @@ use Ratchet\Server\EchoServer;
 
 class WebSocketFactoryTest extends MockeryTestCase
 {
-    /** @var WebSocketFactory|null */
     private ?WebSocketFactory $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->subject = new WebSocketFactory();
     }

--- a/tests/Module/Shout/ShoutCreatorTest.php
+++ b/tests/Module/Shout/ShoutCreatorTest.php
@@ -90,7 +90,7 @@ class ShoutCreatorTest extends TestCase
 
         $shout->expects(static::once())
             ->method('setDate')
-            ->with(self::callback(fn (DateTimeInterface $value): bool => true))
+            ->with(self::callback(static fn (DateTimeInterface $value): bool => true))
             ->willReturnSelf();
         $shout->expects(static::once())
             ->method('setUser')
@@ -130,9 +130,7 @@ class ShoutCreatorTest extends TestCase
                 'shout',
                 $objectType,
                 $objectId,
-                self::callback(function (int $value): bool {
-                    return $value <= time();
-                })
+                self::callback(static fn (int $value): bool => $value <= time())
             );
 
         $this->subject->create(

--- a/tests/Module/User/Activity/TypeHandler/ActivityTypeHandlerMapperTest.php
+++ b/tests/Module/User/Activity/TypeHandler/ActivityTypeHandlerMapperTest.php
@@ -40,7 +40,7 @@ class ActivityTypeHandlerMapperTest extends MockeryTestCase
 
     private ?ActivityTypeHandlerMapper $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->userActivityRepository = $this->mock(UserActivityRepositoryInterface::class);
         $this->modelFactory           = $this->mock(ModelFactoryInterface::class);

--- a/tests/Module/User/Activity/TypeHandler/AlbumActivityTypeHandlerTest.php
+++ b/tests/Module/User/Activity/TypeHandler/AlbumActivityTypeHandlerTest.php
@@ -36,7 +36,7 @@ class AlbumActivityTypeHandlerTest extends MockeryTestCase
 
     private ?AlbumActivityTypeHandler $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->useractivityRepository = $this->mock(UserActivityRepositoryInterface::class);
 

--- a/tests/Module/User/Activity/TypeHandler/ArtistActivityTypeHandlerTest.php
+++ b/tests/Module/User/Activity/TypeHandler/ArtistActivityTypeHandlerTest.php
@@ -36,7 +36,7 @@ class ArtistActivityTypeHandlerTest extends MockeryTestCase
 
     private ?ArtistActivityTypeHandler $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->useractivityRepository = $this->mock(UserActivityRepositoryInterface::class);
 

--- a/tests/Module/User/Activity/TypeHandler/GenericActivityTypeHandlerTest.php
+++ b/tests/Module/User/Activity/TypeHandler/GenericActivityTypeHandlerTest.php
@@ -36,7 +36,7 @@ class GenericActivityTypeHandlerTest extends MockeryTestCase
 
     private ?GenericActivityTypeHandler $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->userActivityRepository = $this->mock(UserActivityRepositoryInterface::class);
 

--- a/tests/Module/User/Activity/TypeHandler/SongActivityTypeHandlerTest.php
+++ b/tests/Module/User/Activity/TypeHandler/SongActivityTypeHandlerTest.php
@@ -36,7 +36,7 @@ class SongActivityTypeHandlerTest extends MockeryTestCase
 
     private ?SongActivityTypeHandler $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->useractivityRepository = $this->mock(UserActivityRepositoryInterface::class);
 

--- a/tests/Module/User/Activity/UserActivityPosterTest.php
+++ b/tests/Module/User/Activity/UserActivityPosterTest.php
@@ -42,7 +42,7 @@ class UserActivityPosterTest extends MockeryTestCase
 
     private ?UserActivityPoster $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->activityTypeHandlerMapper = $this->mock(ActivityTypeHandlerMapperInterface::class);
         $this->logger                    = $this->mock(LoggerInterface::class);

--- a/tests/Module/User/Authorization/UserKeyGeneratorTest.php
+++ b/tests/Module/User/Authorization/UserKeyGeneratorTest.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace Ampache\Module\User\Authorization;
 
+use Exception;
 use Ampache\MockeryTestCase;
 use Ampache\Repository\Model\User;
 use Ampache\Module\System\LegacyLogger;
@@ -43,7 +44,7 @@ class UserKeyGeneratorTest extends MockeryTestCase
 
     private ?UserKeyGenerator $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->userRepository = $this->mock(UserRepositoryInterface::class);
         $this->logger         = $this->mock(LoggerInterface::class);
@@ -121,7 +122,6 @@ class UserKeyGeneratorTest extends MockeryTestCase
 
     public function testGenerateRssTokenDoesNothingOnError(): void
     {
-        $userId       = 666;
         $errorMessage = 'some-error-message';
 
         $user = $this->mock(User::class);
@@ -129,7 +129,7 @@ class UserKeyGeneratorTest extends MockeryTestCase
         $user->shouldReceive('getId')
             ->withNoArgs()
             ->once()
-            ->andThrow(new \Exception($errorMessage));
+            ->andThrow(new Exception($errorMessage));
 
         $this->logger->shouldReceive('error')
             ->with(

--- a/tests/Module/User/Following/UserFollowTogglerTest.php
+++ b/tests/Module/User/Following/UserFollowTogglerTest.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace Ampache\Module\User\Following;
 
+use Mockery;
 use Ampache\MockeryTestCase;
 use Ampache\Module\User\Activity\UserActivityPosterInterface;
 use Ampache\Repository\UserFollowerRepositoryInterface;
@@ -40,7 +41,7 @@ class UserFollowTogglerTest extends MockeryTestCase
 
     private ?UserFollowToggler $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->userFollowerRepository = $this->mock(UserFollowerRepositoryInterface::class);
         $this->userActivityPoster     = $this->mock(UserActivityPosterInterface::class);
@@ -65,7 +66,7 @@ class UserFollowTogglerTest extends MockeryTestCase
             ->once();
 
         $this->userActivityPoster->shouldReceive('post')
-            ->with($followingUserId, 'follow', 'user', $userId, \Mockery::type('int'))
+            ->with($followingUserId, 'follow', 'user', $userId, Mockery::type('int'))
             ->once();
 
         $this->subject->toggle(

--- a/tests/Module/User/PasswordGeneratorTest.php
+++ b/tests/Module/User/PasswordGeneratorTest.php
@@ -31,7 +31,7 @@ class PasswordGeneratorTest extends MockeryTestCase
 {
     private ?PasswordGenerator $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->subject = new PasswordGenerator();
     }

--- a/tests/Module/User/UserStateTogglerTest.php
+++ b/tests/Module/User/UserStateTogglerTest.php
@@ -44,7 +44,7 @@ class UserStateTogglerTest extends MockeryTestCase
 
     private UserStateToggler $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->utilityFactory  = $this->mock(UtilityFactoryInterface::class);

--- a/tests/Module/Util/AjaxUriRetrieverTest.php
+++ b/tests/Module/Util/AjaxUriRetrieverTest.php
@@ -36,7 +36,7 @@ class AjaxUriRetrieverTest extends MockeryTestCase
 
     private AjaxUriRetriever $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
 

--- a/tests/Module/Util/UtilityFactoryTest.php
+++ b/tests/Module/Util/UtilityFactoryTest.php
@@ -42,7 +42,7 @@ class UtilityFactoryTest extends MockeryTestCase
 
     private UtilityFactory $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->userRepository  = $this->mock(UserRepositoryInterface::class);
         $this->configContainer = $this->mock(ConfigContainerInterface::class);

--- a/tests/Module/Util/ZipHandlerTest.php
+++ b/tests/Module/Util/ZipHandlerTest.php
@@ -40,7 +40,7 @@ class ZipHandlerTest extends MockeryTestCase
 
     private ?ZipHandler $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = $this->mock(ConfigContainerInterface::class);
         $this->logger          = $this->mock(LoggerInterface::class);

--- a/tests/Module/Wanted/MissingArtistFinderTest.php
+++ b/tests/Module/Wanted/MissingArtistFinderTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Wanted;
 
+use Mockery;
 use Ampache\MockeryTestCase;
 use Mockery\MockInterface;
 use MusicBrainz\Filters\ArtistFilter;
@@ -36,7 +37,7 @@ class MissingArtistFinderTest extends MockeryTestCase
 
     private ?MissingArtistFinder $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->musicBrainz = $this->mock(MusicBrainz::class);
 
@@ -52,7 +53,7 @@ class MissingArtistFinderTest extends MockeryTestCase
         $name          = 'some-name';
 
         $this->musicBrainz->shouldReceive('search')
-            ->with(\Mockery::type(ArtistFilter::class))
+            ->with(Mockery::type(ArtistFilter::class))
             ->once()
             ->andReturn([(object) ['id' => $musicBrainzId, 'name' => $name]]);
 

--- a/tests/Module/WebDav/WebDavApplicationTest.php
+++ b/tests/Module/WebDav/WebDavApplicationTest.php
@@ -44,7 +44,7 @@ class WebDavApplicationTest extends MockeryTestCase
 
     private ?WebDavApplication $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->configContainer = Mockery::mock(ConfigContainerInterface::class);
         $this->webDavFactory   = Mockery::mock(WebDavFactoryInterface::class);

--- a/tests/Module/WebDav/WebDavFactoryTest.php
+++ b/tests/Module/WebDav/WebDavFactoryTest.php
@@ -39,7 +39,7 @@ class WebDavFactoryTest extends MockeryTestCase
 
     private WebDavFactory $subject;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->authenticationManager = Mockery::mock(AuthenticationManagerInterface::class);
 


### PR DESCRIPTION
Rector allows us to apply automated code-miogrations according to defined rule-sets (see rector.php). As it should only run on code which is considered "safe" (typing, etc...), we start using it for updating our tests.