### PR TITLE
Start the implementation of a BaseRepository and a generic ModelInterface

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4676,11 +4676,6 @@ parameters:
 			path: src/Module/Application/Admin/Catalog/AddCatalogAction.php
 
 		-
-			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\|object\\|null given\\.$#"
-			count: 6
-			path: src/Module/Application/Admin/License/EditAction.php
-
-		-
 			message: "#^Parameter \\#1 \\$current of method Ampache\\\\Module\\\\System\\\\InstallationHelperInterface\\:\\:generate_config\\(\\) expects array, array\\|false given\\.$#"
 			count: 1
 			path: src/Module/Application/Admin/System/GenerateConfigAction.php

--- a/public/templates/show_edit_license.inc.php
+++ b/public/templates/show_edit_license.inc.php
@@ -23,36 +23,29 @@ declare(strict_types=0);
  *
  */
 
-use Ampache\Config\AmpConfig;
-use Ampache\Module\Util\Ui;
+use Ampache\Repository\Model\License;
 
-Ui::show_box_top(T_('Configure License')); ?>
-<form method="post" enctype="multipart/form-data" action="<?php echo AmpConfig::get('web_path'); ?>/admin/license.php?action=edit">
-<?php if (isset($license)) { ?>
-<input type="hidden" name="license_id" value="<?php echo $license->id; ?>" />
-<?php } ?>
+/** @var License $license */
+/** @var string $webPath */
+
+?>
+<form method="post" enctype="multipart/form-data" action="<?php echo $webPath; ?>/admin/license.php?action=edit">
+<input type="hidden" name="license_id" value="<?php echo $license->getId(); ?>" />
 <table class="tabledata">
 <tr>
     <td class="edit_dialog_content_header"><?php echo T_('Name'); ?></td>
-    <td><input type="text" name="name" value="<?php if (isset($license)) {
-        echo $license->name;
-    } ?>" autofocus /></td>
+    <td><input type="text" name="name" value="<?php echo $license->getName(); ?>" autofocus /></td>
 </tr>
 <tr>
     <td><?php echo T_('Description:'); ?></td>
-    <td><textarea rows="5" cols="70" maxlength="250" name="description"><?php if (isset($license)) {
-        echo $license->description;
-    } ?></textarea></td>
+    <td><textarea rows="5" cols="70" maxlength="250" name="description"><?php echo $license->getDescription(); ?></textarea></td>
 </tr>
 <tr>
     <td class="edit_dialog_content_header"><?php echo T_('External Link'); ?></td>
-    <td><input type="text" name="external_link" value="<?php if (isset($license)) {
-        echo $license->external_link;
-    } ?>" /></td>
+    <td><input type="text" name="external_link" value="<?php echo $license->getExternalLink(); ?>" /></td>
 </tr>
 <tr>
     <td><input type="submit" value="<?php echo T_('Confirm'); ?>" /></td>
 </tr>
 </table>
 </form>
-<?php Ui::show_box_bottom(); ?>

--- a/src/Module/Application/Admin/License/ShowCreateAction.php
+++ b/src/Module/Application/Admin/License/ShowCreateAction.php
@@ -25,11 +25,13 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Application\Admin\License;
 
+use Ampache\Config\ConfigContainerInterface;
 use Ampache\Module\Application\ApplicationActionInterface;
 use Ampache\Module\Application\Exception\AccessDeniedException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Util\UiInterface;
+use Ampache\Repository\LicenseRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -39,10 +41,18 @@ final class ShowCreateAction implements ApplicationActionInterface
 
     private UiInterface $ui;
 
+    private LicenseRepositoryInterface $licenseRepository;
+
+    private ConfigContainerInterface $configContainer;
+
     public function __construct(
-        UiInterface $ui
+        UiInterface $ui,
+        LicenseRepositoryInterface $licenseRepository,
+        ConfigContainerInterface $configContainer
     ) {
-        $this->ui = $ui;
+        $this->ui                = $ui;
+        $this->licenseRepository = $licenseRepository;
+        $this->configContainer   = $configContainer;
     }
 
     public function run(ServerRequestInterface $request, GuiGatekeeperInterface $gatekeeper): ?ResponseInterface
