### PR TITLE
Try to bring back the scrutinizer code coverage

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,6 +2,14 @@ build:
     environment:
         php:
             version: "8.2"
+    nodes:
+        coverage:
+            tests:
+                override:
+                    - command: XDEBUG_MODE=coverage ./vendor/bin/phpunit --coverage-clover build/coverage-clover.xml tests
+                      coverage:
+                        file: build/coverage-clover.xml
+                        format: clover
 filter:
     excluded_paths:
         - 'public/lib/components/*'


### PR DESCRIPTION
Has been removed due to unknown errors with bc7313fb000c59e0d26cdce8c9997cf67db5c484. Let's try to bring it back for good