### PR TITLE
Set the curl timeout in WebFetcher

### DIFF
--- a/src/Module/Util/WebFetcher/WebFetcher.php
+++ b/src/Module/Util/WebFetcher/WebFetcher.php
@@ -37,6 +37,9 @@ use Psr\Log\LoggerInterface;
  */
 final class WebFetcher implements WebFetcherInterface
 {
+    /** @var int Curl operation timeout in seconds */
+    private const TIMEOUT = 300;
+
     private ConfigContainerInterface $config;
 
     private UtilityFactoryInterface $utilityFactory;
@@ -101,7 +104,7 @@ final class WebFetcher implements WebFetcherInterface
             );
         } else {
             throw new Exception\FetchFailedException(
-                sprintf('Error downloading to file: %s', $destinationFilePath)
+                sprintf('Error downloading to file: %s. Reason: %s', $destinationFilePath, $curl->errorMessage)
             );
         }
     }
@@ -118,6 +121,7 @@ final class WebFetcher implements WebFetcherInterface
 
         $curl = $this->utilityFactory->createCurl();
         $curl->setFollowLocation();
+        $curl->setTimeout(self::TIMEOUT);
         $curl->setUserAgent(sprintf('Ampache/%s', $this->config->getVersion()));
 
         if ($proxyHost && $proxyPort) {

--- a/tests/Module/Util/WebFetcher/WebFetcherTest.php
+++ b/tests/Module/Util/WebFetcher/WebFetcherTest.php
@@ -143,6 +143,9 @@ class WebFetcherTest extends TestCase
             ->method('setProxy')
             ->with($proxyHost, $proxyPort, null, null);
         $curl->expects(static::once())
+            ->method('setTimeout')
+            ->with(300);
+        $curl->expects(static::once())
             ->method('get')
             ->with($uri);
         $curl->expects(static::once())


### PR DESCRIPTION
This raises the default timeout (30s) up to 300s to mitigate some issues with really slow servers. Anyhow, one should consider adding a config value instead of using a static timeout.