@@ -52,9 +62,15 @@ final class ShowCreateAction implements ApplicationActionInterface
         }
 
         $this->ui->showHeader();
-
-        $this->ui->show('show_edit_license.inc.php');
-
+        $this->ui->showBoxTop(T_('Create license'));
+        $this->ui->show(
+            'show_edit_license.inc.php',
+            [
+                'license' => $this->licenseRepository->prototype(),
+                'webPath' => $this->configContainer->getWebPath(),
+            ]
+        );
+        $this->ui->showBoxBottom();
         $this->ui->showQueryStats();
         $this->ui->showFooter();
 

--- a/src/Module/Application/Admin/License/ShowEditAction.php
+++ b/src/Module/Application/Admin/License/ShowEditAction.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=0);
+declare(strict_types=1);
 
 /**
  * vim:set softtabstop=4 shiftwidth=4 expandtab:
@@ -25,6 +25,7 @@ declare(strict_types=0);
 
 namespace Ampache\Module\Application\Admin\License;
 
+use Ampache\Config\ConfigContainerInterface;
 use Ampache\Module\Application\ApplicationActionInterface;
 use Ampache\Module\Application\Exception\AccessDeniedException;
 use Ampache\Module\Application\Exception\ObjectNotFoundException;
@@ -35,6 +36,9 @@ use Ampache\Repository\LicenseRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Shows the license edit-page
+ */
 final class ShowEditAction implements ApplicationActionInterface
 {
     public const REQUEST_KEY = 'show_edit';
@@ -43,12 +47,16 @@ final class ShowEditAction implements ApplicationActionInterface
 
     private LicenseRepositoryInterface $licenseRepository;
 
+    private ConfigContainerInterface $configContainer;
+
     public function __construct(
         UiInterface $ui,
-        LicenseRepositoryInterface $licenseRepository
+        LicenseRepositoryInterface $licenseRepository,
+        ConfigContainerInterface $configContainer
     ) {
         $this->ui                = $ui;
         $this->licenseRepository = $licenseRepository;
+        $this->configContainer   = $configContainer;
     }
 
     public function run(ServerRequestInterface $request, GuiGatekeeperInterface $gatekeeper): ?ResponseInterface
@@ -66,11 +74,15 @@ final class ShowEditAction implements ApplicationActionInterface
         }
 
         $this->ui->showHeader();
+        $this->ui->showBoxTop(T_('Edit license'));
         $this->ui->show(
             'show_edit_license.inc.php',
-            ['license' => $license]
+            [
+                'license' => $license,
+                'webPath' => $this->configContainer->getWebPath(),
+            ]
         );
-
+        $this->ui->showBoxBottom();
         $this->ui->showQueryStats();
         $this->ui->showFooter();
 

--- a/src/Repository/BaseRepository.php
+++ b/src/Repository/BaseRepository.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=3 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Repository;
+
+use Ampache\Module\Database\DatabaseConnectionInterface;
+use Ampache\Repository\Model\ModelInterface;
+use PDO;
+
+/**
+ * @template TModel as ModelInterface
+ */
+abstract class BaseRepository
+{
+    protected DatabaseConnectionInterface $connection;
+
+    /**
+     * @return class-string<TModel>
+     */
+    abstract protected function getModelClass(): string;
+
+    abstract protected function getTableName(): string;
+
+    /**
+     * @return list<mixed>
+     */
+    abstract protected function getPrototypeParameters(): array;
+
+    /**
+     * Retrieve a single item by its id
+     *
+     * @return null|TModel
+     */
+    public function findById(int $objectId): ?object
+    {
+        $result = $this->connection->query(
+            sprintf(
+                'SELECT * FROM `%s` WHERE `id` = ?',
+                $this->getTableName()
+            ),
+            [$objectId]
+        );
+        $result->setFetchMode(PDO::FETCH_CLASS, $this->getModelClass(), $this->getPrototypeParameters());
+
+        $shout = $result->fetch();
+        if ($shout === false) {
+            return null;
+        }
+
+        return $shout;
+    }
+
+    /**
+     * This function deletes the items entry
+     *
+     * @param TModel $record
+     */
+    public function delete(object $record): void
+    {
+        $this->connection->query(
+            sprintf(
+                'DELETE FROM `%s` WHERE `id` = ?',
+                $this->getTableName()
+            ),
+            [$record->getId()]
+        );
+    }
+
+    /**
+     * Returns a new item
+     *
+     * @return TModel
+     */
+    public function prototype(): ModelInterface
+    {
+        $className = $this->getModelClass();
+
+        return new $className(...$this->getPrototypeParameters());
+    }
+}

