### PR TITLE
Add opml import for podcasts #3737

### DIFF
--- a/public/podcast.php
+++ b/public/podcast.php
@@ -28,8 +28,10 @@ use Ampache\Module\Application\Podcast\ConfirmDeleteAction;
 use Ampache\Module\Application\Podcast\CreateAction;
 use Ampache\Module\Application\Podcast\DeleteAction;
 use Ampache\Module\Application\Podcast\ExportPodcastsAction;
+use Ampache\Module\Application\Podcast\ImportPodcastsAction;
 use Ampache\Module\Application\Podcast\ShowAction;
 use Ampache\Module\Application\Podcast\ShowCreateAction;
+use Ampache\Module\Application\Podcast\ShowImportPodcastsAction;
 use Nyholm\Psr7Server\ServerRequestCreatorInterface;
 use Psr\Container\ContainerInterface;
 
@@ -45,6 +47,8 @@ $dic->get(ApplicationRunner::class)->run(
         ConfirmDeleteAction::REQUEST_KEY => ConfirmDeleteAction::class,
         ShowAction::REQUEST_KEY => ShowAction::class,
         ExportPodcastsAction::REQUEST_KEY => ExportPodcastsAction::class,
+        ShowImportPodcastsAction::REQUEST_KEY => ShowImportPodcastsAction::class,
+        ImportPodcastsAction::REQUEST_KEY => ImportPodcastsAction::class,
     ],
     ShowAction::REQUEST_KEY
 );

--- a/public/templates/show_import_podcasts.inc.php
+++ b/public/templates/show_import_podcasts.inc.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=0);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+use Ampache\Config\AmpConfig;
+use Ampache\Module\System\AmpError;
+use Ampache\Module\System\Core;
+
+/** @var int $catalogId */
+
+?>
+<form name="podcast" method="post" enctype="multipart/form-data" action="<?php echo AmpConfig::get('web_path'); ?>/podcast.php?action=import_podcasts">
+    <table class="tabledata">
+        <tr>
+            <td><?php echo T_('File'); ?> (<?php echo T_('Format: opml') ?>)</td>
+            <td>
+                <input type="file" id="podcast_import_file" name="import_file" value="" />
+                <?php echo AmpError::display('import_file'); ?>
+            </td>
+        </tr>
+        <tr>
+            <td><?php echo T_('Catalog'); ?></td>
+            <td>
+                <?php show_catalog_select('catalog', $catalogId, '', false, 'podcast'); ?>
+                <?php echo AmpError::display('catalog'); ?>
+            </td>
+        </tr>
+    </table>
+    <div class="formValidation">
+        <?php echo Core::form_register('import_podcasts'); ?>
+        <input class="button" type="submit" value="<?php echo T_('Import'); ?>" />
+    </div>
+</form>

--- a/public/templates/show_podcasts.inc.php
+++ b/public/templates/show_podcasts.inc.php
@@ -57,6 +57,12 @@ $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
                 <?php echo T_('Subscribe to Podcast'); ?>
             </a>
         </li>
+        <li>
+            <a href="<?php echo $webPath; ?>/podcast.php?action=show_import_podcasts">
+                <?php echo Ui::get_icon('upload', T_('Import')); ?>
+                <?php echo T_('Import'); ?>
+            </a>
+        </li>
         <?php } ?>
         <li>
             <a href="<?php echo $webPath; ?>/podcast.php?action=export_podcasts" target="_blank">
@@ -64,14 +70,6 @@ $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
                 <?php echo T_('Export'); ?>
             </a>
         </li>
