### PR TITLE
Fix when some SQL query for stats have no match

### DIFF
--- a/src/Module/Statistics/Stats.php
+++ b/src/Module/Statistics/Stats.php
@@ -337,7 +337,7 @@ class Stats
         $db_results = Dba::read($sql, array($object_type, $object_id, $count_type));
         $results    = Dba::fetch_assoc($db_results);
 
-        return (int)$results['total_count'];
+        return (int)($results['total_count']??0);
     }
 
     /**

--- a/src/Module/Statistics/Stats.php
+++ b/src/Module/Statistics/Stats.php
@@ -337,7 +337,7 @@ class Stats
         $db_results = Dba::read($sql, array($object_type, $object_id, $count_type));
         $results    = Dba::fetch_assoc($db_results);
 
-        return (int)($results['total_count']??0);
+        return (int)($results['total_count'] ?? 0);
     }
 
     /**


### PR DESCRIPTION
Error in ampache log was:
[Runtime Error] Undefined array key "total_count" in file src/Module/Statistics/Stats.php(340)