--- a/src/Repository/BaseRepositoryInterface.php
+++ b/src/Repository/BaseRepositoryInterface.php
@@ -1,7 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
- * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ * vim:set softtabstop=3 shiftwidth=4 expandtab:
  *
  * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
  * Copyright Ampache.org, 2001-2023
@@ -23,32 +25,31 @@
 
 namespace Ampache\Repository;
 
-use Ampache\Repository\Model\License;
-use Traversable;
+use Ampache\Repository\Model\ModelInterface;
 
 /**
- * @extends BaseRepositoryInterface<License>
+ * @template TModel of ModelInterface
  */
-interface LicenseRepositoryInterface extends BaseRepositoryInterface
+interface BaseRepositoryInterface
 {
     /**
-     * Returns a list of licenses accessible by the current user.
+     * Retrieve a single item by its id
      *
-     * @return Traversable<int, string>
+     * @return null|TModel
      */
-    public function getList(): Traversable;
+    public function findById(int $objectId): ?object;
 
     /**
-     * Searches for the License by name and external link
+     * This function deletes the items entry
+     *
+     * @param TModel $record
      */
-    public function find(string $searchValue): ?int;
+    public function delete(object $record): void;
 
     /**
-     * Persists the item in the database
+     * Returns a new item
      *
-     * If the item is new, it will be created. Otherwise, an update will happen
-     *
-     * @return null|non-negative-int
+     * @return TModel
      */
-    public function persist(License $license): ?int;
+    public function prototype(): ModelInterface;
 }

--- a/src/Repository/Model/BaseModel.php
+++ b/src/Repository/Model/BaseModel.php
@@ -1,7 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
- * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ * vim:set softtabstop=3 shiftwidth=4 expandtab:
  *
  * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
  * Copyright Ampache.org, 2001-2023
@@ -21,34 +23,28 @@
  *
  */
 
-namespace Ampache\Repository;
+namespace Ampache\Repository\Model;
 
-use Ampache\Repository\Model\License;
-use Traversable;
-
-/**
- * @extends BaseRepositoryInterface<License>
- */
-interface LicenseRepositoryInterface extends BaseRepositoryInterface
+abstract class BaseModel implements ModelInterface
 {
-    /**
-     * Returns a list of licenses accessible by the current user.
-     *
-     * @return Traversable<int, string>
-     */
-    public function getList(): Traversable;
+    /** @var int Primary key*/
+    protected int $id = 0;
 
     /**
-     * Searches for the License by name and external link
+     * Returns true if the object is new/unknown
      */
-    public function find(string $searchValue): ?int;
+    public function isNew(): bool
+    {
+        return $this->id === 0;
+    }
 
     /**
-     * Persists the item in the database
+     * Returns the id of the object
      *
-     * If the item is new, it will be created. Otherwise, an update will happen
-     *
-     * @return null|non-negative-int
+     * Will return `0` if the object is not persisted yet
      */
-    public function persist(License $license): ?int;
+    public function getId(): int
+    {
+        return $this->id;
+    }
 }

--- a/src/Repository/Model/Catalog.php
+++ b/src/Repository/Model/Catalog.php
@@ -2535,7 +2535,16 @@ abstract class Catalog extends database_object
             $licenseName       = (string) $results['license'];
             $licenseId         = $licenseRepository->find($licenseName);
 
