### PR TITLE
Add specific error if the SQL query is empty

### DIFF
--- a/src/Module/System/Dba.php
+++ b/src/Module/System/Dba.php
@@ -55,6 +55,9 @@ class Dba
     {
         // json_encode throws errors about UTF-8 cleanliness, which we don't care about here.
         //debug_event(__CLASS__, $sql . ' ' . json_encode($params), 5);
+        if (empty(trim($sql))) {
+            return false;
+        }
 
         // Be aggressive, be strong, be dumb
         $tries = 0;
@@ -80,11 +83,6 @@ class Dba
             return false;
         }
 
-        self::$_sql = $sql;
-        if (empty(trim(self::$_sql))) {
-            debug_event(__CLASS__, 'Error_query SQL: the QUERY is empty', 1);
-            return false;
-        }
         try {
             // Run the query
             if (!empty($params) && strpos((string)self::$_sql, '?')) {

--- a/src/Module/System/Dba.php
+++ b/src/Module/System/Dba.php
@@ -81,6 +81,10 @@ class Dba
         }
 
         self::$_sql = $sql;
+        if (empty(trim(self::$_sql))) {
+            debug_event(__CLASS__, 'Error_query SQL: the QUERY is empty', 1);
+            return false;
+        }
         try {
             // Run the query
             if (!empty($params) && strpos((string)self::$_sql, '?')) {


### PR DESCRIPTION
Sometimes there is an error about bad syntax of the SQL query, but it's because the query is empty (sometimes it's just space).

Add specific error in the log about that. Will allow further debug later.