### PR TITLE
Replace License loading by repo-method

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4767,7 +4767,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\|object\\|null given\\.$#"
-			count: 7
+			count: 6
 			path: src/Module/Application/Admin/License/EditAction.php
 
 		-

--- a/public/templates/show_license_row.inc.php
+++ b/public/templates/show_license_row.inc.php
@@ -29,14 +29,14 @@ use Ampache\Module\Util\Ui;
 /** @var string $web_path */
 /** @var License $libitem */
 ?>
-<tr id="license_<?php echo $libitem->id; ?>">
+<tr id="license_<?php echo $libitem->getId(); ?>">
     <td class="cel_name"><?php echo $libitem->getLinkFormatted(); ?></td>
-    <td class="cel_description"><?php echo $libitem->description; ?></td>
+    <td class="cel_description"><?php echo $libitem->getDescription(); ?></td>
     <td class="cel_action">
-        <a href="<?php echo $web_path; ?>/admin/license.php?action=show_edit&license_id=<?php echo $libitem->id; ?>">
+        <a href="<?php echo $web_path; ?>/admin/license.php?action=show_edit&license_id=<?php echo $libitem->getId(); ?>">
             <?php echo Ui::get_icon('edit', T_('Edit')); ?>
         </a>
-        <a href="<?php echo $web_path; ?>/admin/license.php?action=delete&license_id=<?php echo $libitem->id; ?>">
+        <a href="<?php echo $web_path; ?>/admin/license.php?action=delete&license_id=<?php echo $libitem->getId(); ?>">
             <?php echo Ui::get_icon('delete', T_('Delete')); ?>
         </a>
     </td>

--- a/public/templates/show_manage_license.inc.php
+++ b/public/templates/show_manage_license.inc.php
@@ -24,10 +24,14 @@ declare(strict_types=0);
  */
 
 use Ampache\Config\AmpConfig;
+use Ampache\Repository\LicenseRepositoryInterface;
 use Ampache\Repository\Model\License;
 use Ampache\Module\Util\Ui;
 
-/** @var array $object_ids */
+/** @var list<int> $object_ids */
+
+global $dic;
+$licenseRepository = $dic->get(LicenseRepositoryInterface::class);
 
 $web_path = (string)AmpConfig::get('web_path', ''); ?>
 <div id="information_actions">
@@ -48,8 +52,8 @@ $web_path = (string)AmpConfig::get('web_path', ''); ?>
     <tbody>
         <?php
         foreach ($object_ids as $license_id) {
-            $libitem = new License($license_id);
-            if ($libitem->isNew()) {
+            $libitem = $licenseRepository->findById($license_id);
+            if ($libitem === null) {
                 continue;
             }
             require Ui::find_template('show_license_row.inc.php');

--- a/src/Gui/Song/SongViewAdapter.php
+++ b/src/Gui/Song/SongViewAdapter.php
@@ -423,8 +423,9 @@ final class SongViewAdapter implements SongViewAdapterInterface
             $songprops[T_('Lyrics')] = $this->song->f_lyrics;
         }
 
-        if ($this->configContainer->isFeatureEnabled(ConfigurationKeyEnum::LICENSING) && $this->song->license) {
-            $songprops[T_('Licensing')] = $this->song->f_license;
+        $license = $this->song->getLicense();
+        if ($license !== null) {
+            $songprops[T_('Licensing')] = $license->getLinkFormatted();
         }
 
         $owner_id = $this->song->get_user_owner();
@@ -508,7 +509,13 @@ final class SongViewAdapter implements SongViewAdapterInterface
 
     public function getLicenseLink(): string
     {
-        return (string) $this->song->f_license;
+        $license = $this->song->getLicense();
+
+        if ($license !== null) {
+            return $license->getLinkFormatted();
+        }
+
+        return '';
     }
 
     public function getNumberPlayed(): int

--- a/src/Module/Api/Method/Api5/License5Method.php
+++ b/src/Module/Api/Method/Api5/License5Method.php
@@ -27,6 +27,7 @@ namespace Ampache\Module\Api\Method\Api5;
 
 use Ampache\Config\AmpConfig;
 use Ampache\Module\Api\Exception\ErrorCodeEnum;
+use Ampache\Repository\LicenseRepositoryInterface;
 use Ampache\Repository\Model\License;
 use Ampache\Module\Api\Api5;
 use Ampache\Module\Api\Json5_Data;
@@ -59,8 +60,8 @@ final class License5Method
             return false;
         }
         $object_id = (int) $input['filter'];
-        $license   = new License($object_id);
-        if ($license->isNew()) {
+        $license   = self::getLicenseRepository()->findById($object_id);
+        if ($license === null) {
             /* HINT: Requested object string/id/type ("album", "myusername", "some song title", 1298376) */
             Api5::error(sprintf(T_('Not Found: %s'), $object_id), ErrorCodeEnum::NOT_FOUND, self::ACTION, 'filter', $input['api_format']);
 
@@ -77,5 +78,15 @@ final class License5Method
         }
 
         return true;
+    }
+
+    /**
+     * @deprecated Inject by constructor
+     */
+    private static function getLicenseRepository(): LicenseRepositoryInterface
+    {
+        global $dic;
+
+        return $dic->get(LicenseRepositoryInterface::class);
     }
 }