-            $new_song->license = $licenseId === 0 ? $licenseRepository->create($licenseName, '', '') : $licenseId;
+            if ($licenseId === 0) {
+                $license = $licenseRepository->prototype()
+                    ->setName($licenseName);
+
+                $license->save();
+
+                $licenseId = $license->getId();
+            }
+
+            $new_song->license = $licenseId;
         } else {
             $new_song->license = null;
         }

--- a/src/Repository/Model/ModelInterface.php
+++ b/src/Repository/Model/ModelInterface.php
@@ -1,7 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
- * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ * vim:set softtabstop=3 shiftwidth=4 expandtab:
  *
  * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
  * Copyright Ampache.org, 2001-2023
@@ -21,34 +23,21 @@
  *
  */
 
-namespace Ampache\Repository;
+namespace Ampache\Repository\Model;
 
-use Ampache\Repository\Model\License;
-use Traversable;
-
-/**
- * @extends BaseRepositoryInterface<License>
- */
-interface LicenseRepositoryInterface extends BaseRepositoryInterface
+interface ModelInterface
 {
     /**
-     * Returns a list of licenses accessible by the current user.
+     * Returns the id of the object
      *
-     * @return Traversable<int, string>
+     * Will return `0` if the object is not persisted yet
      */
-    public function getList(): Traversable;
+    public function getId(): int;
+
+    public function isNew(): bool;
 
     /**
-     * Searches for the License by name and external link
+     * Persists the object
      */
-    public function find(string $searchValue): ?int;
-
-    /**
-     * Persists the item in the database
-     *
-     * If the item is new, it will be created. Otherwise, an update will happen
-     *
-     * @return null|non-negative-int
-     */
-    public function persist(License $license): ?int;
+    public function save(): void;
 }

--- a/src/Repository/Model/Shoutbox.php
+++ b/src/Repository/Model/Shoutbox.php
@@ -35,11 +35,8 @@ use DateTimeInterface;
  *
  * @see ShoutRepository
  */
-class Shoutbox
+class Shoutbox extends BaseModel
 {
-    /** @var int Primary key*/
-    private int $id = 0;
-
     /** @var int User-id */
     private int $user = 0;
 
@@ -67,24 +64,6 @@ class Shoutbox
         ShoutRepositoryInterface $shoutRepository
     ) {
         $this->shoutRepository = $shoutRepository;
-    }
-
-    /**
-     * Returns true if the object is new/unknown
-     */
-    public function isNew(): bool
-    {
-        return $this->id === 0;
-    }
-
-    /**
-     * Returns the id of the object
-     *
-     * Will return `0` if the object is not persisted yet
-     */
-    public function getId(): int
-    {
-        return $this->id;
     }
 
     /**

--- a/src/Repository/ShoutRepositoryInterface.php
+++ b/src/Repository/ShoutRepositoryInterface.php
@@ -24,10 +24,12 @@
 namespace Ampache\Repository;
 
 use Ampache\Repository\Model\Shoutbox;
-use Ampache\Repository\Model\User;
 use Traversable;
 
-interface ShoutRepositoryInterface
+/**
+ * @extends BaseRepositoryInterface<Shoutbox>
+ */
+interface ShoutRepositoryInterface extends BaseRepositoryInterface
 {
     /**
      * Returns all shout-box items for the provided object-type and -id
@@ -40,19 +42,9 @@ interface ShoutRepositoryInterface
     ): Traversable;
 
     /**
-     * Retrieve a single shout-item by its id
-     */
-    public function findById(int $shoutId): ?Shoutbox;
-
-    /**
      * Cleans out orphaned shout-box items
      */
     public function collectGarbage(?string $objectType = null, ?int $objectId = null): void;
-
-    /**
-     * this function deletes the shout-box entry
-     */
-    public function delete(Shoutbox $shout): void;
 
     /**
      * This returns the top user_shouts, shout-box objects are always shown regardless and count against the total
@@ -75,9 +67,4 @@ interface ShoutRepositoryInterface
      * Migrates an object associate shouts to a new object
      */
     public function migrate(string $objectType, int $oldObjectId, int $newObjectId): void;
-
-    /**
-     * Returns a new shout-item
-     */
-    public function prototype(): Shoutbox;
 }

