### PR TITLE
subsonic: do not send a different cover id for each song of the same album

### DIFF
--- a/src/Module/Api/Subsonic_Xml_Data.php
+++ b/src/Module/Api/Subsonic_Xml_Data.php
@@ -454,7 +454,9 @@ class Subsonic_Xml_Data
             $xsong->addAttribute('artistId', (string)self::_getArtistId($song->artist));
             $xsong->addAttribute('artist', (string)self::_checkName($song->get_artist_fullname()));
             if ($song->has_art()) {
-                $xsong->addAttribute('coverArt', $sub_id);
+                $show_song_art = AmpConfig::get('show_song_art', false);
+                $art_id    = $show_song_art ? $sub_id : $subParent;
+                $xsong->addAttribute('coverArt', $art_id);
             }
             $xsong->addAttribute('duration', (string)$song->time);
             $xsong->addAttribute('bitRate', (string)((int)($song->bitrate / 1024)));

--- a/src/Module/Api/Subsonic_Xml_Data.php
+++ b/src/Module/Api/Subsonic_Xml_Data.php
@@ -454,8 +454,7 @@ class Subsonic_Xml_Data
             $xsong->addAttribute('artistId', (string)self::_getArtistId($song->artist));
             $xsong->addAttribute('artist', (string)self::_checkName($song->get_artist_fullname()));
             if ($song->has_art()) {
-                $show_song_art = AmpConfig::get('show_song_art', false);
-                $art_id    = $show_song_art ? $sub_id : $subParent;
+                $art_id = (AmpConfig::get('show_song_art', false)) ? $sub_id : $subParent;
                 $xsong->addAttribute('coverArt', $art_id);
             }
             $xsong->addAttribute('duration', (string)$song->time);


### PR DESCRIPTION
This is a fix/optimization for the retrieval of the cover arts of songs when using the subsonic API.
The current behaviour is "correct" in the sense that the corresponding cover is retrieved for a given song. However the cover_id for all the songs of the same album is different and is actually the song_id. This is allowed by the Ssubsonic API (http://www.subsonic.org/pages/api.jsp#getCoverArt), in the sense that one can give either a song_id or an album_id. However this can confuse clients that think that each of the songs has a different cover. I have tested strawberry music player and it tries to retrieve as many covers as songs, which makes the synchronization and order of magnitude slower than what it should if it only retrieves one cover per album. It also uses more space on the client to cache the cover art.

This is actually a regression introduced in commit cf8fedf2960c86082a9d892297b418a5b281800f. Before that commit ampache would give the album_id unless the show_song_art  setting is on. This commit reverts to that behaviour. However I have not warn that I have not tested with the show_song_art flag since I don't have that configuration in my server.

As an aside comment maybe it would be beneficial for the project to introduce unit tests that are run automatically and prevent the introduction of regressions like this one.