--- a/src/Module/Api/Method/LicenseMethod.php
+++ b/src/Module/Api/Method/LicenseMethod.php
@@ -27,6 +27,7 @@ namespace Ampache\Module\Api\Method;
 
 use Ampache\Config\AmpConfig;
 use Ampache\Module\Api\Exception\ErrorCodeEnum;
+use Ampache\Repository\LicenseRepositoryInterface;
 use Ampache\Repository\Model\License;
 use Ampache\Module\Api\Api;
 use Ampache\Module\Api\Json_Data;
@@ -60,8 +61,8 @@ final class LicenseMethod
             return false;
         }
         $object_id = (int) $input['filter'];
-        $license   = new License($object_id);
-        if ($license->isNew()) {
+        $license   = self::getLicenseRepository()->findById($object_id);
+        if ($license === null) {
             /* HINT: Requested object string/id/type ("album", "myusername", "some song title", 1298376) */
             Api::error(sprintf(T_('Not Found: %s'), $object_id), ErrorCodeEnum::NOT_FOUND, self::ACTION, 'filter', $input['api_format']);
 
@@ -78,5 +79,15 @@ final class LicenseMethod
         }
 
         return true;
+    }
+
+    /**
+     * @deprecated Inject by constructor
+     */
+    private static function getLicenseRepository(): LicenseRepositoryInterface
+    {
+        global $dic;
+
+        return $dic->get(LicenseRepositoryInterface::class);
     }
 }

--- a/src/Module/Api/Xml5_Data.php
+++ b/src/Module/Api/Xml5_Data.php
@@ -25,10 +25,10 @@ declare(strict_types=0);
 
 namespace Ampache\Module\Api;
 
+use Ampache\Repository\LicenseRepositoryInterface;
 use Ampache\Repository\Model\Album;
 use Ampache\Repository\Model\Bookmark;
 use Ampache\Repository\Model\Label;
-use Ampache\Repository\Model\License;
 use Ampache\Repository\Model\Live_Stream;
 use Ampache\Repository\Model\Preference;
 use Ampache\Repository\Model\Shoutbox;
@@ -423,10 +423,14 @@ class Xml5_Data
         }
         $string = "<total_count>" . Catalog::get_update_info('license', $user->id) . "</total_count>\n";
 
+        $licenseRepository = self::getLicenseRepository();
+
         foreach ($licenses as $license_id) {
-            $license = new license($license_id);
-            $string .= "<license id=\"$license_id\">\n\t<name><![CDATA[" . $license->name . "]]></name>\n\t<description><![CDATA[" . $license->description . "]]></description>\n\t<external_link><![CDATA[" . $license->external_link . "]]></external_link>\n</license>\n";
-        } // end foreach
+            $license = $licenseRepository->findById($license_id);
+            if ($license !== null) {
+                $string .= "<license id=\"$license_id\">\n\t<name><![CDATA[" . $license->getName() . "]]></name>\n\t<description><![CDATA[" . $license->getDescription() . "]]></description>\n\t<external_link><![CDATA[" . $license->getLinkFormatted() . "]]></external_link>\n</license>\n";
+            }
+        }
 
         return Xml_Data::output_xml($string);
     }
@@ -859,6 +863,13 @@ class Xml5_Data
             $songMime      = $song->mime;
             $songBitrate   = $song->bitrate;
             $play_url      = $song->play_url('', 'api', false, $user->id, $user->streamtoken);
