### PR TITLE
Fix the publication date of RSS feeds.

### DIFF
--- a/src/Module/Util/Rss/AmpacheRss.php
+++ b/src/Module/Util/Rss/AmpacheRss.php
@@ -330,7 +330,7 @@ final class AmpacheRss implements AmpacheRssInterface
     private function load_recently_played(int $user_id, int &$pub_date): array
     {
         $results = array();
-        $data = Stats::get_recently_played($user_id, 'stream', 'song');
+        $data    = Stats::get_recently_played($user_id, 'stream', 'song');
 
         foreach ($data as $item) {
             $client = new User($item['user']);

--- a/src/Module/Util/Rss/AmpacheRss.php
+++ b/src/Module/Util/Rss/AmpacheRss.php
@@ -137,6 +137,7 @@ final class AmpacheRss implements AmpacheRssInterface
                 },
                 'recently_played' => function () use ($user, &$pub_date): array {
                     $pub_date = 0;
+
                     return $this->load_recently_played($user->getId(), $pub_date);
                 },
                 'latest_album' => function () use ($rssToken): array {
@@ -337,7 +338,7 @@ final class AmpacheRss implements AmpacheRssInterface
             $row_id = ($item['user'] > 0) ? (int) $item['user'] : -1;
 
             $has_allowed_recent = (bool) $item['user_recent'];
-            $is_allowed_recent  = $user_id > 0 ? $user_id == $row_id : $has_allowed_recent;
+            $is_allowed_recent  = ($user_id > 0) ? $user_id == $row_id : $has_allowed_recent;
             if ($song->enabled && $is_allowed_recent) {
                 $description = '<p>' . T_('User') . ': ' . $client->username . '</p><p>' . T_('Title') . ': ' . $song->get_fullname() . '</p><p>' . T_('Artist') . ': ' . $song->get_artist_fullname() . '</p><p>' . T_('Album') . ': ' . $song->get_album_fullname() . '</p><p>' . T_('Play date') . ': ' . get_datetime($item['date']) . '</p>';
 

--- a/src/Module/Util/Rss/AmpacheRss.php
+++ b/src/Module/Util/Rss/AmpacheRss.php
@@ -30,7 +30,6 @@ use Ampache\Module\Api\Xml_Data;
 use Ampache\Module\Playback\Stream;
 use Ampache\Module\Shout\ShoutObjectLoaderInterface;
 use Ampache\Module\Statistics\Stats;
-use Ampache\Module\System\Core;
 use Ampache\Module\User\Authorization\UserKeyGeneratorInterface;
 use Ampache\Module\Util\InterfaceImplementationChecker;
 use Ampache\Module\Util\ObjectTypeToClassNameMapper;
@@ -350,8 +349,9 @@ final class AmpacheRss implements AmpacheRssInterface
                     'pubDate' => date("r", (int)$item['date'])
                 );
                 $results[] = $xml_array;
-                if ($pub_date == 0)
+                if ($pub_date == 0) {
                     $pub_date = (int)$item['date'];
+                }
             }
         } // end foreach
 

--- a/src/Module/Util/Rss/AmpacheRss.php
+++ b/src/Module/Util/Rss/AmpacheRss.php
@@ -135,10 +135,9 @@ final class AmpacheRss implements AmpacheRssInterface
 
                     return $this->load_now_playing();
                 },
