### PR TITLE
Use the name provided by musicbrainz rather than the ALBUMARTIST tag

### DIFF
--- a/src/Repository/Model/Artist.php
+++ b/src/Repository/Model/Artist.php
@@ -706,9 +706,9 @@ class Artist extends database_object implements library_item, GarbageCollectible
 
         // prefer the name of the artist as provided by MusicBrainz
         if (!empty($mbid)) {
-            $plugin = new Plugin('musicbrainz');
+            $plugin      = new Plugin('musicbrainz');
             $parsed_mbid = VaInfo::parse_mbid($mbid);
-            $data   = $plugin->_plugin->get_artist($parsed_mbid);
+            $data        = $plugin->_plugin->get_artist($parsed_mbid);
             if (array_key_exists('name', $data)) {
                 $trimmed = Catalog::trim_prefix(trim((string)$data['name']));
                 $name    = $trimmed['string'];

--- a/src/Repository/Model/Artist.php
+++ b/src/Repository/Model/Artist.php
@@ -703,6 +703,19 @@ class Artist extends database_object implements library_item, GarbageCollectible
         if ($readonly) {
             return null;
         }
+
+        // prefer the name of the artist as provided by MusicBrainz
+        if (!empty($mbid)) {
+            $plugin = new Plugin('musicbrainz');
+            $parsed_mbid = VaInfo::parse_mbid($mbid);
+            $data   = $plugin->_plugin->get_artist($parsed_mbid);
+            if (array_key_exists('name', $data)) {
+                $trimmed = Catalog::trim_prefix(trim((string)$data['name']));
+                $name    = $trimmed['string'];
+                $prefix  = $trimmed['prefix'];
+            }
+        }
+
         // if all else fails, insert a new artist, cache it and return the id
         $sql  = 'INSERT INTO `artist` (`name`, `prefix`, `mbid`) ' . 'VALUES(?, ?, ?)';
         $mbid = !empty($mbid) ? $mbid : null;


### PR DESCRIPTION
This PR is a potential solution for #3833 . It basically sets the name that musicbrainz provides when creating a new album artist.

I don't find this solution particularly elegant for a couple of things:

1. It duplicates code that is found in function` check_mbid()`.
2. It assumes that the musicbrainz plugin is enabled. However this is already the case for `check_mbid()` function, so maybe it is the time to promote the plugin to be part of the core, since ampache already relies on musicbrainz metadata extensively for its correct behaviour.

Maybe this can be merged for the time being to fix the bug, but in the long run it is probably better to refactor the logic when creating a new artist to avoid a cleaner code.

BTW, other possibility to solve #3833 is to "properly" parse the `ALBUMARTIST` tag. However I find that prone to error the general case. If no mbid are available then that's the only option, but if mbid do exist then I think the best option is to rely on a proper musicbrainz query. 