+            $license       = $song->getLicense();
+            if ($license !== null) {
+                $licenseLink = $license->getLinkFormatted();
+            } else {
+                $licenseLink = '';
+            }
+
             $playlist_track++;
 
             $string .= "<song id=\"" . $song->id . "\">\n\t<title><![CDATA[" . $song->get_fullname() . "]]></title>\n\t<name><![CDATA[" . $song->f_name . "]]></name>\n"
@@ -867,7 +878,7 @@ class Xml5_Data
             if ($song->get_album_artist_fullname() != "") {
                 $string .= "\t<albumartist id=\"" . $song->albumartist . "\"><![CDATA[" . $song->get_album_artist_fullname() . "]]></albumartist>\n";
             }
-            $string .= "\t<disk><![CDATA[" . $song->disk . "]]></disk>\n\t<track>" . $song->track . "</track>\n" . $tag_string . "\t<filename><![CDATA[" . $song->file . "]]></filename>\n\t<playlisttrack>" . $playlist_track . "</playlisttrack>\n\t<time>" . $song->time . "</time>\n\t<year>" . $song->year . "</year>\n\t<bitrate>" . $songBitrate . "</bitrate>\n\t<rate>" . $song->rate . "</rate>\n\t<mode><![CDATA[" . $song->mode . "]]></mode>\n\t<mime><![CDATA[" . $songMime . "]]></mime>\n\t<url><![CDATA[" . $play_url . "]]></url>\n\t<size>" . $song->size . "</size>\n\t<mbid><![CDATA[" . $song->mbid . "]]></mbid>\n\t<album_mbid><![CDATA[" . $song->album_mbid . "]]></album_mbid>\n\t<artist_mbid><![CDATA[" . $song->artist_mbid . "]]></artist_mbid>\n\t<albumartist_mbid><![CDATA[" . $song->albumartist_mbid . "]]></albumartist_mbid>\n\t<art><![CDATA[" . $art_url . "]]></art>\n\t<flag>" . (!$flag->get_flag($user->getId()) ? 0 : 1) . "</flag>\n\t<preciserating>" . $user_rating . "</preciserating>\n\t<rating>" . $user_rating . "</rating>\n\t<averagerating>" . (string) $rating->get_average_rating() . "</averagerating>\n\t<playcount>" . $song->total_count . "</playcount>\n\t<catalog>" . $song->getCatalogId() . "</catalog>\n\t<composer><![CDATA[" . $song->composer . "]]></composer>\n\t<channels>" . $song->channels . "</channels>\n\t<comment><![CDATA[" . $song->comment . "]]></comment>\n\t<license><![CDATA[" . $song->f_license . "]]></license>\n\t<publisher><![CDATA[" . $song->label . "]]></publisher>\n\t<language>" . $song->language . "</language>\n\t<lyrics><![CDATA[" . $song->lyrics . "]]></lyrics>\n\t<replaygain_album_gain>" . $song->replaygain_album_gain . "</replaygain_album_gain>\n\t<replaygain_album_peak>" . $song->replaygain_album_peak . "</replaygain_album_peak>\n\t<replaygain_track_gain>" . $song->replaygain_track_gain . "</replaygain_track_gain>\n\t<replaygain_track_peak>" . $song->replaygain_track_peak . "</replaygain_track_peak>\n\t<r128_album_gain>" . $song->r128_album_gain . "</r128_album_gain>\n\t<r128_track_gain>" . $song->r128_track_gain . "</r128_track_gain>\n";
+            $string .= "\t<disk><![CDATA[" . $song->disk . "]]></disk>\n\t<track>" . $song->track . "</track>\n" . $tag_string . "\t<filename><![CDATA[" . $song->file . "]]></filename>\n\t<playlisttrack>" . $playlist_track . "</playlisttrack>\n\t<time>" . $song->time . "</time>\n\t<year>" . $song->year . "</year>\n\t<bitrate>" . $songBitrate . "</bitrate>\n\t<rate>" . $song->rate . "</rate>\n\t<mode><![CDATA[" . $song->mode . "]]></mode>\n\t<mime><![CDATA[" . $songMime . "]]></mime>\n\t<url><![CDATA[" . $play_url . "]]></url>\n\t<size>" . $song->size . "</size>\n\t<mbid><![CDATA[" . $song->mbid . "]]></mbid>\n\t<album_mbid><![CDATA[" . $song->album_mbid . "]]></album_mbid>\n\t<artist_mbid><![CDATA[" . $song->artist_mbid . "]]></artist_mbid>\n\t<albumartist_mbid><![CDATA[" . $song->albumartist_mbid . "]]></albumartist_mbid>\n\t<art><![CDATA[" . $art_url . "]]></art>\n\t<flag>" . (!$flag->get_flag($user->getId()) ? 0 : 1) . "</flag>\n\t<preciserating>" . $user_rating . "</preciserating>\n\t<rating>" . $user_rating . "</rating>\n\t<averagerating>" . (string) $rating->get_average_rating() . "</averagerating>\n\t<playcount>" . $song->total_count . "</playcount>\n\t<catalog>" . $song->getCatalogId() . "</catalog>\n\t<composer><![CDATA[" . $song->composer . "]]></composer>\n\t<channels>" . $song->channels . "</channels>\n\t<comment><![CDATA[" . $song->comment . "]]></comment>\n\t<license><![CDATA[" . $licenseLink . "]]></license>\n\t<publisher><![CDATA[" . $song->label . "]]></publisher>\n\t<language>" . $song->language . "</language>\n\t<lyrics><![CDATA[" . $song->lyrics . "]]></lyrics>\n\t<replaygain_album_gain>" . $song->replaygain_album_gain . "</replaygain_album_gain>\n\t<replaygain_album_peak>" . $song->replaygain_album_peak . "</replaygain_album_peak>\n\t<replaygain_track_gain>" . $song->replaygain_track_gain . "</replaygain_track_gain>\n\t<replaygain_track_peak>" . $song->replaygain_track_peak . "</replaygain_track_peak>\n\t<r128_album_gain>" . $song->r128_album_gain . "</r128_album_gain>\n\t<r128_track_gain>" . $song->r128_track_gain . "</r128_track_gain>\n";
             if (Song::isCustomMetadataEnabled()) {
                 foreach ($song->getMetadata() as $metadata) {
                     $meta_name = str_replace(
@@ -1185,5 +1196,15 @@ class Xml5_Data
         global $dic;
 
         return $dic->get(PodcastRepositoryInterface::class);
+    }
+
+    /**
+     * @deprecated Inject by constructor
+     */
+    private static function getLicenseRepository(): LicenseRepositoryInterface
+    {
+        global $dic;
+
+        return $dic->get(LicenseRepositoryInterface::class);
     }
 }

--- a/src/Module/Api/Xml_Data.php
+++ b/src/Module/Api/Xml_Data.php
@@ -26,10 +26,10 @@ declare(strict_types=0);
 namespace Ampache\Module\Api;
 
 use Ampache\Module\System\Dba;
+use Ampache\Repository\LicenseRepositoryInterface;
 use Ampache\Repository\Model\Album;
 use Ampache\Repository\Model\Bookmark;
 use Ampache\Repository\Model\Label;
-use Ampache\Repository\Model\License;
 use Ampache\Repository\Model\Live_Stream;
 use Ampache\Repository\Model\Preference;
 use Ampache\Repository\Model\Shoutbox;
@@ -706,10 +706,14 @@ class Xml_Data
         }
         $string = "<total_count>" . Catalog::get_update_info('license', $user->id) . "</total_count>\n";
 
