### PR TITLE
Allow the user api method to return the current user info

### DIFF
--- a/docs/API-JSON-methods.md
+++ b/docs/API-JSON-methods.md
@@ -2814,11 +2814,13 @@ This takes a url and returns the song object in question
 
 ### user
 
-This gets a user's public information
+This gets a user's public information.
+
+If the username is omitted, this will return the current api user's public information.
 
 | Input      | Type   | Description                         | Optional |
 |------------|--------|-------------------------------------|---------:|
-| 'username' | string | Username of the user to get details |       NO |
+| 'username' | string | Username of the user to get details |      YES |
 
 * return array
 

--- a/docs/API-XML-methods.md
+++ b/docs/API-XML-methods.md
@@ -2898,11 +2898,13 @@ This takes a url and returns the song object in question
 
 ### user
 
-This gets a user's public information
+This gets a user's public information.
+
+If the username is omitted, this will return the current api user's public information.
 
 | Input      | Type   | Description                             | Optional |
 |------------|--------|-----------------------------------------|---------:|
-| 'username' | string | Username of the user to get details for |       NO |
+| 'username' | string | Username of the user to get details for |      YES |
 
 * return
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3226,11 +3226,6 @@ parameters:
 			path: src/Module/Api/Method/UserEditMethod.php
 
 		-
-			message: "#^Method Ampache\\\\Module\\\\Api\\\\Method\\\\UserMethod\\:\\:user\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Module/Api/Method/UserMethod.php
-
-		-
 			message: "#^Method Ampache\\\\Module\\\\Api\\\\Method\\\\UserPreferenceMethod\\:\\:user_preference\\(\\) has parameter \\$input with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Module/Api/Method/UserPreferenceMethod.php

--- a/src/Module/Api/Method/UserMethod.php
+++ b/src/Module/Api/Method/UserMethod.php
@@ -26,6 +26,7 @@ declare(strict_types=0);
 namespace Ampache\Module\Api\Method;
 
 use Ampache\Module\Api\Exception\ErrorCodeEnum;
+use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Repository\Model\User;
 use Ampache\Module\Api\Api;
 use Ampache\Module\Api\Json_Data;
@@ -47,32 +48,37 @@ final class UserMethod
      * This get a user's public information
      *
      * username = (string) $username
+     *
+     * @param array{
+     *  username?: scalar,
+     *  api_format: string
+     * } $input
      */
     public static function user(array $input, User $user): bool
     {
-        if (!Api::check_parameter($input, array('username'), self::ACTION)) {
-            return false;
+        $username = $input['username'] ?? null;
+
+        // if the username is omitted, use the current users context to retrieve its own data
+        if ($username === null) {
+            $check_user = $user;
+
+            $fullinfo = true;
+        } else {
+            $userRepository = self::getUserRepository();
+            $check_user     = $userRepository->findByUsername((string) $username);
+            if (
+                $check_user === null ||
+                !in_array($check_user->getId(), $userRepository->getValid(true))
+            ) {
+                /* HINT: Requested object string/id/type */
+                Api::error(sprintf(T_('Not Found: %s'), $username), ErrorCodeEnum::NOT_FOUND, self::ACTION, 'username', $input['api_format']);
+
+                return false;
+            }
+
+            // get full info when you're an admin or searching for yourself
+            $fullinfo = $check_user->getId() === $user->getId() || $user->access === AccessLevelEnum::LEVEL_ADMIN;
         }
-        $username = (string) $input['username'];
-        if (empty($username)) {
-            debug_event(self::class, 'User `' . $username . '` cannot be found.', 1);
-            /* HINT: Requested object string/id/type ("album", "myusername", "some song title", 1298376) */
-            Api::error(sprintf(T_('Not Found: %s'), $username), ErrorCodeEnum::NOT_FOUND, self::ACTION, 'username', $input['api_format']);
-
-            return false;
-        }
-
-        $check_user = User::get_from_username($username);
-        $valid      = ($check_user instanceof User && $check_user->isNew() === false && in_array($check_user->id, static::getUserRepository()->getValid(true)));
-        if (!$valid) {
-            /* HINT: Requested object string/id/type ("album", "myusername", "some song title", 1298376) */
-            Api::error(sprintf(T_('Not Found: %s'), $username), ErrorCodeEnum::NOT_FOUND, self::ACTION, 'username', $input['api_format']);
-
-            return false;
-        }
-
-        // get full info when you're an admin or searching for yourself
-        $fullinfo = (($check_user->id == $user->id) || ($user->access === 100));
 
         ob_end_clean();
         switch ($input['api_format']) {


### PR DESCRIPTION
If a user uses the Api via Api-Key, the user name of the user is not known. Api methods that require the specification of a user name cannot be used in this way.

This change allows the `username` parameter to be omitted and in this case returns all the information of the currently used API user - including the username.