### PR TITLE
Update link for FMPL license

### DIFF
--- a/resources/sql/ampache.sql
+++ b/resources/sql/ampache.sql
@@ -585,7 +585,7 @@ INSERT INTO `license` (`id`, `name`, `description`, `external_link`) VALUES
 (10, 'Green OpenMusic', NULL, 'http://openmusic.linuxtag.org/green.html'),
 (11, 'Gnu GPL Art', NULL, 'http://gnuart.org/english/gnugpl.html'),
 (12, 'WTFPL', NULL, 'https://en.wikipedia.org/wiki/WTFPL'),
-(13, 'FMPL', NULL, 'http://www.fmpl.org/fmpl.html'),
+(13, 'FMPL', NULL, 'http://www.ram.org/ramblings/philosophy/fmp/fmpl/fmpl.html'),
 (14, 'C Reaction', NULL, 'http://morne.free.fr/Necktar7/creaction.htm');
 
 -- --------------------------------------------------------

--- a/resources/sql/ampache.sql
+++ b/resources/sql/ampache.sql
@@ -585,7 +585,7 @@ INSERT INTO `license` (`id`, `name`, `description`, `external_link`) VALUES
 (10, 'Green OpenMusic', NULL, 'http://openmusic.linuxtag.org/green.html'),
 (11, 'Gnu GPL Art', NULL, 'http://gnuart.org/english/gnugpl.html'),
 (12, 'WTFPL', NULL, 'https://en.wikipedia.org/wiki/WTFPL'),
-(13, 'FMPL', NULL, 'http://www.ram.org/ramblings/philosophy/fmp/fmpl/fmpl.html'),
+(13, 'FMPL', NULL, 'http://www.fmpl.org/fmpl.html'),
 (14, 'C Reaction', NULL, 'http://morne.free.fr/Necktar7/creaction.htm');
 
 -- --------------------------------------------------------

--- a/src/Module/System/Update.php
+++ b/src/Module/System/Update.php
@@ -5190,4 +5190,19 @@ class Update
 
         return (self::_write($interactor, "ALTER TABLE `rating` ADD COLUMN `date` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `rating`;") !== false);
     }
+
+    /**
+     * _update_600049
+     *
+     * Update link for `FMPL` license
+     */
+    private static function _update_600049(Interactor $interactor = null): bool
+    {
+        $sql = "UPDATE `license` SET `external_link` = 'http://www.ram.org/ramblings/philosophy/fmp/fmpl/fmpl.html' WHERE `name` = 'FMPL'";
+        if (self::_write($interactor, $sql) === false) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/Module/System/Update.php
+++ b/src/Module/System/Update.php
@@ -927,6 +927,9 @@ class Update
         $update_string = "* Add `date` column to rating table";
         $version[]     = array('version' => '600048', 'description' => $update_string);
 
+        $update_string = "* Update link for `FMPL` license";
+        $version[]     = array('version' => '600049', 'description' => $update_string);
+
         return $version;
     }
 


### PR DESCRIPTION
Another low hanging fruit, fixes #2588 

Wayback Machine confirms its the same license https://web.archive.org/web/20070124060916/http://www.fmpl.org/fmpl.html

That guy (Ram) is the current maintainer, says so at the very bottom: http://www.ram.org/ramblings/philosophy/fmp/fmpl/fmpl.html