+        $licenseRepository = self::getLicenseRepository();
+
         foreach ($licenses as $license_id) {
-            $license = new license($license_id);
-            $string .= "<license id=\"$license_id\">\n\t<name><![CDATA[" . $license->name . "]]></name>\n\t<description><![CDATA[" . $license->description . "]]></description>\n\t<external_link><![CDATA[" . $license->external_link . "]]></external_link>\n</license>\n";
-        } // end foreach
+            $license = $licenseRepository->findById($license_id);
+            if ($license !== null) {
+                $string .= "<license id=\"$license_id\">\n\t<name><![CDATA[" . $license->getName() . "]]></name>\n\t<description><![CDATA[" . $license->getDescription() . "]]></description>\n\t<external_link><![CDATA[" . $license->getLinkFormatted() . "]]></external_link>\n</license>\n";
+            }
+        }
 
         return self::output_xml($string);
     }
@@ -1158,6 +1162,13 @@ class Xml_Data
             $songMime      = $song->mime;
             $songBitrate   = $song->bitrate;
             $play_url      = $song->play_url('', 'api', false, $user->id, $user->streamtoken);
+            $license       = $song->getLicense();
+            if ($license !== null) {
+                $licenseLink = $license->getLinkFormatted();
+            } else {
+                $licenseLink = '';
+            }
+
             $playlist_track++;
 
             $string .= "<song id=\"" . $song->id . "\">\n\t<name><![CDATA[" . $song->f_name . "]]></name>\n\t<title><![CDATA[" . $song->get_fullname() . "]]></title>\n";