-        <?php if (Access::check('interface', 75)) { ?>
-            <li>
-                <a href="<?php echo $webPath; ?>/podcast.php?action=show_import_podcasts">
-                    <?php echo Ui::get_icon('upload', T_('Import')); ?>
-                    <?php echo T_('Import'); ?>
-                </a>
-            </li>
-        <?php } ?>
     </ul>
 </div>
 <?php if ($browse->is_show_header()) {

--- a/public/templates/show_podcasts.inc.php
+++ b/public/templates/show_podcasts.inc.php
@@ -64,6 +64,14 @@ $cel_counter = ($is_table) ? "cel_counter" : 'grid_counter'; ?>
                 <?php echo T_('Export'); ?>
             </a>
         </li>
+        <?php if (Access::check('interface', 75)) { ?>
+            <li>
+                <a href="<?php echo $webPath; ?>/podcast.php?action=show_import_podcasts">
+                    <?php echo Ui::get_icon('upload', T_('Import')); ?>
+                    <?php echo T_('Import'); ?>
+                </a>
+            </li>
+        <?php } ?>
     </ul>
 </div>
 <?php if ($browse->is_show_header()) {

--- a/src/Module/Application/Podcast/ImportPodcastsAction.php
+++ b/src/Module/Application/Podcast/ImportPodcastsAction.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Module\Application\Podcast;
+
+use Ampache\Config\ConfigContainerInterface;
+use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\Application\ApplicationActionInterface;
+use Ampache\Module\Application\Exception\AccessDeniedException;
+use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\GuiGatekeeperInterface;
+use Ampache\Module\Catalog\CatalogLoaderInterface;
+use Ampache\Module\Catalog\Exception\CatalogLoadingException;
+use Ampache\Module\Podcast\Exception\InvalidCatalogException;
+use Ampache\Module\Podcast\Exchange\PodcastOpmlImporterInterface;
+use Ampache\Module\System\AmpError;
+use Ampache\Module\Util\RequestParserInterface;
+use Ampache\Module\Util\UiInterface;
+use Ampache\Repository\Model\Catalog;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+/**
+ * Loads and imports podcasts
+ */
+final class ImportPodcastsAction implements ApplicationActionInterface
+{
+    /** @var list<string> */
+    private const EXPECTED_MIME_TYPES = [
+        'text/x-opml+xml',
+        'text/xml'
+    ];
+
+    public const REQUEST_KEY = 'import_podcasts';
+
+    private ConfigContainerInterface $configContainer;
+
+    private UiInterface $ui;
+
+    private RequestParserInterface $requestParser;
+
+    private CatalogLoaderInterface $catalogLoader;
+
+    private PodcastOpmlImporterInterface $podcastOpmlImporter;
+
+    public function __construct(
+        ConfigContainerInterface $configContainer,
+        UiInterface $ui,
+        RequestParserInterface $requestParser,
+        CatalogLoaderInterface $catalogLoader,
+        PodcastOpmlImporterInterface $podcastOpmlImporter
+    ) {
+        $this->configContainer     = $configContainer;
+        $this->ui                  = $ui;
+        $this->requestParser       = $requestParser;
+        $this->catalogLoader       = $catalogLoader;
+        $this->podcastOpmlImporter = $podcastOpmlImporter;
+    }
+
+    public function run(ServerRequestInterface $request, GuiGatekeeperInterface $gatekeeper): ?ResponseInterface
+    {
+        if ($this->configContainer->isFeatureEnabled(ConfigurationKeyEnum::PODCAST) === false) {
+            return null;
+        }
+
+        if (
+            $gatekeeper->mayAccess(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_MANAGER) === false ||
+            $this->configContainer->isFeatureEnabled(ConfigurationKeyEnum::DEMO_MODE) === true ||
+            !$this->requestParser->verifyForm('import_podcasts')
+        ) {
+            throw new AccessDeniedException();
+        }
+
+        $data = $request->getParsedBody();
+
+        $catalogId = (int) ($data['catalog'] ?? 0);
+
+        try {
+            $catalog = $this->catalogLoader->getById($catalogId);
+
+            $importedCount = $this->importPodcasts($request, $catalog);
+        } catch (CatalogLoadingException $e) {
+            AmpError::add('catalog', T_('Catalog not found'));
+
+            $importedCount = 0;
+        }
+
+        $this->ui->showHeader();
+        if (AmpError::occurred()) {
+            $this->ui->show(
+                'show_import_podcasts.inc.php',
+                [
+                    'catalogId' => (int)($data['catalog'] ?? 0),
+                ]
+            );
+        } else {
+            $this->ui->showConfirmation(
+                T_('No Problem'),
+                sprintf(T_('Podcast-import finished. Imported %d podcasts'), $importedCount),
+                sprintf(
+                    '%s/browse.php?action=podcast',
+                    $this->configContainer->getWebPath()
+                )
+            );
+        }
+        $this->ui->showQueryStats();
+        $this->ui->showFooter();
+
+        return null;
+    }
+
+    /**
+     * Invokes the actual import
+     */
+    private function importPodcasts(
+        ServerRequestInterface $request,
+        Catalog $catalog
+    ): int {
+        /** @var null|UploadedFileInterface $file */
+        $file = $request->getUploadedFiles()['import_file'] ?? null;
+
+        if ($file === null) {
+            AmpError::add('import_file', T_('File is invalid'));
+
+            return 0;
+        }
+
+        if (!in_array($file->getClientMediaType(), self::EXPECTED_MIME_TYPES, true)) {
+            AmpError::add('import_file', T_('File-type not recognized'));
+
+            return 0;
+        }
+
+        try {
+            return $this->podcastOpmlImporter->import($catalog, $file->getStream()->getContents());
+        } catch (InvalidCatalogException $e) {
+            AmpError::add('catalog', T_('Invalid catalog type'));
+
+            return 0;
+        }
+    }
+}

--- a/src/Module/Application/Podcast/ShowImportPodcastsAction.php
+++ b/src/Module/Application/Podcast/ShowImportPodcastsAction.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=0);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Module\Application\Podcast;
+
+use Ampache\Config\ConfigContainerInterface;
+use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\Application\ApplicationActionInterface;
+use Ampache\Module\Application\Exception\AccessDeniedException;
+use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\GuiGatekeeperInterface;
+use Ampache\Module\Util\UiInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Renders the podcast import dialogue
+ */
+final class ShowImportPodcastsAction implements ApplicationActionInterface
+{
+    public const REQUEST_KEY = 'show_import_podcasts';
+
+    private ConfigContainerInterface $configContainer;
+
+    private UiInterface $ui;
+
+    public function __construct(
+        ConfigContainerInterface $configContainer,
+        UiInterface $ui
+    ) {
+        $this->configContainer = $configContainer;
+        $this->ui              = $ui;
+    }
+
+    public function run(ServerRequestInterface $request, GuiGatekeeperInterface $gatekeeper): ?ResponseInterface
+    {
+        if ($this->configContainer->isFeatureEnabled(ConfigurationKeyEnum::PODCAST) === false) {
+            return null;
+        }
+
+        if ($gatekeeper->mayAccess(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_MANAGER) === false) {
+            throw new AccessDeniedException();
+        }
+
+
+        $this->ui->showHeader();
+        $this->ui->showBoxTop(T_('Import Podcasts'), 'box box_add_podcast');
+        $this->ui->show(
+            'show_import_podcasts.inc.php',
+            [
+                'catalogId' => 0,
+            ]
+        );
+        $this->ui->showBoxBottom();
+        $this->ui->showQueryStats();
+        $this->ui->showFooter();
+
+        return null;
+    }
+}

--- a/src/Module/Podcast/Exchange/PodcastOpmlImporter.php
+++ b/src/Module/Podcast/Exchange/PodcastOpmlImporter.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Module\Podcast\Exchange;
+
+use Ampache\Module\Podcast\Exception\FeedNotLoadableException;
+use Ampache\Module\Podcast\Exception\InvalidCatalogException;
+use Ampache\Module\Podcast\Exception\InvalidFeedUrlException;
+use Ampache\Module\Podcast\PodcastCreatorInterface;
+use Ampache\Module\System\LegacyLogger;
+use Ampache\Repository\Model\Catalog;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Imports exported podcast items (from ampache or from an external service)
+ *
+ * Uses the OPML format to import podcasts from external sources
+ *
+ * @see http://opml.org/spec2.opml
+ */
+final class PodcastOpmlImporter implements PodcastOpmlImporterInterface
+{
+    private PodcastOpmlLoaderInterface $podcastOpmlLoader;
+
+    private PodcastCreatorInterface $podcastCreator;
+
+    private LoggerInterface $logger;
+
+    public function __construct(
+        PodcastOpmlLoaderInterface $podcastOpmlLoader,
+        PodcastCreatorInterface $podcastCreator,
+        LoggerInterface $logger
+    ) {
+        $this->podcastOpmlLoader = $podcastOpmlLoader;
+        $this->podcastCreator    = $podcastCreator;
+        $this->logger            = $logger;
+    }
+
+    /**
+     * Loads the opml-xml and tries to create all contained podcasts
+     *
+     * @param string $xml xml following the opml specs
+     *
+     * @throws InvalidCatalogException
+     */
+    public function import(Catalog $catalog, string $xml): int
+    {
+        $imported = 0;
+
+        foreach ($this->podcastOpmlLoader->load($xml) as $feedUrl) {
+            $this->logger->debug(
+                sprintf('Importing feed: %s', $feedUrl),
+                [LegacyLogger::CONTEXT_TYPE => self::class]
+            );
+
+            try {
+                $this->podcastCreator->create(
+                    $feedUrl,
+                    $catalog
+                );
+
+                $imported++;
+            } catch (InvalidFeedUrlException $e) {
+                $this->logger->warning(
+                    sprintf('Feed-url invalid: %s', $feedUrl),
+                    [LegacyLogger::CONTEXT_TYPE => self::class]
+                );
+            } catch (FeedNotLoadableException $e) {
+                $this->logger->warning(
+                    sprintf('Feed-url not readable: %s', $feedUrl),
+                    [LegacyLogger::CONTEXT_TYPE => self::class]
+                );
+            }
+        }
+
+        return $imported;
+    }
+}

--- a/src/Module/Podcast/Exchange/PodcastOpmlImporterInterface.php
+++ b/src/Module/Podcast/Exchange/PodcastOpmlImporterInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Module\Podcast\Exchange;
+
+use Ampache\Module\Podcast\Exception\InvalidCatalogException;
+use Ampache\Repository\Model\Catalog;
+
+interface PodcastOpmlImporterInterface
+{
+    /**
+     * Loads the opml-xml and tries to create all contained podcasts
+     *
+     * @param string $xml xml following the opml specs
+     *
+     * @throws InvalidCatalogException
+     */
+    public function import(Catalog $catalog, string $xml): int;
+}

--- a/src/Module/Podcast/Exchange/PodcastOpmlLoader.php
+++ b/src/Module/Podcast/Exchange/PodcastOpmlLoader.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Module\Podcast\Exchange;
+
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+use Generator;
+
+/**
+ * Loads a xml string
+ */
+final class PodcastOpmlLoader implements PodcastOpmlLoaderInterface
+{
+    /**
+     * Load the opml file and yields the feed-urls
+     *
+     * @return Generator<string> Podcast feed-urls
+     */
+    public function load(string $xml): Generator
+    {
+        $dom = new DOMDocument();
+        @$dom->loadXML($xml);
+
+        $xpath = new DOMXpath($dom);
+        $feeds = $xpath->query('//outline');
+
+        if ($feeds !== false) {
+            foreach ($feeds as $element) {
+                /** @var DOMElement $element */
+                $feedUrl = trim($element->getAttribute('xmlUrl'));
+
+                if ($feedUrl !== '') {
+                    yield $feedUrl;
+                }
+            }
+        }
+    }
+}

--- a/src/Module/Podcast/Exchange/PodcastOpmlLoaderInterface.php
+++ b/src/Module/Podcast/Exchange/PodcastOpmlLoaderInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Module\Podcast\Exchange;
+
+use Traversable;
+
+interface PodcastOpmlLoaderInterface
+{
+    /**
+     * Load the opml file and yields the feed-urls
+     *
+     * @return Traversable<int, string> Podcast feed-urls
+     */
+    public function load(string $xml): Traversable;
+}

--- a/src/Module/Podcast/service_definition.php
+++ b/src/Module/Podcast/service_definition.php
@@ -38,4 +38,6 @@ return [
     PodcastEpisodeDownloaderInterface::class => autowire(PodcastEpisodeDownloader::class),
     PodcastDeleterInterface::class => autowire(PodcastDeleter::class),
     Exchange\PodcastExporterInterface::class => autowire(Exchange\PodcastOpmlExporter::class),
+    Exchange\PodcastOpmlLoaderInterface::class => autowire(Exchange\PodcastOpmlLoader::class),
+    Exchange\PodcastOpmlImporterInterface::class => autowire(Exchange\PodcastOpmlImporter::class),
 ];

--- a/tests/Module/Application/Podcast/ImportPodcastsActionTest.php
+++ b/tests/Module/Application/Podcast/ImportPodcastsActionTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Module\Application\Podcast;
+
+use Ampache\Config\ConfigContainerInterface;
+use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\Application\Exception\AccessDeniedException;
+use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\GuiGatekeeperInterface;
+use Ampache\Module\Catalog\CatalogLoaderInterface;
+use Ampache\Module\Podcast\Exchange\PodcastOpmlImporterInterface;
+use Ampache\Module\Util\RequestParserInterface;
+use Ampache\Module\Util\UiInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use SEEC\PhpUnit\Helper\ConsecutiveParams;
+
+class ImportPodcastsActionTest extends TestCase
+{
+    use ConsecutiveParams;
+
+    private ConfigContainerInterface&MockObject $configContainer;
+
+    private UiInterface&MockObject $ui;
+
+    private RequestParserInterface&MockObject $requestParser;
+
+    private CatalogLoaderInterface&MockObject $catalogLoader;
+
+    private PodcastOpmlImporterInterface&MockObject $podcastOpmlImporter;
+
+    private ImportPodcastsAction $subject;
+
+    private ServerRequestInterface&MockObject $request;
+
+    private GuiGatekeeperInterface&MockObject $gatekeeper;
+
+    protected function setUp(): void
+    {
+        $this->configContainer     = $this->createMock(ConfigContainerInterface::class);
+        $this->ui                  = $this->createMock(UiInterface::class);
+        $this->requestParser       = $this->createMock(RequestParserInterface::class);
+        $this->catalogLoader       = $this->createMock(CatalogLoaderInterface::class);
+        $this->podcastOpmlImporter = $this->createMock(PodcastOpmlImporterInterface::class);
+
+        $this->subject = new ImportPodcastsAction(
+            $this->configContainer,
+            $this->ui,
+            $this->requestParser,
+            $this->catalogLoader,
+            $this->podcastOpmlImporter
+        );
+
+        $this->request    = $this->createMock(ServerRequestInterface::class);
+        $this->gatekeeper = $this->createMock(GuiGatekeeperInterface::class);
+    }
+
+    public function testRunReturnsNullIfPodcastIsDisabled(): void
+    {
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::PODCAST)
+            ->willReturn(false);
+
+        static::assertNull(
+            $this->subject->run($this->request, $this->gatekeeper)
+        );
+    }
+
+    public function testRunThrowsIfAccessLevelIsInsufficient(): void
+    {
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::PODCAST)
+            ->willReturn(true);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_MANAGER)
+            ->willReturn(false);
+
+        static::expectException(AccessDeniedException::class);
+
+        $this->subject->run($this->request, $this->gatekeeper);
+    }
+
+    public function testRunThrowsIfDemoMode(): void
+    {
+        $this->configContainer->expects(static::exactly(2))
+            ->method('isFeatureEnabled')
+            ->with(...self::withConsecutive(
+                [ConfigurationKeyEnum::PODCAST],
+                [ConfigurationKeyEnum::DEMO_MODE],
+            ))
+            ->willReturn(true, true);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_MANAGER)
+            ->willReturn(true);
+
+        static::expectException(AccessDeniedException::class);
+
+        $this->subject->run($this->request, $this->gatekeeper);
+    }
+
+    public function testRunThrowsIfFormVerificationFails(): void
+    {
+        $this->configContainer->expects(static::exactly(2))
+            ->method('isFeatureEnabled')
+            ->with(...self::withConsecutive(
+                [ConfigurationKeyEnum::PODCAST],
+                [ConfigurationKeyEnum::DEMO_MODE],
+            ))
+            ->willReturn(true, false);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_MANAGER)
+            ->willReturn(true);
+
+        $this->requestParser->expects(static::once())
+            ->method('verifyForm')
+            ->with('import_podcasts')
+            ->willReturn(false);
+
+        static::expectException(AccessDeniedException::class);
+
+        $this->subject->run($this->request, $this->gatekeeper);
+    }
+}