--- a/tests/Module/Application/Admin/License/ShowEditActionTest.php
+++ b/tests/Module/Application/Admin/License/ShowEditActionTest.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Application\Admin\License;
 
+use Ampache\Config\ConfigContainerInterface;
 use Ampache\MockeryTestCase;
 use Ampache\Module\Application\Exception\ObjectNotFoundException;
 use Ampache\Repository\LicenseRepositoryInterface;
@@ -43,16 +44,20 @@ class ShowEditActionTest extends MockeryTestCase
 
     private LicenseRepositoryInterface&MockObject $licenseRepository;
 
+    private ConfigContainerInterface&MockObject $configContainer;
+
     private ShowEditAction $subject;
 
     protected function setUp(): void
     {
         $this->ui                = $this->mock(UiInterface::class);
         $this->licenseRepository = $this->createMock(LicenseRepositoryInterface::class);
+        $this->configContainer   = $this->createMock(ConfigContainerInterface::class);
 
         $this->subject = new ShowEditAction(
             $this->ui,
             $this->licenseRepository,
+            $this->configContainer,
         );
     }
 
@@ -81,6 +86,7 @@ class ShowEditActionTest extends MockeryTestCase
         $license    = $this->mock(License::class);
 
         $licenseId = 666;
+        $webPath   = 'some-path';
 
         $gatekeeper->shouldReceive('mayAccess')
             ->with(AccessLevelEnum::TYPE_INTERFACE, AccessLevelEnum::LEVEL_MANAGER)
@@ -97,11 +103,26 @@ class ShowEditActionTest extends MockeryTestCase
             ->with($licenseId)
             ->willReturn($license);
 
+        $this->configContainer->expects(static::once())
+            ->method('getWebPath')
+            ->willReturn($webPath);
+
         $this->ui->shouldReceive('showHeader')
             ->withNoArgs()
             ->once();
+        $this->ui->shouldReceive('showBoxTop')
+            ->with('Edit license')
+            ->once();
         $this->ui->shouldReceive('show')
-            ->with('show_edit_license.inc.php', ['license' => $license])
+            ->with(
+                'show_edit_license.inc.php',
+                [
+                    'license' => $license,
+                    'webPath' => $webPath,
+                ]
+            )
+            ->once();
+        $this->ui->shouldReceive('showBoxBottom')
             ->once();
         $this->ui->shouldReceive('showQueryStats')
             ->withNoArgs()

--- a/tests/Repository/Model/LicenseTest.php
+++ b/tests/Repository/Model/LicenseTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=3 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Repository\Model;
+
+use Ampache\Repository\LicenseRepositoryInterface;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class LicenseTest extends TestCase
+{
+    private LicenseRepositoryInterface&MockObject $licenseRepository;
+
+    private License $subject;
+
+    protected function setUp(): void
+    {
+        $this->licenseRepository = $this->createMock(LicenseRepositoryInterface::class);
+
+        $this->subject = new License(
+            $this->licenseRepository,
+        );
+    }
+
+    public function testIsNewReturnsTrueIfIdIsZero(): void
+    {
+        static::assertTrue(
+            $this->subject->isNew()
+        );
+    }
+
+    public function testIsNewReturnsTrueIfIdIsNotZero(): void
+    {
+        $licenseId = 666;
+
+        $this->licenseRepository->expects(static::once())
+            ->method('persist')
+            ->with($this->subject)
+            ->willReturn($licenseId);
+
+        $this->subject->save();
+
+        static::assertFalse(
+            $this->subject->isNew()
+        );
+        static::assertSame(
+            $licenseId,
+            $this->subject->getId()
+        );
+    }
+
+    #[DataProvider(methodName: 'setterGetterDataProvider')]
+    public function testGetterReturnsSetData(
+        string $getterMethod,
+        string $setterMethod,
+        mixed $defaultValue,
+        mixed $setValue
+    ): void {
+        static::assertSame(
+            $defaultValue,
+            call_user_func_array([$this->subject, $getterMethod], [])
+        );
+
+        call_user_func_array([$this->subject, $setterMethod], [$setValue]);
+
+        static::assertSame(
+            $setValue,
+            call_user_func_array([$this->subject, $getterMethod], [])
+        );
+    }
+
+    public static function setterGetterDataProvider(): Generator
+    {
+        yield ['getName', 'setName', '', 'some-name'];
+        yield ['getDescription', 'setDescription', '', 'some-description'];
+        yield ['getExternalLink', 'setExternalLink', '', 'some-link'];
+    }
+
+    public function testGetLinkFormattedReturnsFormattedExternalLink(): void
+    {
+        $link = 'some-link';
+        $name = 'some-name';
+
+        $this->subject->setName($name);
+        $this->subject->setExternalLink($link);
+
+        static::assertSame(
+            sprintf(
+                '<a href="%s">%s</a>',
+                $link,
+                $name
+            ),
+            $this->subject->getLinkFormatted()
+        );
+    }
+
+    public function testGetLinkFormattedReturnsNameIfLinkIsEmpty(): void
+    {
+        $name = 'some-name';
+
+        $this->subject->setName($name);
+
+        static::assertSame(
+            $name,
+            $this->subject->getLinkFormatted()
+        );
+    }
+}