@@ -1171,7 +1182,7 @@ class Xml_Data
                     : $song_artist;
                 $string .= "\t<albumartist id=\"" . $song->albumartist . "\"><name><![CDATA[" . $album_artist['name'] . "]]></name>\n\t<prefix><![CDATA[" . $album_artist['prefix'] . "]]></prefix>\n\t<basename><![CDATA[" . $album_artist['basename'] . "]]></basename>\n</albumartist>\n";
             }
-            $string .= "\t<disk><![CDATA[" . $song->disk . "]]></disk>\n\t<disksubtitle><![CDATA[" . $song->disksubtitle . "]]></disksubtitle>\n\t<track>" . $song->track . "</track>\n" . $tag_string . "\t<filename><![CDATA[" . $song->file . "]]></filename>\n\t<playlisttrack>" . $playlist_track . "</playlisttrack>\n\t<time>" . $song->time . "</time>\n\t<year>" . $song->year . "</year>\n\t<format>" . $songType . "</format>\n\t<stream_format>" . $song->type . "</stream_format>\n\t<bitrate>" . $songBitrate . "</bitrate>\n\t<stream_bitrate>" . $song->bitrate . "</stream_bitrate>\n\t<rate>" . $song->rate . "</rate>\n\t<mode><![CDATA[" . $song->mode . "]]></mode>\n\t<mime><![CDATA[" . $songMime . "]]></mime>\n\t<stream_mime><![CDATA[" . $song->mime . "]]></stream_mime>\n\t<url><![CDATA[" . $play_url . "]]></url>\n\t<size>" . $song->size . "</size>\n\t<mbid><![CDATA[" . $song->mbid . "]]></mbid>\n\t<art><![CDATA[" . $art_url . "]]></art>\n\t<has_art>" . ($song->has_art() ? 1 : 0) . "</has_art>\n\t<flag>" . (!$flag->get_flag($user->getId()) ? 0 : 1) . "</flag>\n\t<rating>" . $user_rating . "</rating>\n\t<averagerating>" . (string)$rating->get_average_rating() . "</averagerating>\n\t<playcount>" . $song->total_count . "</playcount>\n\t<catalog>" . $song->getCatalogId() . "</catalog>\n\t<composer><![CDATA[" . $song->composer . "]]></composer>\n\t<channels>" . $song->channels . "</channels>\n\t<comment><![CDATA[" . $song->comment . "]]></comment>\n\t<license><![CDATA[" . $song->f_license . "]]></license>\n\t<publisher><![CDATA[" . $song->label . "]]></publisher>\n\t<language>" . $song->language . "</language>\n\t<lyrics><![CDATA[" . $song->lyrics . "]]></lyrics>\n\t<replaygain_album_gain>" . $song->replaygain_album_gain . "</replaygain_album_gain>\n\t<replaygain_album_peak>" . $song->replaygain_album_peak . "</replaygain_album_peak>\n\t<replaygain_track_gain>" . $song->replaygain_track_gain . "</replaygain_track_gain>\n\t<replaygain_track_peak>" . $song->replaygain_track_peak . "</replaygain_track_peak>\n\t<r128_album_gain>" . $song->r128_album_gain . "</r128_album_gain>\n\t<r128_track_gain>" . $song->r128_track_gain . "</r128_track_gain>\n";
+            $string .= "\t<disk><![CDATA[" . $song->disk . "]]></disk>\n\t<disksubtitle><![CDATA[" . $song->disksubtitle . "]]></disksubtitle>\n\t<track>" . $song->track . "</track>\n" . $tag_string . "\t<filename><![CDATA[" . $song->file . "]]></filename>\n\t<playlisttrack>" . $playlist_track . "</playlisttrack>\n\t<time>" . $song->time . "</time>\n\t<year>" . $song->year . "</year>\n\t<format>" . $songType . "</format>\n\t<stream_format>" . $song->type . "</stream_format>\n\t<bitrate>" . $songBitrate . "</bitrate>\n\t<stream_bitrate>" . $song->bitrate . "</stream_bitrate>\n\t<rate>" . $song->rate . "</rate>\n\t<mode><![CDATA[" . $song->mode . "]]></mode>\n\t<mime><![CDATA[" . $songMime . "]]></mime>\n\t<stream_mime><![CDATA[" . $song->mime . "]]></stream_mime>\n\t<url><![CDATA[" . $play_url . "]]></url>\n\t<size>" . $song->size . "</size>\n\t<mbid><![CDATA[" . $song->mbid . "]]></mbid>\n\t<art><![CDATA[" . $art_url . "]]></art>\n\t<has_art>" . ($song->has_art() ? 1 : 0) . "</has_art>\n\t<flag>" . (!$flag->get_flag($user->getId()) ? 0 : 1) . "</flag>\n\t<rating>" . $user_rating . "</rating>\n\t<averagerating>" . (string)$rating->get_average_rating() . "</averagerating>\n\t<playcount>" . $song->total_count . "</playcount>\n\t<catalog>" . $song->getCatalogId() . "</catalog>\n\t<composer><![CDATA[" . $song->composer . "]]></composer>\n\t<channels>" . $song->channels . "</channels>\n\t<comment><![CDATA[" . $song->comment . "]]></comment>\n\t<license><![CDATA[" . $licenseLink . "]]></license>\n\t<publisher><![CDATA[" . $song->label . "]]></publisher>\n\t<language>" . $song->language . "</language>\n\t<lyrics><![CDATA[" . $song->lyrics . "]]></lyrics>\n\t<replaygain_album_gain>" . $song->replaygain_album_gain . "</replaygain_album_gain>\n\t<replaygain_album_peak>" . $song->replaygain_album_peak . "</replaygain_album_peak>\n\t<replaygain_track_gain>" . $song->replaygain_track_gain . "</replaygain_track_gain>\n\t<replaygain_track_peak>" . $song->replaygain_track_peak . "</replaygain_track_peak>\n\t<r128_album_gain>" . $song->r128_album_gain . "</r128_album_gain>\n\t<r128_track_gain>" . $song->r128_track_gain . "</r128_track_gain>\n";
             if (Song::isCustomMetadataEnabled()) {
                 foreach ($song->getMetadata() as $metadata) {
                     $meta_name = str_replace(array(' ', '(', ')', '/', '\\', '#'), '_', $metadata->getField()->getName());
@@ -1521,5 +1532,15 @@ class Xml_Data
         global $dic;
 
         return $dic->get(PodcastRepositoryInterface::class);
+    }
+
+    /**
+     * @deprecated Inject by constructor
+     */
+    private static function getLicenseRepository(): LicenseRepositoryInterface
+    {
+        global $dic;
+
+        return $dic->get(LicenseRepositoryInterface::class);
     }
 }