--- a/tests/Module/Application/Podcast/ShowImportPodcastsActionTest.php
+++ b/tests/Module/Application/Podcast/ShowImportPodcastsActionTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Module\Application\Podcast;
+
+use Ampache\Config\ConfigContainerInterface;
+use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\Application\Exception\AccessDeniedException;
+use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\GuiGatekeeperInterface;
+use Ampache\Module\Util\UiInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+class ShowImportPodcastsActionTest extends TestCase
+{
+    private ConfigContainerInterface&MockObject $configContainer;
+
+    private UiInterface&MockObject $ui;
+
+    private ShowImportPodcastsAction $subject;
+
+    private ServerRequestInterface&MockObject $request;
+
+    private GuiGatekeeperInterface&MockObject $gatekeeper;
+
+    protected function setUp(): void
+    {
+        $this->configContainer = $this->createMock(ConfigContainerInterface::class);
+        $this->ui              = $this->createMock(UiInterface::class);
+
+        $this->subject = new ShowImportPodcastsAction(
+            $this->configContainer,
+            $this->ui
+        );
+
+        $this->request    = $this->createMock(ServerRequestInterface::class);
+        $this->gatekeeper = $this->createMock(GuiGatekeeperInterface::class);
+    }
+
+    public function testRunReturnsNullIfPodcastsAreDisabled(): void
+    {
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::PODCAST)
+            ->willReturn(false);
+
+        static::assertNull(
+            $this->subject->run($this->request, $this->gatekeeper)
+        );
+    }
+
+    public function testRunThrowsIsAccessIsDenied(): void
+    {
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::PODCAST)
+            ->willReturn(true);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_MANAGER)
+            ->willReturn(false);
+
+        static::expectException(AccessDeniedException::class);
+
+        $this->subject->run($this->request, $this->gatekeeper);
+    }
+
+    public function testRunRenders(): void
+    {
+        $this->configContainer->expects(static::once())
+            ->method('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::PODCAST)
+            ->willReturn(true);
+
+        $this->gatekeeper->expects(static::once())
+            ->method('mayAccess')
+            ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_MANAGER)
+            ->willReturn(true);
+
+        $this->ui->expects(static::once())
+            ->method('showHeader');
+        $this->ui->expects(static::once())
+            ->method('showBoxTop')
+            ->with('Import Podcasts', 'box box_add_podcast');
+        $this->ui->expects(static::once())
+            ->method('show')
+            ->with(
+                'show_import_podcasts.inc.php',
+                [
+                    'catalogId' => 0,
+                ]
+            );
+        $this->ui->expects(static::once())
+            ->method('showBoxBottom');
+        $this->ui->expects(static::once())
+            ->method('showQueryStats');
+        $this->ui->expects(static::once())
+            ->method('showFooter');
+
+        static::assertNull(
+            $this->subject->run($this->request, $this->gatekeeper)
+        );
+    }
+}