--- a/tests/Repository/RepositoryTestTrait.php
+++ b/tests/Repository/RepositoryTestTrait.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=3 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Repository;
+
+use PDO;
+use PDOStatement;
+
+trait RepositoryTestTrait
+{
+    public function runFindByIdTrait(
+        string $tableName,
+        string $className,
+        array $parameters
+    ): void {
+        $itemId = 666;
+
+        $result = $this->createMock(PDOStatement::class);
+
+        $this->connection->expects(static::once())
+            ->method('query')
+            ->with(
+                sprintf(
+                    'SELECT * FROM `%s` WHERE `id` = ?',
+                    $tableName
+                ),
+                [$itemId]
+            )
+            ->willReturn($result);
+
+        $result->expects(static::once())
+            ->method('setFetchMode')
+            ->with(PDO::FETCH_CLASS, $className, $parameters);
+        $result->expects(static::once())
+            ->method('fetch')
+            ->willReturn(false);
+
+        static::assertNull(
+            $this->subject->findById($itemId)
+        );
+    }
+
+    public function testPrototypeYieldsNewItems(): void
+    {
+        $result = $this->subject->prototype();
+
+        static::assertTrue(
+            $result->isNew()
+        );
+
+        static::assertNotSame(
+            spl_object_hash($result),
+            spl_object_hash($this->subject->prototype())
+        );
+    }
+}

--- a/tests/Repository/ShoutRepositoryTest.php
+++ b/tests/Repository/ShoutRepositoryTest.php
@@ -38,6 +38,7 @@ use SEEC\PhpUnit\Helper\ConsecutiveParams;
 class ShoutRepositoryTest extends TestCase
 {
     use ConsecutiveParams;
+    use RepositoryTestTrait;
 
     private DatabaseConnectionInterface&MockObject $connection;
 
@@ -416,17 +417,12 @@ class ShoutRepositoryTest extends TestCase
         $this->subject->migrate($objectType, $oldId, $newId);
     }
 
-    public function testPrototypeYieldsNewItems(): void
+    public function testFindByIdPerformsTest(): void
     {
-        $result = $this->subject->prototype();
-
-        static::assertTrue(
-            $result->isNew()
-        );
-
-        static::assertNotSame(
-            spl_object_hash($result),
-            spl_object_hash($this->subject->prototype())
+        $this->runFindByIdTrait(
+            'user_shout',
+            Shoutbox::class,
+            [$this->subject]
         );
     }
 }


### PR DESCRIPTION
The BaseRepository defines a set of standard-methods (like `delete`, `prototype`, `findById`, etc..) for all inherting repositories. Make use of the BaseRepo in License- and ShoutRepo