--- a/src/Module/Util/ObjectTypeToClassNameMapper.php
+++ b/src/Module/Util/ObjectTypeToClassNameMapper.php
@@ -31,7 +31,6 @@ use Ampache\Repository\Model\Artist;
 use Ampache\Repository\Model\Bookmark;
 use Ampache\Repository\Model\Clip;
 use Ampache\Repository\Model\Label;
-use Ampache\Repository\Model\License;
 use Ampache\Repository\Model\Live_Stream;
 use Ampache\Repository\Model\Movie;
 use Ampache\Repository\Model\Personal_Video;
@@ -66,7 +65,6 @@ final class ObjectTypeToClassNameMapper
         'clip' => Clip::class,
         'genre' => Tag::class,
         'label' => Label::class,
-        'license' => License::class,
         'live_stream' => Live_Stream::class,
         'movie' => Movie::class,
         'personal_video' => Personal_Video::class,

--- a/src/Repository/LicenseRepository.php
+++ b/src/Repository/LicenseRepository.php
@@ -60,6 +60,19 @@ final class LicenseRepository implements LicenseRepositoryInterface
     }
 
     /**
+     * Retrieve a single license-item by its id
+     */
+    public function findById(int $licenseId): ?License
+    {
+        $license = new License($licenseId);
+        if ($license->isNew()) {
+            return null;
+        }
+
+        return $license;
+    }
+
+    /**
      * This inserts a new license entry, it returns the auto_inc id
      *
      * @return int The id of the created license

--- a/src/Repository/LicenseRepositoryInterface.php
+++ b/src/Repository/LicenseRepositoryInterface.php
@@ -36,6 +36,11 @@ interface LicenseRepositoryInterface
     public function getList(): Traversable;
 
     /**
+     * Retrieve a single license-item by its id
+     */
+    public function findById(int $licenseId): ?License;
+
+    /**
      * This inserts a new license entry, it returns the auto_inc id
      *
      * @return int The id of the created license

--- a/src/Repository/Model/License.php
+++ b/src/Repository/Model/License.php
@@ -31,10 +31,10 @@ class License
 {
     protected const DB_TABLENAME = 'license';
 
-    public int $id                = 0;
-    public ?string $name          = null;
-    public ?string $description   = null;
-    public ?string $external_link = null;
+    private int $id                = 0;
+    private ?string $name          = null;
+    private ?string $description   = null;
+    private ?string $external_link = null;
 
     /**
      * Constructor
@@ -63,6 +63,11 @@ class License
     public function getName(): string
     {
         return (string) $this->name;
+    }
+
+    public function getDescription(): string
+    {
+        return (string) $this->description;
     }
 
     /**

--- a/src/Repository/Model/ModelFactory.php
+++ b/src/Repository/Model/ModelFactory.php
@@ -160,12 +160,6 @@ final class ModelFactory implements ModelFactoryInterface
         return new Search((int) $searchId, $searchType, $user);
     }
 
-    public function createLicense(
-        int $licenseId
-    ): License {
-        return new License($licenseId);
-    }
-
     public function createAccess(
         int $accessId
     ): Access {

--- a/src/Repository/Model/ModelFactoryInterface.php
+++ b/src/Repository/Model/ModelFactoryInterface.php
@@ -109,10 +109,6 @@ interface ModelFactoryInterface
         ?User $user = null
     ): Search;
 
-    public function createLicense(
-        int $licenseId
-    ): License;
-
     public function createAccess(
         int $accessId
     ): Access;

--- a/src/Repository/Model/Song.php
+++ b/src/Repository/Model/Song.php
@@ -37,6 +37,7 @@ use Ampache\Module\User\Activity\UserActivityPosterInterface;
 use Ampache\Module\Util\Recommendation;
 use Ampache\Module\Util\Ui;
 use Ampache\Repository\AlbumRepositoryInterface;
+use Ampache\Repository\LicenseRepositoryInterface;
 use Ampache\Repository\Model\Metadata\Metadata;
 use Ampache\Module\Authorization\Access;
 use Ampache\Config\AmpConfig;
@@ -161,20 +162,20 @@ class Song extends database_object implements
     public $f_size;
     /** @var null|string $f_lyrics */
     public $f_lyrics;