-                'recently_played' => function () use ($rssToken, &$pub_date): array {
-                    $pub_date = $this->pubdate_recently_played();
-
-                    return $this->load_recently_played($rssToken);
+                'recently_played' => function () use ($user, &$pub_date): array {
+                    $pub_date = 0;
+                    return $this->load_recently_played($user->getId(), $pub_date);
                 },
                 'latest_album' => function () use ($rssToken): array {
                     return $this->load_latest_album($rssToken);
@@ -327,15 +326,10 @@ final class AmpacheRss implements AmpacheRssInterface
      *  pubDate: non-empty-string
      * }>
      */
-    private function load_recently_played(string $rsstoken): array
+    private function load_recently_played(int $user_id, int &$pub_date): array
     {
         $results = array();
-        $user    = $rsstoken !== ''
-            ? $this->userRepository->getByRssToken($rsstoken)
-            : null;
-        $data = ($user)
-            ? Stats::get_recently_played($user->id, 'stream', 'song')
-            : Stats::get_recently_played(-1, 'stream', 'song');
+        $data = Stats::get_recently_played($user_id, 'stream', 'song');
 
         foreach ($data as $item) {
             $client = new User($item['user']);
@@ -343,19 +337,20 @@ final class AmpacheRss implements AmpacheRssInterface
             $row_id = ($item['user'] > 0) ? (int) $item['user'] : -1;
 
             $has_allowed_recent = (bool) $item['user_recent'];
-            $is_allowed_recent  = ($user) ? $user->id == $row_id : $has_allowed_recent;
+            $is_allowed_recent  = $user_id > 0 ? $user_id == $row_id : $has_allowed_recent;
             if ($song->enabled && $is_allowed_recent) {
-                $song->format();
-                $description = '<p>' . T_('User') . ': ' . $client->username . '</p><p>' . T_('Title') . ': ' . $song->f_name . '</p><p>' . T_('Artist') . ': ' . $song->get_artist_fullname() . '</p><p>' . T_('Album') . ': ' . $song->f_album_full . '</p><p>' . T_('Play date') . ': ' . get_datetime($item['date']) . '</p>';
+                $description = '<p>' . T_('User') . ': ' . $client->username . '</p><p>' . T_('Title') . ': ' . $song->get_fullname() . '</p><p>' . T_('Artist') . ': ' . $song->get_artist_fullname() . '</p><p>' . T_('Album') . ': ' . $song->get_album_fullname() . '</p><p>' . T_('Play date') . ': ' . get_datetime($item['date']) . '</p>';
 
                 $xml_array = array(
-                    'title' => $song->f_name . ' - ' . $song->f_artist . ' - ' . $song->f_album,
+                    'title' => $song->get_fullname() . ' - ' . $song->get_artist_fullname() . ' - ' . $song->get_album_fullname(),
                     'link' => str_replace('&amp;', '&', (string)$song->get_link()),
                     'description' => $description,
                     'comments' => (string)$client->username,
                     'pubDate' => date("r", (int)$item['date'])
                 );
                 $results[] = $xml_array;
+                if ($pub_date == 0)
+                    $pub_date = (int)$item['date'];
             }
         } // end foreach
 
@@ -479,19 +474,6 @@ final class AmpacheRss implements AmpacheRssInterface
         } // end foreach
 
         return $results;
-    }
-
-    /**
-     * pubdate_recently_played
-     * This just returns the 'newest' Recently Played entry
-     */
-    private function pubdate_recently_played(): int
-    {
-        $user_id = Core::get_global('user')->id ?? -1;
-        $data    = Stats::get_recently_played($user_id, 'stream', 'song');
-        $element = array_shift($data);
-
-        return (int) $element['date'];
     }
 
     /**


### PR DESCRIPTION
This PR fixes the creation date of the RSS feed for the last played songs. Without that, the logs of ampache show the following error:
```
2024-03-04T17:35:48+00:00 [ampache] (log.lib) -> [Runtime Error] Trying to access array offset on value of type null in file src/Module/Util/Rss/AmpacheRss.php(491)
```
On top of that, the RSS publication date is set it unix time 0 (Thu Jan 01 00:00:00 1970 UTC).

After the fix, the publication date is correct:
```
...
        <pubDate>Wed, 06 Mar 2024 19:38:05 +0000</pubDate>
...
```
Also, I refactored a bit the function that publishes the last played songs and improved the performance. At least in my ampache server,  retrieving the RSS feed before took ~2.5 s round trip, and after this PR it takes ~0.55 s. In the case of asking without an rsstoken, which corresponds to retrieving all the played songs from all users (which allow it) the improvement is smaller: from ~4.5s to ~2.5s.