### PR TITLE
Really show default favicon by default

### DIFF
--- a/src/Module/Util/Ui.php
+++ b/src/Module/Util/Ui.php
@@ -529,7 +529,7 @@ class Ui implements UiInterface
             echo "<style>#loginPage #headerlogo, #registerPage #headerlogo { background-image: url('" . AmpConfig::get('custom_login_logo') . "') !important; }</style>";
         }
 
-        $favicon = AmpConfig::get('custom_favicon', false) ?? AmpConfig::get('web_path') . "/favicon.ico";
+        $favicon = AmpConfig::get('custom_favicon', false) ?: AmpConfig::get('web_path') . "/favicon.ico";
         echo "<link rel='shortcut icon' href='" . $favicon . "' />\n";
     }
 


### PR DESCRIPTION
Since commit 0d1ece0866, the default favicon is never shown.

Since the default value of the `custom_favicon` is an empty string and the use of the the default value `false`, the result of `AmpConfig::get('custom_favicon', false)` will never be unset.

Using the `??` operator always returns the `custom_favicon` setting, even if its NULL or an empty string. This causes the default favicon to never being shown even in the absence of the `custon_favicon` setting.

This issue has been introduced in commit 0d1ece0866.

Change `??` to `?:` to use the value of the `custom_favicon` setting only if it a non-empty string (`false`, `NULL` and `""` would evaluate to false in the test).