-    /** @var null|string $f_pattern */
-    public $f_pattern;
+
     /** @var int $count */
     public $count;
     /** @var null|string $f_publisher */
     public $f_publisher;
     /** @var null|string $f_composer */
     public $f_composer;
-    /** @var null|string $f_license */
-    public $f_license;
+
     /** @var int $tag_id */
     public $tag_id;
 
     private ?bool $has_art = null;
+
+    private ?License $licenseObj = null;
 
     /* Setting Variables */
     /**
@@ -1624,12 +1625,6 @@ class Song extends database_object implements
 
         $year              = (int)$this->year;
         $this->f_year_link = "<a href=\"" . $web_path . "/search.php?type=album&action=search&limit=0&rule_1=year&rule_1_operator=2&rule_1_input=" . $year . "\">" . $year . "</a>";
-
-        if (AmpConfig::get('licensing') && $this->license !== null) {
-            $license = new License($this->license);
-
-            $this->f_license = $license->getLinkFormatted();
-        }
     }
 
     /**
@@ -2302,6 +2297,19 @@ class Song extends database_object implements
         return $this->getSongDeleter()->delete($this);
     }
 
+    public function getLicense(): ?License
+    {
+        if (
+            AmpConfig::get('licensing') &&
+            $this->licenseObj !== null &&
+            $this->license !== null
+        ) {
+            $this->licenseObj = $this->getLicenseRepository()->findById($this->license);
+        }
+
+        return $this->licenseObj;
+    }
+
     /**
      * @deprecated
      */