--- a/tests/Module/Podcast/Exchange/PodcastOpmlImporterTest.php
+++ b/tests/Module/Podcast/Exchange/PodcastOpmlImporterTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Module\Podcast\Exchange;
+
+use Ampache\Module\Podcast\Exception\FeedNotLoadableException;
+use Ampache\Module\Podcast\Exception\InvalidFeedUrlException;
+use Ampache\Module\Podcast\PodcastCreatorInterface;
+use Ampache\Module\System\LegacyLogger;
+use Ampache\Repository\Model\Catalog;
+use ArrayIterator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class PodcastOpmlImporterTest extends TestCase
+{
+    private PodcastOpmlLoaderInterface&MockObject $podcastOpmlLoader;
+
+    private PodcastCreatorInterface&MockObject $podcastCreator;
+
+    private LoggerInterface&MockObject $logger;
+
+    private PodcastOpmlImporter $subject;
+
+    protected function setUp(): void
+    {
+        $this->podcastOpmlLoader = $this->createMock(PodcastOpmlLoaderInterface::class);
+        $this->podcastCreator    = $this->createMock(PodcastCreatorInterface::class);
+        $this->logger            = $this->createMock(LoggerInterface::class);
+
+        $this->subject = new PodcastOpmlImporter(
+            $this->podcastOpmlLoader,
+            $this->podcastCreator,
+            $this->logger
+        );
+    }
+
+    public function testImportSkipsIfUrlIsInvalid(): void
+    {
+        $catalog = $this->createMock(Catalog::class);
+
+        $xml     = 'some-xml';
+        $feedUrl = 'some-url';
+
+        $this->podcastOpmlLoader->expects(static::once())
+            ->method('load')
+            ->with($xml)
+            ->willReturn(new ArrayIterator([$feedUrl]));
+
+        $this->podcastCreator->expects(static::once())
+            ->method('create')
+            ->with($feedUrl, $catalog)
+            ->willThrowException(new InvalidFeedUrlException());
+
+        $this->logger->expects(static::once())
+            ->method('debug')
+            ->with(
+                sprintf('Importing feed: %s', $feedUrl),
+                [LegacyLogger::CONTEXT_TYPE => PodcastOpmlImporter::class]
+            );
+        $this->logger->expects(static::once())
+            ->method('warning')
+            ->with(
+                sprintf('Feed-url invalid: %s', $feedUrl),
+                [LegacyLogger::CONTEXT_TYPE => PodcastOpmlImporter::class]
+            );
+
+        $this->subject->import($catalog, $xml);
+    }
+
+    public function testImportSkipsIfFeedUrlIsNotLoadable(): void
+    {
+        $catalog = $this->createMock(Catalog::class);
+
+        $xml     = 'some-xml';
+        $feedUrl = 'some-url';
+
+        $this->podcastOpmlLoader->expects(static::once())
+            ->method('load')
+            ->with($xml)
+            ->willReturn(new ArrayIterator([$feedUrl]));
+
+        $this->podcastCreator->expects(static::once())
+            ->method('create')
+            ->with($feedUrl, $catalog)
+            ->willThrowException(new FeedNotLoadableException());
+
+        $this->logger->expects(static::once())
+            ->method('debug')
+            ->with(
+                sprintf('Importing feed: %s', $feedUrl),
+                [LegacyLogger::CONTEXT_TYPE => PodcastOpmlImporter::class]
+            );
+        $this->logger->expects(static::once())
+            ->method('warning')
+            ->with(
+                sprintf('Feed-url not readable: %s', $feedUrl),
+                [LegacyLogger::CONTEXT_TYPE => PodcastOpmlImporter::class]
+            );
+
+        $this->subject->import($catalog, $xml);
+    }
+
+    public function testImportReturnsCountOfImportedFeeds(): void
+    {
+        $catalog = $this->createMock(Catalog::class);
+
+        $xml     = 'some-xml';
+        $feedUrl = 'some-url';
+
+        $this->podcastOpmlLoader->expects(static::once())
+            ->method('load')
+            ->with($xml)
+            ->willReturn(new ArrayIterator([$feedUrl]));
+
+        $this->podcastCreator->expects(static::once())
+            ->method('create')
+            ->with($feedUrl, $catalog);
+
+        $this->logger->expects(static::once())
+            ->method('debug')
+            ->with(
+                sprintf('Importing feed: %s', $feedUrl),
+                [LegacyLogger::CONTEXT_TYPE => PodcastOpmlImporter::class]
+            );
+
+        static::assertSame(
+            1,
+            $this->subject->import($catalog, $xml)
+        );
+    }
+}

--- a/tests/Module/Podcast/Exchange/PodcastOpmlLoaderTest.php
+++ b/tests/Module/Podcast/Exchange/PodcastOpmlLoaderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Module\Podcast\Exchange;
+
+use PHPUnit\Framework\TestCase;
+
+class PodcastOpmlLoaderTest extends TestCase
+{
+    private PodcastOpmlLoader $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new PodcastOpmlLoader();
+    }
+
+    public function testLoadReturnsEmptyListIfNoInputAvailable(): void
+    {
+        static::assertSame(
+            [],
+            iterator_to_array($this->subject->load('<asdf'))
+        );
+    }
+
+    public function testLoadYieldUrls(): void
+    {
+        $url = 'some-url';
+
+        static::assertSame(
+            [$url],
+            iterator_to_array(
+                $this->subject->load('<root><outline xmlUrl="" /><outline xmlUrl="' . $url . '" /></root>')
+            )
+        );
+    }
+}


### PR DESCRIPTION
This allows the import of exported podcasts (e.g. from external app or other ampache instances) using the opml format.