@@ -2370,5 +2378,15 @@ class Song extends database_object implements
         global $dic;
 
         return $dic->get(ShareRepositoryInterface::class);
+    }
+
+    /**
+     * @deprecated inject dependency
+     */
+    private function getLicenseRepository(): LicenseRepositoryInterface
+    {
+        global $dic;
+
+        return $dic->get(LicenseRepositoryInterface::class);
     }
 }

--- a/tests/Gui/Song/SongViewAdapterTest.php
+++ b/tests/Gui/Song/SongViewAdapterTest.php
@@ -28,6 +28,7 @@ namespace Ampache\Gui\Song;
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
 use Ampache\MockeryTestCase;
+use Ampache\Repository\Model\License;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\Model\Rating;
 use Ampache\Repository\Model\Song;
@@ -375,9 +376,33 @@ class SongViewAdapterTest extends MockeryTestCase
         );
     }
 
-    public function testGetLicenseLinkReturnsValue(): void
+    public function testGetLicenseLinkReturnsValueIfSet(): void
     {
-        $this->song->f_license = null;
+        $license = $this->createMock(License::class);
+
+        $link = 'some-link';
+
+        $this->song->shouldReceive('getLicense')
+            ->withNoArgs()
+            ->once()
+            ->andReturn($license);
+
+        $license->expects(static::once())
+            ->method('getLinkFormatted')
+            ->willReturn($link);
+
+        $this->assertSame(
+            $link,
+            $this->subject->getLicenseLink()
+        );
+    }
+
+    public function testGetLicenseLinkReturnsEmptyStringIfNotSet(): void
+    {
+        $this->song->shouldReceive('getLicense')
+            ->withNoArgs()
+            ->once()
+            ->andReturnNull();
 
         $this->assertSame(
             '',

--- a/tests/Module/Application/Admin/License/EditActionTest.php
+++ b/tests/Module/Application/Admin/License/EditActionTest.php
@@ -27,43 +27,34 @@ namespace Ampache\Module\Application\Admin\License;
 
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\MockeryTestCase;
-use Ampache\Repository\Model\License;
-use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Module\Application\Exception\AccessDeniedException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Util\UiInterface;
 use Ampache\Repository\LicenseRepositoryInterface;
+use Ampache\Repository\Model\License;
 use Mockery\MockInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class EditActionTest extends MockeryTestCase
 {
-    /** @var MockInterface|UiInterface|null */
-    private MockInterface $ui;
+    private MockInterface&UiInterface $ui;
 
-    /** @var MockInterface|ConfigContainerInterface|null */
-    private MockInterface $configContainer;
+    private MockInterface&ConfigContainerInterface $configContainer;
 
-    /** @var MockInterface|ModelFactoryInterface|null */
-    private MockInterface $modelFactory;
+    private MockInterface&LicenseRepositoryInterface $licenseRepository;
 
-    /** @var MockInterface|LicenseRepositoryInterface|null */
-    private MockInterface $licenseRepository;
-
-    private ?EditAction $subject;
+    private EditAction $subject;
 
     protected function setUp(): void
     {
         $this->ui                = $this->mock(UiInterface::class);
         $this->configContainer   = $this->mock(ConfigContainerInterface::class);
-        $this->modelFactory      = $this->mock(ModelFactoryInterface::class);
         $this->licenseRepository = $this->mock(LicenseRepositoryInterface::class);
 
         $this->subject = new EditAction(
             $this->ui,
             $this->configContainer,
-            $this->modelFactory,
             $this->licenseRepository
         );
     }
@@ -113,11 +104,6 @@ class EditActionTest extends MockeryTestCase
             )
             ->once();
 
-        $license->shouldReceive('isNew')
-            ->withNoArgs()
-            ->once()
-            ->andReturnFalse();
-
         $this->configContainer->shouldReceive('getWebPath')
             ->withNoArgs()
             ->once()
@@ -133,7 +119,7 @@ class EditActionTest extends MockeryTestCase
             ->once()
             ->andReturn($data);
 
-        $this->modelFactory->shouldReceive('createLicense')
+        $this->licenseRepository->shouldReceive('findById')
             ->with($licenseId)
             ->once()
             ->andReturn($license);


### PR DESCRIPTION
- Use LicenseRepository::findById instead of direct class instantiation or the ModelFactory
- Replace License property-access by dedicated methods