### PR TITLE
Implement a generic loader for library items

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8346,6 +8346,11 @@ parameters:
 			path: src/Module/Playback/Stream_Playlist.php
 
 		-
+			message: "#^Parameter \\#1 \\$className of static method Ampache\\\\Module\\\\Util\\\\ObjectTypeToClassNameMapper\\:\\:reverseMap\\(\\) expects class\\-string\\<Ampache\\\\Repository\\\\Model\\\\database_object\\>, class\\-string\\<Ampache\\\\Repository\\\\Model\\\\Media\\> given\\.$#"
+			count: 1
+			path: src/Module/Playback/Stream_Playlist.php
+
+		-
 			message: "#^Property Ampache\\\\Module\\\\Playback\\\\Stream_Playlist\\:\\:\\$id has no type specified\\.$#"
 			count: 1
 			path: src/Module/Playback/Stream_Playlist.php
@@ -11556,6 +11561,11 @@ parameters:
 			path: src/Module/WebDav/WebDavFile.php
 
 		-
+			message: "#^Parameter \\#1 \\$className of static method Ampache\\\\Module\\\\Util\\\\ObjectTypeToClassNameMapper\\:\\:reverseMap\\(\\) expects class\\-string\\<Ampache\\\\Repository\\\\Model\\\\database_object\\>, class\\-string\\<Ampache\\\\Repository\\\\Model\\\\Media\\> given\\.$#"
+			count: 1
+			path: src/Module/WebDav/WebDavFile.php
+
+		-
 			message: "#^Method Ampache\\\\Plugin\\\\Ampache7digital\\:\\:get_song_preview\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Plugin/Ampache7digital.php
@@ -12311,11 +12321,6 @@ parameters:
 			path: src/Repository/Model/Album.php
 
 		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Album\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/Album.php
-
-		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Album\\:\\:get_parent_array\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/Album.php
@@ -12357,11 +12362,6 @@ parameters:
 
 		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\AlbumDisk\\:\\:get_keywords\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/AlbumDisk.php
-
-		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\AlbumDisk\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/AlbumDisk.php
 
@@ -12581,11 +12581,6 @@ parameters:
 			path: src/Repository/Model/Artist.php
 
 		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Artist\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/Artist.php
-
-		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Artist\\:\\:remove_artist_map\\(\\) has parameter \\$artist_id with no type specified\\.$#"
 			count: 1
 			path: src/Repository/Model/Artist.php
@@ -12637,11 +12632,6 @@ parameters:
 
 		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Broadcast\\:\\:get_keywords\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/Broadcast.php
-
-		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Broadcast\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/Broadcast.php
 
@@ -12961,11 +12951,6 @@ parameters:
 			path: src/Repository/Model/Clip.php
 
 		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Clip\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/Clip.php
-
-		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Clip\\:\\:insert\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/Clip.php
@@ -13106,11 +13091,6 @@ parameters:
 			path: src/Repository/Model/Label.php
 
 		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Label\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/Label.php
-
-		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Label\\:\\:update\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/Label.php
@@ -13157,11 +13137,6 @@ parameters:
 
 		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Live_Stream\\:\\:get_keywords\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/Live_Stream.php
-
-		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Live_Stream\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/Live_Stream.php
 
@@ -13391,11 +13366,6 @@ parameters:
 			path: src/Repository/Model/Podcast.php
 
 		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Podcast\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/Podcast.php
-
-		-
 			message: "#^Default value of the parameter \\#4 \\$uid \\(false\\) of method Ampache\\\\Repository\\\\Model\\\\Podcast_Episode\\:\\:play_url\\(\\) is incompatible with type int\\|string\\.$#"
 			count: 1
 			path: src/Repository/Model/Podcast_Episode.php
@@ -13412,11 +13382,6 @@ parameters:
 
 		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Podcast_Episode\\:\\:get_keywords\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/Podcast_Episode.php
-
-		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Podcast_Episode\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/Podcast_Episode.php
 
@@ -13816,11 +13781,6 @@ parameters:
 			path: src/Repository/Model/Song.php
 
 		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Song\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/Song.php
-
-		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Song\\:\\:get_parent_array\\(\\) has parameter \\$type with no type specified\\.$#"
 			count: 1
 			path: src/Repository/Model/Song.php
@@ -13912,11 +13872,6 @@ parameters:
 
 		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Song_Preview\\:\\:get_childrens\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/Song_Preview.php
-
-		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Song_Preview\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/Song_Preview.php
 
@@ -14021,11 +13976,6 @@ parameters:
 			path: src/Repository/Model/TVShow_Episode.php
 
 		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\TVShow_Episode\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/TVShow_Episode.php
-
-		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\TVShow_Episode\\:\\:get_release_item_art\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/TVShow_Episode.php
@@ -14102,11 +14052,6 @@ parameters:
 
 		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\TVShow_Season\\:\\:get_keywords\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/TVShow_Season.php
-
-		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\TVShow_Season\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/TVShow_Season.php
 
@@ -14216,11 +14161,6 @@ parameters:
 			path: src/Repository/Model/Tag.php
 
 		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Tag\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/Tag.php
-
-		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Tag\\:\\:get_tags\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/Tag.php
@@ -14302,11 +14242,6 @@ parameters:
 
 		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\TvShow\\:\\:get_keywords\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/TvShow.php
-
-		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\TvShow\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/TvShow.php
 
@@ -14521,11 +14456,6 @@ parameters:
 			path: src/Repository/Model/Video.php
 
 		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Video\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/Video.php
-
-		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\Video\\:\\:get_release_item_art\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/Video.php
@@ -14701,11 +14631,6 @@ parameters:
 			path: src/Repository/Model/playable_item.php
 
 		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\playable_item\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/playable_item.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:get_parent\\(\\)\\.$#"
 			count: 1
 			path: src/Repository/Model/playlist_object.php
@@ -14732,11 +14657,6 @@ parameters:
 
 		-
 			message: "#^Method Ampache\\\\Repository\\\\Model\\\\playlist_object\\:\\:get_keywords\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Repository/Model/playlist_object.php
-
-		-
-			message: "#^Method Ampache\\\\Repository\\\\Model\\\\playlist_object\\:\\:get_parent\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Repository/Model/playlist_object.php
 

--- a/public/templates/show_add_share.inc.php
+++ b/public/templates/show_add_share.inc.php
@@ -29,11 +29,18 @@ use Ampache\Module\Authorization\AccessFunctionEnum;
 use Ampache\Module\System\AmpError;
 use Ampache\Module\System\Core;
 use Ampache\Module\Util\Ui;
+use Ampache\Repository\Model\Album;
+use Ampache\Repository\Model\AlbumDisk;
+use Ampache\Repository\Model\LibraryItemEnum;
+use Ampache\Repository\Model\Playlist;
+use Ampache\Repository\Model\Podcast_Episode;
+use Ampache\Repository\Model\Song;
+use Ampache\Repository\Model\Video;
 
 /** @var bool $has_failed */
 /** @var string $message */
-/** @var Ampache\Repository\Model\Song|Ampache\Repository\Model\Album|Ampache\Repository\Model\AlbumDisk|Ampache\Repository\Model\Playlist|Ampache\Repository\Model\Video|Ampache\Repository\Model\Podcast_Episode $object */
-/** @var string $object_type */
+/** @var Song|Album|AlbumDisk|Playlist|Video|Podcast_Episode $object */
+/** @var LibraryItemEnum $object_type */
 /** @var string $token */
 /** @var bool $isZipable */
 
@@ -42,7 +49,7 @@ $allow_download = $_REQUEST['allow_download'] ?? false;
 
 Ui::show_box_top(T_('Create Share'), 'box box_add_share'); ?>
 <form name="share" method="post" action="<?php echo AmpConfig::get('web_path'); ?>/share.php?action=create">
-<input type="hidden" name="type" value="<?php echo scrub_out($object_type); ?>" />
+<input type="hidden" name="type" value="<?php echo $object_type->value; ?>" />
 <input type="hidden" name="id" value="<?php echo $object->getId(); ?>" />
 <table class="tabledata">
 <tr>
@@ -69,7 +76,7 @@ Ui::show_box_top(T_('Create Share'), 'box box_add_share'); ?>
     <td><?php echo T_('Allow Stream'); ?></td>
     <td><input type="checkbox" name="allow_stream" value="1" <?php echo ($allow_stream || Core::get_server('REQUEST_METHOD') === 'GET') ? 'checked' : ''; ?> /></td>
 </tr>
-<?php if ((in_array($object_type, array('song', 'video', 'podcast_episode')) && (Access::check_function(AccessFunctionEnum::FUNCTION_DOWNLOAD))) || (Access::check_function(AccessFunctionEnum::FUNCTION_BATCH_DOWNLOAD) && $isZipable)) { ?>
+<?php if ((in_array($object_type, [LibraryItemEnum::SONG, LibraryItemEnum::VIDEO, LibraryItemEnum::PODCAST_EPISODE], true) && (Access::check_function(AccessFunctionEnum::FUNCTION_DOWNLOAD))) || (Access::check_function(AccessFunctionEnum::FUNCTION_BATCH_DOWNLOAD) && $isZipable)) { ?>
 <tr>
     <td><?php echo T_('Allow Download'); ?></td>
     <td><input type="checkbox" name="allow_download" value="1" <?php echo ($allow_download || Core::get_server('REQUEST_METHOD') === 'GET') ? 'checked' : ''; ?> /></td>

--- a/public/templates/show_add_shout.inc.php
+++ b/public/templates/show_add_shout.inc.php
@@ -30,11 +30,12 @@ use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Shout\ShoutRendererInterface;
 use Ampache\Module\System\Core;
 use Ampache\Module\Util\Ui;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Shoutbox;
 
 /** @var string $data */
 /** @var Ampache\Repository\Model\library_item $object */
-/** @var string $object_type */
+/** @var LibraryItemEnum $object_type */
 /** @var Traversable<Shoutbox> $shouts */
 /** @var ShoutRendererInterface $shoutRenderer */
 ?>
@@ -64,7 +65,7 @@ $boxtitle = T_('Post to Shoutbox');
     <td>
         <?php echo Core::form_register('add_shout'); ?>
         <input type="hidden" name="object_id" value="<?php echo $object->getId(); ?>" />
-        <input type="hidden" name="object_type" value="<?php echo $object_type; ?>" />
+        <input type="hidden" name="object_type" value="<?php echo $object_type->value; ?>" />
         <input type="hidden" name="data" value="<?php echo $data; ?>" />
         <input type="submit" value="<?php echo T_('Create'); ?>" /></td>
 </tr>

--- a/src/Application/Api/Ajax/Handler/SongAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/SongAjaxHandler.php
@@ -32,6 +32,7 @@ use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Shout\ShoutRendererInterface;
 use Ampache\Module\System\Core;
 use Ampache\Module\Util\RequestParserInterface;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Shoutbox;
 use Ampache\Repository\Model\Song;
 use Ampache\Repository\ShoutRepositoryInterface;
@@ -86,10 +87,10 @@ final class SongAjaxHandler implements AjaxHandlerInterface
                 break;
             case 'shouts':
                 ob_start();
-                $type   = Core::get_request('object_type');
+                $type   = LibraryItemEnum::from(Core::get_request('object_type'));
                 $songid = (int) filter_input(INPUT_GET, 'object_id', FILTER_SANITIZE_NUMBER_INT);
 
-                if ($type == "song" && $songid > 0) {
+                if ($type === LibraryItemEnum::SONG && $songid > 0) {
                     $media  = new Song($songid);
                     $shouts = $this->shoutRepository->getBy($type, $songid);
                     echo "<script>\r\n";

--- a/src/Module/Api/Method/Api3/PlaylistSongs3Method.php
+++ b/src/Module/Api/Method/Api3/PlaylistSongs3Method.php
@@ -25,6 +25,7 @@ declare(strict_types=0);
 
 namespace Ampache\Module\Api\Method\Api3;
 
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Playlist;
 use Ampache\Module\Api\Xml3_Data;
 use Ampache\Repository\Model\User;
@@ -47,7 +48,7 @@ final class PlaylistSongs3Method
 
         $results = array();
         foreach ($items as $object) {
-            if ($object['object_type'] == 'song') {
+            if ($object['object_type'] === LibraryItemEnum::SONG) {
                 $results[] = $object['object_id'];
             }
         } // end foreach

--- a/src/Module/Api/Method/Api4/Localplay4Method.php
+++ b/src/Module/Api/Method/Api4/Localplay4Method.php
@@ -30,6 +30,7 @@ use Ampache\Module\Api\Api4;
 use Ampache\Module\Api\Xml4_Data;
 use Ampache\Module\Playback\Localplay\LocalPlay;
 use Ampache\Module\Playback\Stream_Playlist;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\User;
 
 /**
@@ -70,8 +71,9 @@ final class Localplay4Method
             case 'add':
                 // for add commands get the object details
                 $object_id = (int)($input['oid'] ?? 0);
-                $type      = $input['type'] ? (string) $input['type'] : 'Song';
-                if (!AmpConfig::get('allow_video') && $type == 'Video') {
+                $type      = LibraryItemEnum::tryFrom((string) ($input['type'] ?? '')) ?? LibraryItemEnum::SONG;
+
+                if (!AmpConfig::get('allow_video') && $type === LibraryItemEnum::VIDEO) {
                     Api4::message('error', T_('Access Denied: allow_video is not enabled.'), '400', $input['api_format']);
 
                     return false;

--- a/src/Module/Api/Method/Api4/ShareCreate4Method.php
+++ b/src/Module/Api/Method/Api4/ShareCreate4Method.php
@@ -32,6 +32,7 @@ use Ampache\Module\Util\InterfaceImplementationChecker;
 use Ampache\Module\Util\ObjectTypeToClassNameMapper;
 use Ampache\Repository\Model\Catalog;
 use Ampache\Repository\Model\library_item;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Share;
 use Ampache\Module\Api\Api4;
 use Ampache\Module\Api\Json4_Data;
@@ -106,7 +107,7 @@ final class ShareCreate4Method
 
             $results[] = $shareCreator->create(
                 $user,
-                $object_type,
+                LibraryItemEnum::from($object_type),
                 $object_id,
                 true,
                 $functionChecker->check(AccessFunctionEnum::FUNCTION_DOWNLOAD),

--- a/src/Module/Api/Method/Api5/Localplay5Method.php
+++ b/src/Module/Api/Method/Api5/Localplay5Method.php
@@ -33,6 +33,7 @@ use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Playback\Localplay\LocalPlay;
 use Ampache\Module\Playback\Stream_Playlist;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\User;
 
 /**
@@ -79,8 +80,9 @@ final class Localplay5Method
             case 'add':
                 // for add commands get the object details
                 $object_id = (int)($input['oid'] ?? 0);
-                $type      = $input['type'] ? (string) $input['type'] : 'Song';
-                if (!AmpConfig::get('allow_video') && $type == 'Video') {
+                $type      = LibraryItemEnum::tryFrom((string) ($input['type'] ?? '')) ?? LibraryItemEnum::SONG;
+
+                if (!AmpConfig::get('allow_video') && $type === LibraryItemEnum::VIDEO) {
                     Api5::error(T_('Enable: video'), ErrorCodeEnum::ACCESS_DENIED, self::ACTION, 'system', $input['api_format']);
 
                     return false;

--- a/src/Module/Api/Method/Api5/ShareCreate5Method.php
+++ b/src/Module/Api/Method/Api5/ShareCreate5Method.php
@@ -32,6 +32,7 @@ use Ampache\Module\Share\ShareCreatorInterface;
 use Ampache\Repository\Model\Album;
 use Ampache\Repository\Model\Artist;
 use Ampache\Repository\Model\Catalog;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Share;
 use Ampache\Module\Api\Api5;
 use Ampache\Module\Api\Json5_Data;
@@ -113,7 +114,7 @@ final class ShareCreate5Method
 
             $share = $shareCreator->create(
                 $user,
-                $object_type,
+                LibraryItemEnum::from($object_type),
                 $object_id,
                 true,
                 $functionChecker->check(AccessFunctionEnum::FUNCTION_DOWNLOAD),

--- a/src/Module/Api/Method/LocalplayMethod.php
+++ b/src/Module/Api/Method/LocalplayMethod.php
@@ -33,6 +33,7 @@ use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Playback\Localplay\LocalPlay;
 use Ampache\Module\Playback\Stream_Playlist;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\User;
 
 /**
@@ -80,8 +81,9 @@ final class LocalplayMethod
             case 'add':
                 // for add commands get the object details
                 $object_id = (int)($input['oid'] ?? 0);
-                $type      = $input['type'] ? (string) $input['type'] : 'Song';
-                if (!AmpConfig::get('allow_video') && $type == 'Video') {
+                $type      = LibraryItemEnum::tryFrom((string) ($input['type'] ?? '')) ?? LibraryItemEnum::SONG;
+
+                if (!AmpConfig::get('allow_video') && $type === LibraryItemEnum::VIDEO) {
                     Api::error(T_('Enable: video'), ErrorCodeEnum::ACCESS_DENIED, self::ACTION, 'system', $input['api_format']);
 
                     return false;

--- a/src/Module/Api/Method/ShareCreateMethod.php
+++ b/src/Module/Api/Method/ShareCreateMethod.php
@@ -32,6 +32,7 @@ use Ampache\Module\Share\ShareCreatorInterface;
 use Ampache\Repository\Model\Album;
 use Ampache\Repository\Model\Artist;
 use Ampache\Repository\Model\Catalog;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Live_Stream;
 use Ampache\Repository\Model\Playlist;
 use Ampache\Repository\Model\Podcast;
@@ -125,7 +126,7 @@ final class ShareCreateMethod
 
             $share = $shareCreator->create(
                 $user,
-                $object_type,
+                LibraryItemEnum::from($object_type),
                 $object_id,
                 true,
                 $functionChecker->check(AccessFunctionEnum::FUNCTION_DOWNLOAD),

--- a/src/Module/Api/Subsonic_Api.php
+++ b/src/Module/Api/Subsonic_Api.php
@@ -55,6 +55,7 @@ use Ampache\Repository\Model\Art;
 use Ampache\Repository\Model\Artist;
 use Ampache\Repository\Model\Bookmark;
 use Ampache\Repository\Model\Catalog;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Live_Stream;
 use Ampache\Repository\Model\Playlist;
 use Ampache\Repository\Model\Podcast;
@@ -1531,9 +1532,9 @@ class Subsonic_Api
         $bitRate = $input['bitRate'] ?? false;
         $media   = array();
         if (Subsonic_Xml_Data::_isSong($fileid)) {
-            $media['object_type'] = 'song';
+            $media['object_type'] = LibraryItemEnum::SONG;
         } elseif (Subsonic_Xml_Data::_isVideo($fileid)) {
-            $media['object_type'] = 'video';
+            $media['object_type'] = LibraryItemEnum::VIDEO;
         } else {
             self::_apiOutput(
                 $input,
@@ -1932,7 +1933,7 @@ class Subsonic_Api
                 $shares   = array();
                 $shares[] = $shareCreator->create(
                     $user,
-                    $object_type,
+                    LibraryItemEnum::from($object_type),
                     $object_id,
                     true,
                     Access::check_function(AccessFunctionEnum::FUNCTION_DOWNLOAD),

--- a/src/Module/Application/Batch/DefaultAction.php
+++ b/src/Module/Application/Batch/DefaultAction.php
@@ -203,7 +203,7 @@ final class DefaultAction implements ApplicationActionInterface
         foreach ($media_ids as $element) {
             if (is_array($element)) {
                 if (isset($element['object_type'])) {
-                    $type    = $element['object_type'];
+                    $type    = $element['object_type']->value;
                     $mediaid = $element['object_id'];
                 } else {
                     $type    = array_shift($element);
@@ -223,7 +223,7 @@ final class DefaultAction implements ApplicationActionInterface
                 $dirname    = '';
                 $parent     = $media->get_parent();
                 if ($parent != null) {
-                    $className = ObjectTypeToClassNameMapper::map($parent['object_type']);
+                    $className = ObjectTypeToClassNameMapper::map($parent['object_type']->value);
                     /** @var class-string<library_item> $className */
                     $pobj = new $className($parent['object_id']);
                     $pobj->format();

--- a/src/Module/Application/Playback/Play2Action.php
+++ b/src/Module/Application/Playback/Play2Action.php
@@ -413,7 +413,7 @@ final class Play2Action implements ApplicationActionInterface
                 return null;
             }
 
-            if (!$share->is_shared_media($object_id)) {
+            if (!$share->is_shared_media((int) $object_id)) {
                 header('HTTP/1.1 403 Access Unauthorized');
 
                 return null;

--- a/src/Module/Application/Playback/PlayAction.php
+++ b/src/Module/Application/Playback/PlayAction.php
@@ -387,7 +387,7 @@ final class PlayAction implements ApplicationActionInterface
                 return null;
             }
 
-            if (!$share->is_shared_media($object_id)) {
+            if (!$share->is_shared_media((int) $object_id)) {
                 header('HTTP/1.1 403 Access Unauthorized');
 
                 return null;

--- a/src/Module/Application/Playlist/RemoveDuplicatesAction.php
+++ b/src/Module/Application/Playlist/RemoveDuplicatesAction.php
@@ -69,11 +69,11 @@ final class RemoveDuplicatesAction implements ApplicationActionInterface
         $map          = [];
         $items        = $playlist->get_items();
         foreach ($items as $item) {
-            if (!array_key_exists($item['object_type'], $map)) {
-                $map[$item['object_type']] = [];
+            if (!array_key_exists($item['object_type']->value, $map)) {
+                $map[$item['object_type']->value] = [];
             }
-            if (!in_array($item['object_id'], $map[$item['object_type']])) {
-                $map[$item['object_type']][] = $item['object_id'];
+            if (!in_array($item['object_id'], $map[$item['object_type']->value])) {
+                $map[$item['object_type']->value][] = $item['object_id'];
             } else {
                 $tracks_to_rm[] = $item['track_id'];
             }

--- a/src/Module/Application/Share/CreateAction.php
+++ b/src/Module/Application/Share/CreateAction.php
@@ -36,6 +36,7 @@ use Ampache\Module\Util\RequestParserInterface;
 use Ampache\Module\Util\ZipHandlerInterface;
 use Ampache\Repository\Model\Album;
 use Ampache\Repository\Model\AlbumDisk;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Playlist;
 use Ampache\Repository\Model\Share;
 use Ampache\Module\Application\ApplicationActionInterface;
@@ -103,7 +104,7 @@ final class CreateAction implements ApplicationActionInterface
 
         $share_id = $this->shareCreator->create(
             $user,
-            $_REQUEST['type'] ?? '',
+            LibraryItemEnum::from($_REQUEST['type'] ?? ''),
             (int)($_REQUEST['id'] ?? 0),
             (bool)($_REQUEST['allow_stream'] ?? 0),
             (bool)($_REQUEST['allow_download'] ?? 0),

--- a/src/Module/Application/Share/ExternalShareAction.php
+++ b/src/Module/Application/Share/ExternalShareAction.php
@@ -31,6 +31,7 @@ use Ampache\Config\ConfigurationKeyEnum;
 use Ampache\Module\Authorization\AccessFunctionEnum;
 use Ampache\Module\Share\ShareCreatorInterface;
 use Ampache\Module\Util\RequestParserInterface;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Plugin;
 use Ampache\Repository\Model\Share;
 use Ampache\Module\Application\ApplicationActionInterface;
@@ -97,10 +98,10 @@ final class ExternalShareAction implements ApplicationActionInterface
         }
         $plugin->load($user);
 
-        $type           = $this->requestParser->getFromRequest('type');
+        $type           = LibraryItemEnum::from($this->requestParser->getFromRequest('type'));
         $share_id       = $this->requestParser->getFromRequest('id');
         $secret         = $this->passwordGenerator->generate_token();
-        $allow_download = ($type == 'song' && $this->functionChecker->check(AccessFunctionEnum::FUNCTION_DOWNLOAD)) ||
+        $allow_download = ($type === LibraryItemEnum::SONG && $this->functionChecker->check(AccessFunctionEnum::FUNCTION_DOWNLOAD)) ||
             $this->functionChecker->check(AccessFunctionEnum::FUNCTION_BATCH_DOWNLOAD);
 
         $share_id = $this->shareCreator->create(

--- a/src/Module/Application/Shout/AddShoutAction.php
+++ b/src/Module/Application/Shout/AddShoutAction.php
@@ -35,6 +35,7 @@ use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Shout\ShoutCreatorInterface;
 use Ampache\Module\Shout\ShoutObjectLoaderInterface;
 use Ampache\Module\Util\RequestParserInterface;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -84,7 +85,7 @@ final class AddShoutAction implements ApplicationActionInterface
         }
 
         $body       = (array) $request->getParsedBody();
-        $objectType = $body['object_type'] ?? '';
+        $objectType = LibraryItemEnum::from($body['object_type'] ?? '');
         $objectId   = (int) ($body['object_id'] ?? 0);
         $text       = $body['comment'] ?? '';
         $isSticky   = array_key_exists('sticky', $body);
@@ -113,7 +114,7 @@ final class AddShoutAction implements ApplicationActionInterface
                 sprintf(
                     '%s/shout.php?action=show_add_shout&type=%s&id=%d',
                     $this->configContainer->getWebPath(),
-                    $objectType,
+                    $objectType->value,
                     $objectId
                 )
             );

--- a/src/Module/Application/Shout/ShowAddShoutAction.php
+++ b/src/Module/Application/Shout/ShowAddShoutAction.php
@@ -28,11 +28,11 @@ namespace Ampache\Module\Application\Shout;
 use Ampache\Module\Shout\ShoutObjectLoaderInterface;
 use Ampache\Module\Shout\ShoutRendererInterface;
 use Ampache\Module\Util\RequestParserInterface;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Song;
 use Ampache\Module\Application\ApplicationActionInterface;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\System\AmpError;
-use Ampache\Module\Util\ObjectTypeToClassNameMapper;
 use Ampache\Module\Util\UiInterface;
 use Ampache\Repository\ShoutRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -49,6 +49,7 @@ final class ShowAddShoutAction implements ApplicationActionInterface
     private ShoutRepositoryInterface $shoutRepository;
 
     private ShoutRendererInterface $shoutRenderer;
+
     private ShoutObjectLoaderInterface $shoutObjectLoader;
 
     public function __construct(
@@ -67,7 +68,7 @@ final class ShowAddShoutAction implements ApplicationActionInterface
 
     public function run(ServerRequestInterface $request, GuiGatekeeperInterface $gatekeeper): ?ResponseInterface
     {
-        $object_type = $this->requestParser->getFromRequest('type');
+        $object_type = LibraryItemEnum::from($this->requestParser->getFromRequest('type'));
         $object_id   = (int)$this->requestParser->getFromRequest('id');
 
         // Get our object first
@@ -90,8 +91,8 @@ final class ShowAddShoutAction implements ApplicationActionInterface
         if (get_class($object) === Song::class) {
             $data = $this->requestParser->getFromRequest('offset');
         }
-        $object_type = ObjectTypeToClassNameMapper::reverseMap(get_class($object));
-        $shouts      = $this->shoutRepository->getBy($object_type, $object->getId());
+
+        $shouts = $this->shoutRepository->getBy($object_type, $object->getId());
 
         // Now go ahead and display the page where we let them add a comment etc
         $this->ui->show(

--- a/src/Module/Broadcast/Broadcast_Server.php
+++ b/src/Module/Broadcast/Broadcast_Server.php
@@ -29,6 +29,7 @@ use Ampache\Config\AmpConfig;
 use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Repository\Model\Broadcast;
 use Ampache\Module\System\Core;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Exception;
 use Ratchet\MessageComponentInterface;
 use Ratchet\ConnectionInterface;
@@ -146,7 +147,7 @@ class Broadcast_Server implements MessageComponentInterface
     {
         $media   = array();
         $media[] = array(
-            'object_type' => 'song',
+            'object_type' => LibraryItemEnum::SONG,
             'object_id' => $song_id
         );
         $item          = Stream_Playlist::media_to_urlarray($media);

--- a/src/Module/Playback/Stream_Playlist.php
+++ b/src/Module/Playback/Stream_Playlist.php
@@ -27,6 +27,7 @@ namespace Ampache\Module\Playback;
 
 use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Repository\Model\library_item;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Live_Stream;
 use Ampache\Repository\Model\Media;
 use Ampache\Module\Playback\Localplay\LocalPlay;
@@ -175,7 +176,7 @@ class Stream_Playlist
      * media_to_urlarray
      * Formats the URL and media information and adds it to the object
      * @param list<array{
-     *  object_type: string,
+     *  object_type: LibraryItemEnum,
      *  object_id: int,
      *  client?: string,
      *  action?: string,
@@ -203,7 +204,7 @@ class Stream_Playlist
     /**
      * media_to_url
      * @param array{
-     *  object_type: string,
+     *  object_type: LibraryItemEnum,
      *  object_id: int,
      *  client?: string,
      *  action?: string,
@@ -214,9 +215,14 @@ class Stream_Playlist
      *  custom_play_action?: string
      * } $media
      */
-    public static function media_to_url(array $media, string $additional_params = '', string $urltype = 'web', ?User $user = null): ?Stream_Url
-    {
-        $type      = $media['object_type'];
+    public static function media_to_url(
+        array $media,
+        string $additional_params = '',
+        string $urltype = 'web',
+        ?User $user = null
+    ): ?Stream_Url {
+        // @todo use LibraryItemLoader
+        $type      = $media['object_type']->value;
         $object_id = $media['object_id'];
         $className = ObjectTypeToClassNameMapper::map($type);
         /** @var library_item $object */
@@ -497,7 +503,7 @@ class Stream_Playlist
      * add
      * Adds an array of media
      * @param list<array{
-     *  object_type: string,
+     *  object_type: LibraryItemEnum,
      *  object_id: int,
      *  client?: string,
      *  action?: string,

--- a/src/Module/Share/ShareCreatorInterface.php
+++ b/src/Module/Share/ShareCreatorInterface.php
@@ -24,13 +24,14 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Share;
 
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\User;
 
 interface ShareCreatorInterface
 {
     public function create(
         User $user,
-        string $object_type,
+        LibraryItemEnum $object_type,
         int $object_id,
         bool $allow_stream = true,
         bool $allow_download = true,

--- a/src/Module/Shout/ShoutCreator.php
+++ b/src/Module/Shout/ShoutCreator.php
@@ -31,6 +31,7 @@ use Ampache\Module\User\Activity\UserActivityPosterInterface;
 use Ampache\Module\Util\Mailer;
 use Ampache\Module\Util\UtilityFactoryInterface;
 use Ampache\Repository\Model\library_item;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\Model\User;
 use Ampache\Repository\ShoutRepositoryInterface;
@@ -74,7 +75,7 @@ final class ShoutCreator implements ShoutCreatorInterface
     public function create(
         User $user,
         library_item $libItem,
-        string $objectType,
+        LibraryItemEnum $objectType,
         string $text,
         bool $isSticky,
         int $offset
@@ -96,7 +97,7 @@ final class ShoutCreator implements ShoutCreatorInterface
         $this->userActivityPoster->post(
             $user->getId(),
             'shout',
-            $objectType,
+            $objectType->value,
             $objectId,
             $date->getTimestamp()
         );
@@ -121,7 +122,7 @@ final class ShoutCreator implements ShoutCreatorInterface
                     $message .= sprintf(
                         '%s/shout.php?action=show_add_shout&type=%s&id=%d#shout%d',
                         $this->configContainer->getWebPath(),
-                        $objectType,
+                        $objectType->value,
                         $libItem->getId(),
                         $shout->getId()
                     );

--- a/src/Module/Shout/ShoutObjectLoader.php
+++ b/src/Module/Shout/ShoutObjectLoader.php
@@ -25,9 +25,9 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Shout;
 
-use Ampache\Module\Util\InterfaceImplementationChecker;
-use Ampache\Module\Util\ObjectTypeToClassNameMapper;
 use Ampache\Repository\Model\library_item;
+use Ampache\Repository\Model\LibraryItemEnum;
+use Ampache\Repository\Model\LibraryItemLoaderInterface;
 use Ampache\Repository\Model\Podcast_Episode;
 use Ampache\Repository\Model\Shoutbox;
 use Ampache\Repository\Model\Song;
@@ -39,29 +39,28 @@ use Ampache\Repository\Model\Video;
  * Shouts should only be linked to enabled library-items
  * (at least in some cases)
  */
-final class ShoutObjectLoader implements ShoutObjectLoaderInterface
+final readonly class ShoutObjectLoader implements ShoutObjectLoaderInterface
 {
+    public function __construct(
+        private LibraryItemLoaderInterface $libraryItemLoader
+    ) {
+
+    }
+
     /**
      * Loads a library item by its type and id and check if it may be used
      */
-    public function loadByObjectType(string $type, int $object_id): ?library_item
+    public function loadByObjectType(LibraryItemEnum $type, int $object_id): ?library_item
     {
-        if (!InterfaceImplementationChecker::is_library_item($type)) {
-            return null;
-        }
+        $object = $this->libraryItemLoader->load(
+            $type,
+            $object_id
+        );
 
-        $className = ObjectTypeToClassNameMapper::map($type);
-        /** @var library_item $object */
-        $object = new $className($object_id);
-
-        if ($object->getId() > 0) {
-            if ($object instanceof Song || $object instanceof Podcast_Episode || $object instanceof Video) {
-                if (!$object->enabled) {
-                    $object = null;
-                }
+        if ($object instanceof Song || $object instanceof Podcast_Episode || $object instanceof Video) {
+            if (!$object->enabled) {
+                $object = null;
             }
-        } else {
-            $object = null;
         }
 
         return $object;
@@ -72,6 +71,6 @@ final class ShoutObjectLoader implements ShoutObjectLoaderInterface
      */
     public function loadByShout(Shoutbox $shout): ?library_item
     {
-        return $this->loadByObjectType((string) $shout->getObjectType(), $shout->getObjectId());
+        return $this->loadByObjectType($shout->getObjectType(), $shout->getObjectId());
     }
 }

--- a/src/Module/Shout/ShoutObjectLoaderInterface.php
+++ b/src/Module/Shout/ShoutObjectLoaderInterface.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace Ampache\Module\Shout;
 
 use Ampache\Repository\Model\library_item;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Shoutbox;
 
 interface ShoutObjectLoaderInterface
@@ -34,7 +35,7 @@ interface ShoutObjectLoaderInterface
      * get_object
      * This takes a type and an ID and returns a created object
      */
-    public function loadByObjectType(string $type, int $object_id): ?library_item;
+    public function loadByObjectType(LibraryItemEnum $type, int $object_id): ?library_item;
 
     /**
      * Loads the object the shout is linked to

--- a/src/Module/Shout/ShoutRenderer.php
+++ b/src/Module/Shout/ShoutRenderer.php
@@ -66,7 +66,7 @@ final class ShoutRenderer implements ShoutRendererInterface
     {
         $object          = $this->shoutObjectLoader->loadByShout($shout);
         $shoutObjectId   = $shout->getObjectId();
-        $shoutObjectType = (string) $shout->getObjectType();
+        $shoutObjectType = $shout->getObjectType()->value;
 
         if ($object === null) {
             return '';

--- a/src/Module/Util/ObjectTypeToClassNameMapper.php
+++ b/src/Module/Util/ObjectTypeToClassNameMapper.php
@@ -27,12 +27,16 @@ namespace Ampache\Module\Util;
 
 use Ampache\Repository\Model\Album;
 use Ampache\Repository\Model\AlbumDisk;
+use Ampache\Repository\Model\Art;
 use Ampache\Repository\Model\Artist;
 use Ampache\Repository\Model\Bookmark;
 use Ampache\Repository\Model\Clip;
+use Ampache\Repository\Model\database_object;
 use Ampache\Repository\Model\Label;
+use Ampache\Repository\Model\LibraryItemLoader;
 use Ampache\Repository\Model\Live_Stream;
 use Ampache\Repository\Model\Movie;
+use Ampache\Repository\Model\ObjectTypeEnum;
 use Ampache\Repository\Model\Personal_Video;
 use Ampache\Repository\Model\Playlist;
 use Ampache\Repository\Model\Podcast;
@@ -40,7 +44,6 @@ use Ampache\Repository\Model\Podcast_Episode;
 use Ampache\Repository\Model\Search;
 use Ampache\Repository\Model\Share;
 use Ampache\Repository\Model\Song;
-use Ampache\Repository\Model\Art;
 use Ampache\Repository\Model\Song_Preview;
 use Ampache\Repository\Model\Tag;
 use Ampache\Repository\Model\TVShow_Episode;
@@ -53,51 +56,61 @@ use Ampache\Repository\Model\Wanted;
  * This class maps object types like `album` to their corresponding php class name (if known)
  *
  * @deprecated Remove after every usage has been removed
+ *
+ * @see LibraryItemLoader
  */
 final class ObjectTypeToClassNameMapper
 {
+    /** @var array<string, class-string<database_object>> */
     private const OBJECT_TYPE_MAPPING = [
-        'album' => Album::class,
-        'album_disk' => AlbumDisk::class,
-        'art' => Art::class,
-        'artist' => Artist::class,
-        'bookmark' => Bookmark::class,
-        'clip' => Clip::class,
-        'genre' => Tag::class,
-        'label' => Label::class,
-        'live_stream' => Live_Stream::class,
-        'movie' => Movie::class,
-        'personal_video' => Personal_Video::class,
-        'playlist' => Playlist::class,
-        'podcast' => Podcast::class,
-        'podcast_episode' => Podcast_Episode::class,
-        'search' => Search::class,
-        'share' => Share::class,
-        'song' => Song::class,
-        'song_preview' => Song_Preview::class,
-        'tag_hidden' => Tag::class,
-        'tag' => Tag::class,
-        'tvshow_episode' => TVShow_Episode::class,
-        'tvshow_season' => TVShow_Season::class,
-        'user' => User::class,
-        'video' => Video::class,
-        'wanted' => Wanted::class,
+        ObjectTypeEnum::ALBUM->value => Album::class,
+        ObjectTypeEnum::ALBUM_DISK->value => AlbumDisk::class,
+        ObjectTypeEnum::ART->value => Art::class,
+        ObjectTypeEnum::ARTIST->value => Artist::class,
+        ObjectTypeEnum::BOOKMARK->value => Bookmark::class,
+        ObjectTypeEnum::CLIP->value => Clip::class,
+        ObjectTypeEnum::GENRE->value => Tag::class,
+        ObjectTypeEnum::LABEL->value => Label::class,
+        ObjectTypeEnum::LIVE_STREAM->value => Live_Stream::class,
+        ObjectTypeEnum::MOVIE->value => Movie::class,
+        ObjectTypeEnum::PERSONAL_VIDEO->value => Personal_Video::class,
+        ObjectTypeEnum::PLAYLIST->value => Playlist::class,
+        ObjectTypeEnum::PODCAST->value => Podcast::class,
+        ObjectTypeEnum::PODCAST_EPISODE->value => Podcast_Episode::class,
+        ObjectTypeEnum::SEARCH->value => Search::class,
+        ObjectTypeEnum::SHARE->value => Share::class,
+        ObjectTypeEnum::SONG->value => Song::class,
+        ObjectTypeEnum::SONG_PREVIEW->value => Song_Preview::class,
+        ObjectTypeEnum::TAG_HIDDEN->value => Tag::class,
+        ObjectTypeEnum::TAG->value => Tag::class,
+        ObjectTypeEnum::TV_SHOW_EPISODE->value => TVShow_Episode::class,
+        ObjectTypeEnum::TV_SHOW_SEASON->value => TVShow_Season::class,
+        ObjectTypeEnum::USER->value => User::class,
+        ObjectTypeEnum::VIDEO->value => Video::class,
+        ObjectTypeEnum::WANTED->value => Wanted::class,
     ];
 
+    /** @var array<class-string, ObjectTypeEnum> */
     public const VIDEO_TYPES = [
-        Clip::class => 'clip',
-        Movie::class => 'movie',
-        Personal_Video::class => 'personal_video',
-        TVShow_Episode::class => 'tvshow_episode',
-        TVShow_Season::class => 'tvshow_season',
-        Video::class => 'video',
+        Clip::class => ObjectTypeEnum::CLIP,
+        Movie::class => ObjectTypeEnum::MOVIE,
+        Personal_Video::class => ObjectTypeEnum::PERSONAL_VIDEO,
+        TVShow_Episode::class => ObjectTypeEnum::TV_SHOW_EPISODE,
+        TVShow_Season::class => ObjectTypeEnum::TV_SHOW_SEASON,
+        Video::class => ObjectTypeEnum::VIDEO,
     ];
 
+    /**
+     * @return class-string<database_object>|string
+     */
     public static function map(string $object_type): string
     {
         return self::OBJECT_TYPE_MAPPING[strtolower($object_type)] ?? $object_type;
     }
 
+    /**
+     * @param class-string<database_object> $className
+     */
     public static function reverseMap(string $className): string
     {
         return array_flip(self::OBJECT_TYPE_MAPPING)[$className] ?? $className;

--- a/src/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapter.php
+++ b/src/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapter.php
@@ -25,8 +25,8 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Util\Rss\Surrogate;
 
-use Ampache\Module\Util\ObjectTypeToClassNameMapper;
 use Ampache\Repository\Model\Art;
+use Ampache\Repository\Model\LibraryItemLoaderInterface;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\Model\playable_item;
 use Ampache\Repository\Model\Podcast_Episode;
@@ -37,22 +37,14 @@ use Generator;
 /**
  * Abstraction layer for creating rss/podcasts from playable-items
  */
-final class PlayableItemRssItemAdapter implements RssItemInterface
+final readonly class PlayableItemRssItemAdapter implements RssItemInterface
 {
-    private ModelFactoryInterface $modelFactory;
-
-    private playable_item $playable;
-
-    private User $user;
-
     public function __construct(
-        ModelFactoryInterface $modelFactory,
-        playable_item $playable,
-        User $user
+        private LibraryItemLoaderInterface $libraryItemLoader,
+        private ModelFactoryInterface $modelFactory,
+        private playable_item $playable,
+        private User $user
     ) {
-        $this->playable     = $playable;
-        $this->user         = $user;
-        $this->modelFactory = $modelFactory;
     }
 
     /**
@@ -132,9 +124,16 @@ final class PlayableItemRssItemAdapter implements RssItemInterface
     public function getMedias(): Generator
     {
         foreach ($this->playable->get_medias() as $media_info) {
-            $className = ObjectTypeToClassNameMapper::map($media_info['object_type']);
-            /** @var Song|Podcast_Episode $media */
-            $media      = new $className($media_info['object_id']);
+            $media = $this->libraryItemLoader->load(
+                $media_info['object_type'],
+                $media_info['object_id'],
+                [Song::class, Podcast_Episode::class]
+            );
+
+            if ($media === null) {
+                continue;
+            }
+
             $media->format();
 
             $data = [

--- a/src/Repository/Model/Album.php
+++ b/src/Repository/Model/Album.php
@@ -659,16 +659,15 @@ class Album extends database_object implements library_item, CatalogItemInterfac
     }
 
     /**
-     * get_parent
-     * Return parent `object_type`, `object_id`; null otherwise.
+     * @return null|array{object_type: LibraryItemEnum, object_id: int}
      */
     public function get_parent(): ?array
     {
-        if ($this->artist_count == 1) {
-            return array(
-                'object_type' => 'artist',
-                'object_id' => $this->album_artist
-            );
+        if ($this->artist_count === 1) {
+            return [
+                'object_type' => LibraryItemEnum::ALBUM,
+                'object_id' => (int) $this->album_artist
+            ];
         }
 
         return null;
@@ -728,7 +727,7 @@ class Album extends database_object implements library_item, CatalogItemInterfac
     /**
      * Get all children and sub-childrens media.
      *
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array
     {
@@ -737,7 +736,7 @@ class Album extends database_object implements library_item, CatalogItemInterfac
             $songs = $this->getSongRepository()->getByAlbum($this->id);
             foreach ($songs as $song_id) {
                 $medias[] = [
-                    'object_type' => 'song',
+                    'object_type' => LibraryItemEnum::SONG,
                     'object_id' => $song_id
                 ];
             }

--- a/src/Repository/Model/AlbumDisk.php
+++ b/src/Repository/Model/AlbumDisk.php
@@ -373,14 +373,13 @@ class AlbumDisk extends database_object implements library_item, CatalogItemInte
     }
 
     /**
-     * get_parent
-     * Return parent `object_type`, `object_id`; null otherwise.
+     * @return null|array{object_type: LibraryItemEnum, object_id: int}
      */
     public function get_parent(): ?array
     {
         if ($this->album_id) {
             return array(
-                'object_type' => 'album',
+                'object_type' => LibraryItemEnum::ARTIST,
                 'object_id' => $this->album_id
             );
         }
@@ -412,7 +411,7 @@ class AlbumDisk extends database_object implements library_item, CatalogItemInte
     /**
      * Get all children and sub-childrens media.
      *
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array
     {
@@ -421,7 +420,7 @@ class AlbumDisk extends database_object implements library_item, CatalogItemInte
             $songs = $this->getSongRepository()->getByAlbumDisk($this->id);
             foreach ($songs as $song_id) {
                 $medias[] = array(
-                    'object_type' => 'song',
+                    'object_type' => LibraryItemEnum::SONG,
                     'object_id' => $song_id
                 );
             }

--- a/src/Repository/Model/Artist.php
+++ b/src/Repository/Model/Artist.php
@@ -515,7 +515,7 @@ class Artist extends database_object implements library_item, CatalogItemInterfa
     /**
      * Get all childrens and sub-childrens medias.
      *
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array
     {
@@ -524,7 +524,7 @@ class Artist extends database_object implements library_item, CatalogItemInterfa
             $songs = $this->getSongRepository()->getByArtist($this->id);
             foreach ($songs as $song_id) {
                 $medias[] = array(
-                    'object_type' => 'song',
+                    'object_type' => LibraryItemEnum::SONG,
                     'object_id' => $song_id
                 );
             }

--- a/src/Repository/Model/Broadcast.php
+++ b/src/Repository/Model/Broadcast.php
@@ -272,7 +272,7 @@ class Broadcast extends database_object implements library_item
     /**
      * Get all childrens and sub-childrens medias.
      *
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string  $filter_type = null): array
     {
@@ -280,7 +280,7 @@ class Broadcast extends database_object implements library_item
         $medias = array();
         if ($filter_type === null || $filter_type === 'broadcast') {
             $medias[] = array(
-                'object_type' => 'broadcast',
+                'object_type' => LibraryItemEnum::BROADCAST,
                 'object_id' => $this->id
             );
         }

--- a/src/Repository/Model/Catalog.php
+++ b/src/Repository/Model/Catalog.php
@@ -1962,7 +1962,7 @@ abstract class Catalog extends database_object
 
             $parent = $libitem->get_parent();
             if (!empty($parent) && $type !== 'album') {
-                self::gather_art_item($parent['object_type'], $parent['object_id'], $db_art_first, $api);
+                self::gather_art_item($parent['object_type']->value, $parent['object_id'], $db_art_first, $api);
             }
         }
 

--- a/src/Repository/Model/Clip.php
+++ b/src/Repository/Model/Clip.php
@@ -196,14 +196,13 @@ class Clip extends Video
     }
 
     /**
-     * get_parent
-     * Return parent `object_type`, `object_id`; null otherwise.
+     * @return null|array{object_type: LibraryItemEnum, object_id: int}
      */
     public function get_parent(): ?array
     {
         if ($this->artist) {
             return array(
-                'object_type' => 'artist',
+                'object_type' => LibraryItemEnum::ARTIST,
                 'object_id' => $this->artist
             );
         }

--- a/src/Repository/Model/Label.php
+++ b/src/Repository/Model/Label.php
@@ -215,7 +215,7 @@ class Label extends database_object implements library_item
     }
 
     /**
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array
     {
@@ -224,7 +224,7 @@ class Label extends database_object implements library_item
             $songs = static::getSongRepository()->getByLabel((string)$this->name);
             foreach ($songs as $song_id) {
                 $medias[] = array(
-                    'object_type' => 'song',
+                    'object_type' => LibraryItemEnum::SONG,
                     'object_id' => $song_id
                 );
             }

--- a/src/Repository/Model/LibraryItemEnum.php
+++ b/src/Repository/Model/LibraryItemEnum.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=3 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Repository\Model;
+
+enum LibraryItemEnum: string
+{
+    case ALBUM           = 'album';
+    case ALBUM_DISK      = 'album_disk';
+    case ART             = 'art';
+    case ARTIST          = 'artist';
+    case BROADCAST       = 'broadcast';
+    case CLIP            = 'clip';
+    case LABEL           = 'label';
+    case LIVE_STREAM     = 'live_stream';
+    case MOVIE           = 'movie';
+    case PERSONAL_VIDEO  = 'personal_video';
+    case PLAYLIST        = 'playlist';
+    case PODCAST         = 'podcast';
+    case PODCAST_EPISODE = 'podcast_episode';
+    case SEARCH          = 'search';
+    case SONG            = 'song';
+    case SONG_PREVIEW    = 'song_preview';
+    case TAG_HIDDEN      = 'tag_hidden';
+    case TAG             = 'tag';
+    case TV_SHOW         = 'tvshow';
+    case TV_SHOW_EPISODE = 'tvshow_episode';
+    case TV_SHOW_SEASON  = 'tvshow_season';
+    case VIDEO           = 'video';
+}

--- a/src/Repository/Model/LibraryItemLoader.php
+++ b/src/Repository/Model/LibraryItemLoader.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=3 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Repository\Model;
+
+use Ampache\Repository\LabelRepositoryInterface;
+use Ampache\Repository\LiveStreamRepositoryInterface;
+use Ampache\Repository\PodcastRepositoryInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Generic loader for all kind of library-items
+ *
+ * Supports loading of all kind of library-items as defined within the LibraryItemEnum
+ *
+ * @see LibraryItemEnum
+ */
+final readonly class LibraryItemLoader implements LibraryItemLoaderInterface
+{
+    public function __construct(
+        private ContainerInterface $dic
+    ) {
+    }
+
+    /**
+     * Loads a generic library-item
+     *
+     * Will try to load an item with the given object-type and -id.
+     * Supports the specification of a list of allowed classes/interfaces to check against.
+     *
+     * @template TITemType of library_item
+     *
+     * @param list<class-string<TITemType>> $allowedItems List of all possible class-/interface-names
+     *
+     * @return null|TITemType
+     */
+    public function load(
+        LibraryItemEnum $objectType,
+        int $objectId,
+        array $allowedItems = [library_item::class]
+    ): ?library_item {
+        $object = match ($objectType) {
+            LibraryItemEnum::ALBUM => new Album($objectId),
+            LibraryItemEnum::ALBUM_DISK => new AlbumDisk($objectId),
+            LibraryItemEnum::ART => new Art($objectId),
+            LibraryItemEnum::ARTIST => new Artist($objectId),
+            LibraryItemEnum::BROADCAST => new Broadcast($objectId),
+            LibraryItemEnum::CLIP => new Clip($objectId),
+            LibraryItemEnum::LABEL => $this->dic->get(LabelRepositoryInterface::class)->findById($objectId),
+            LibraryItemEnum::LIVE_STREAM => $this->dic->get(LiveStreamRepositoryInterface::class)->findById($objectId),
+            LibraryItemEnum::MOVIE => new Movie($objectId),
+            LibraryItemEnum::PERSONAL_VIDEO => new Personal_Video($objectId),
+            LibraryItemEnum::PLAYLIST => new Playlist($objectId),
+            LibraryItemEnum::PODCAST => $this->dic->get(PodcastRepositoryInterface::class)->findById($objectId),
+            LibraryItemEnum::PODCAST_EPISODE => new Podcast_Episode($objectId),
+            LibraryItemEnum::SEARCH => new Search($objectId),
+            LibraryItemEnum::SONG => new Song($objectId),
+            LibraryItemEnum::SONG_PREVIEW => new Song_Preview($objectId),
+            LibraryItemEnum::TAG_HIDDEN, LibraryItemEnum::TAG => new Tag($objectId),
+            LibraryItemEnum::TV_SHOW => new TvShow($objectId),
+            LibraryItemEnum::TV_SHOW_EPISODE => new TVShow_Episode($objectId),
+            LibraryItemEnum::TV_SHOW_SEASON => new TVShow_Season($objectId),
+            LibraryItemEnum::VIDEO => new Video($objectId),
+        };
+
+        if (!($object?->isNew())) {
+            foreach ($allowedItems as $className) {
+                if ($object instanceof $className) {
+                    return $object;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Repository/Model/LibraryItemLoaderInterface.php
+++ b/src/Repository/Model/LibraryItemLoaderInterface.php
@@ -1,7 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
- * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ * vim:set softtabstop=3 shiftwidth=4 expandtab:
  *
  * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
  * Copyright Ampache.org, 2001-2023
@@ -21,28 +23,27 @@
  *
  */
 
-namespace Ampache\Module\Shout;
+namespace Ampache\Repository\Model;
 
-use Ampache\Repository\Model\library_item;
-use Ampache\Repository\Model\LibraryItemEnum;
-use Ampache\Repository\Model\User;
-use PHPMailer\PHPMailer\Exception;
+use Ampache\Repository\Model\library_item as TITemType;
 
-interface ShoutCreatorInterface
+interface LibraryItemLoaderInterface
 {
     /**
-     * Creates a new shout item
+     * Loads a generic library-item
      *
-     * This will create a new shout item and inform the owning user about the shout (if enabled)
+     * Will try to load an item with the given object-type and -id.
+     * Supports the specification of a list of allowed classes/interfaces to check against.
      *
-     * @throws Exception
+     * @template TITemType of library_item
+     *
+     * @param list<class-string<TITemType>> $allowedItems List of all possible class-/interface-names
+     *
+     * @return null|TITemType
      */
-    public function create(
-        User $user,
-        library_item $libItem,
+    public function load(
         LibraryItemEnum $objectType,
-        string $text,
-        bool $isSticky,
-        int $offset
-    ): void;
+        int $objectId,
+        array $allowedItems = [library_item::class]
+    ): ?library_item;
 }

--- a/src/Repository/Model/Live_Stream.php
+++ b/src/Repository/Model/Live_Stream.php
@@ -219,14 +219,14 @@ class Live_Stream extends database_object implements Media, library_item, Catalo
     }
 
     /**
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array
     {
         $medias = array();
         if ($filter_type === null || $filter_type === 'live_stream') {
             $medias[] = array(
-                'object_type' => 'live_stream',
+                'object_type' => LibraryItemEnum::LIVE_STREAM,
                 'object_id' => $this->id
             );
         }

--- a/src/Repository/Model/ObjectTypeEnum.php
+++ b/src/Repository/Model/ObjectTypeEnum.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=3 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Repository\Model;
+
+/**
+ * Defines all available object-types
+ */
+enum ObjectTypeEnum: string
+{
+    case ALBUM           = 'album';
+    case ALBUM_DISK      = 'album_disk';
+    case ART             = 'art';
+    case ARTIST          = 'artist';
+    case BOOKMARK        = 'bookmark';
+    case CLIP            = 'clip';
+    case GENRE           = 'genre';
+    case LABEL           = 'label';
+    case LIVE_STREAM     = 'live_stream';
+    case MOVIE           = 'movie';
+    case PERSONAL_VIDEO  = 'personal_video';
+    case PLAYLIST        = 'playlist';
+    case PODCAST         = 'podcast';
+    case PODCAST_EPISODE = 'podcast_episode';
+    case SEARCH          = 'search';
+    case SHARE           = 'share';
+    case SONG            = 'song';
+    case SONG_PREVIEW    = 'song_preview';
+    case TAG_HIDDEN      = 'tag_hidden';
+    case TAG             = 'tag';
+    case TV_SHOW_EPISODE = 'tvshow_episode';
+    case TV_SHOW_SEASON  = 'tvshow_season';
+    case USER            = 'user';
+    case VIDEO           = 'video';
+    case WANTED          = 'wanted';
+}

--- a/src/Repository/Model/Playlist.php
+++ b/src/Repository/Model/Playlist.php
@@ -311,7 +311,7 @@ class Playlist extends playlist_object
      * Because the same media can be on the same playlist twice they are
      * keyed by the uid from playlist_data
      * @return list<array{
-     *  object_type: string,
+     *  object_type: LibraryItemEnum,
      *  object_id: int,
      *  track: int,
      *  track_id: int
@@ -328,7 +328,7 @@ class Playlist extends playlist_object
         $db_object_types = Dba::read($sql);
 
         while ($row = Dba::fetch_assoc($db_object_types)) {
-            $object_type = $row['object_type'];
+            $object_type = LibraryItemEnum::from($row['object_type']);
             $params      = array($this->id);
 
             switch ($object_type) {
@@ -350,14 +350,14 @@ class Playlist extends playlist_object
                     break;
                 default:
                     $sql = "SELECT `id`, `object_id`, `object_type`, `track` FROM `playlist_data` WHERE `playlist` = ? AND `playlist_data`.`object_type` != 'song' AND `playlist_data`.`object_type` != 'podcast_episode' ORDER BY `track`";
-                    debug_event(__CLASS__, "get_items(): $object_type not handled", 5);
+                    debug_event(__CLASS__, "get_items(): $object_type->value not handled", 5);
             }
             // debug_event(__CLASS__, "get_items(): Results:\n" . print_r($results,true) , 5);
             $db_results = Dba::read($sql, $params);
 
             while ($row = Dba::fetch_assoc($db_results)) {
                 $results[] = array(
-                    'object_type' => $row['object_type'],
+                    'object_type' => LibraryItemEnum::from($row['object_type']),
                     'object_id' => (int)$row['object_id'],
                     'track' => (int)$row['track'],
                     'track_id' => $row['id']

--- a/src/Repository/Model/Podcast.php
+++ b/src/Repository/Model/Podcast.php
@@ -217,7 +217,7 @@ class Podcast extends database_object implements library_item, CatalogItemInterf
     }
 
     /**
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array
     {
@@ -226,7 +226,7 @@ class Podcast extends database_object implements library_item, CatalogItemInterf
             $episodes = $this->getEpisodeIds(PodcastEpisodeStateEnum::COMPLETED);
             foreach ($episodes as $episode_id) {
                 $medias[] = array(
-                    'object_type' => 'podcast_episode',
+                    'object_type' => LibraryItemEnum::PODCAST_EPISODE,
                     'object_id' => $episode_id
                 );
             }

--- a/src/Repository/Model/Podcast_Episode.php
+++ b/src/Repository/Model/Podcast_Episode.php
@@ -328,13 +328,12 @@ class Podcast_Episode extends database_object implements
     }
 
     /**
-     * get_parent
-     * Return parent `object_type`, `object_id`; null otherwise.
+     * @return array{object_type: LibraryItemEnum, object_id: int}
      */
-    public function get_parent(): ?array
+    public function get_parent(): array
     {
         return array(
-            'object_type' => 'podcast',
+            'object_type' => LibraryItemEnum::PODCAST,
             'object_id' => $this->podcast
         );
     }
@@ -360,14 +359,14 @@ class Podcast_Episode extends database_object implements
     }
 
     /**
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array
     {
         $medias = array();
         if ($filter_type === null || $filter_type === 'podcast_episode') {
             $medias[] = array(
-                'object_type' => 'podcast_episode',
+                'object_type' => LibraryItemEnum::PODCAST_EPISODE,
                 'object_id' => $this->id
             );
         }

--- a/src/Repository/Model/Search.php
+++ b/src/Repository/Model/Search.php
@@ -1304,7 +1304,7 @@ class Search extends playlist_object
         while ($row = Dba::fetch_assoc($db_results)) {
             $results[] = array(
                 'object_id' => $row['id'],
-                'object_type' => $this->objectType,
+                'object_type' => LibraryItemEnum::from($this->objectType),
                 'track' => $count++,
                 'track_id' => $row['id'],
             );

--- a/src/Repository/Model/Shoutbox.php
+++ b/src/Repository/Model/Shoutbox.php
@@ -91,9 +91,9 @@ class Shoutbox extends BaseModel
     /**
      * Sets the related object-type
      */
-    public function setObjectType(string $object_type): Shoutbox
+    public function setObjectType(LibraryItemEnum $object_type): Shoutbox
     {
-        $this->object_type = $object_type;
+        $this->object_type = $object_type->value;
 
         return $this;
     }
@@ -101,9 +101,9 @@ class Shoutbox extends BaseModel
     /**
      * Returns the related object-type
      */
-    public function getObjectType(): string
+    public function getObjectType(): LibraryItemEnum
     {
-        return (string) $this->object_type;
+        return LibraryItemEnum::from((string) $this->object_type);
     }
 
     /**

--- a/src/Repository/Model/Song.php
+++ b/src/Repository/Model/Song.php
@@ -1785,15 +1785,14 @@ class Song extends database_object implements
     }
 
     /**
-     * get_parent
-     * Return parent `object_type`, `object_id`; null otherwise.
+     * @return array{object_type: LibraryItemEnum, object_id: int}
      */
-    public function get_parent(): ?array
+    public function get_parent(): array
     {
-        return array(
-            'object_type' => 'album',
+        return [
+            'object_type' => LibraryItemEnum::ALBUM,
             'object_id' => $this->album
-        );
+        ];
     }
 
     /**
@@ -1840,14 +1839,14 @@ class Song extends database_object implements
     /**
      * Get all childrens and sub-childrens medias.
      *
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array
     {
         $medias = array();
         if ($filter_type === null || $filter_type === 'song') {
             $medias[] = array(
-                'object_type' => 'song',
+                'object_type' => LibraryItemEnum::SONG,
                 'object_id' => $this->id
             );
         }

--- a/src/Repository/Model/Song_Preview.php
+++ b/src/Repository/Model/Song_Preview.php
@@ -325,14 +325,14 @@ class Song_Preview extends database_object implements Media, playable_item
     }
 
     /**
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array
     {
         $medias = array();
         if ($filter_type === null || $filter_type === 'song_preview') {
             $medias[] = array(
-                'object_type' => 'song_preview',
+                'object_type' => LibraryItemEnum::SONG_PREVIEW,
                 'object_id' => $this->id
             );
         }

--- a/src/Repository/Model/TVShow_Episode.php
+++ b/src/Repository/Model/TVShow_Episode.php
@@ -234,13 +234,12 @@ class TVShow_Episode extends Video
     }
 
     /**
-     * get_parent
-     * Return parent `object_type`, `object_id`; null otherwise.
+     * @return array{object_type: LibraryItemEnum, object_id: int}
      */
     public function get_parent(): ?array
     {
         return array(
-            'object_type' => 'tvshow_season',
+            'object_type' => LibraryItemEnum::TV_SHOW_SEASON,
             'object_id' => $this->season
         );
     }

--- a/src/Repository/Model/TVShow_Season.php
+++ b/src/Repository/Model/TVShow_Season.php
@@ -227,13 +227,12 @@ class TVShow_Season extends database_object implements
     }
 
     /**
-     * get_parent
-     * Return parent `object_type`, `object_id`; null otherwise.
+     * @return array{object_type: LibraryItemEnum, object_id: int}
      */
-    public function get_parent(): ?array
+    public function get_parent(): array
     {
         return array(
-            'object_type' => 'tvshow',
+            'object_type' => LibraryItemEnum::TV_SHOW,
             'object_id' => $this->tvshow
         );
     }
@@ -259,7 +258,7 @@ class TVShow_Season extends database_object implements
     }
 
     /**
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array
     {
@@ -268,7 +267,7 @@ class TVShow_Season extends database_object implements
             $episodes = $this->get_episodes();
             foreach ($episodes as $episode_id) {
                 $medias[] = array(
-                    'object_type' => 'video',
+                    'object_type' => LibraryItemEnum::VIDEO,
                     'object_id' => $episode_id
                 );
             }

--- a/src/Repository/Model/Tag.php
+++ b/src/Repository/Model/Tag.php
@@ -1006,7 +1006,7 @@ class Tag extends database_object implements library_item, GarbageCollectibleInt
     }
 
     /**
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array
     {
@@ -1015,7 +1015,7 @@ class Tag extends database_object implements library_item, GarbageCollectibleInt
             $ids = self::get_tag_objects($filter_type, $this->id);
             foreach ($ids as $object_id) {
                 $medias[] = array(
-                    'object_type' => $filter_type,
+                    'object_type' => LibraryItemEnum::from($filter_type),
                     'object_id' => $object_id
                 );
             }

--- a/src/Repository/Model/TvShow.php
+++ b/src/Repository/Model/TvShow.php
@@ -271,7 +271,7 @@ class TvShow extends database_object implements library_item, CatalogItemInterfa
     }
 
     /**
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array
     {
@@ -280,7 +280,7 @@ class TvShow extends database_object implements library_item, CatalogItemInterfa
             $episodes = $this->get_episodes();
             foreach ($episodes as $episode_id) {
                 $medias[] = array(
-                    'object_type' => 'video',
+                    'object_type' => LibraryItemEnum::VIDEO,
                     'object_id' => $episode_id
                 );
             }

--- a/src/Repository/Model/Video.php
+++ b/src/Repository/Model/Video.php
@@ -189,11 +189,11 @@ class Video extends database_object implements
     public static function create_from_id($video_id): Video
     {
         foreach (ObjectTypeToClassNameMapper::VIDEO_TYPES as $dtype) {
-            $sql        = "SELECT `id` FROM `" . strtolower((string) $dtype) . "` WHERE `id` = ?";
+            $sql        = "SELECT `id` FROM `" . strtolower($dtype->value) . "` WHERE `id` = ?";
             $db_results = Dba::read($sql, array($video_id));
             $results    = Dba::fetch_assoc($db_results);
             if (array_key_exists('id', $results)) {
-                $className = ObjectTypeToClassNameMapper::map(strtolower($dtype));
+                $className = ObjectTypeToClassNameMapper::map(strtolower($dtype->value));
 
                 return new $className($video_id);
             }
@@ -404,14 +404,14 @@ class Video extends database_object implements
     /**
      * Get all childrens and sub-childrens medias.
      *
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array
     {
         $medias = array();
         if ($filter_type === null || $filter_type === 'video') {
             $medias[] = array(
-                'object_type' => 'video',
+                'object_type' => LibraryItemEnum::VIDEO,
                 'object_id' => $this->id
             );
         }

--- a/src/Repository/Model/playable_item.php
+++ b/src/Repository/Model/playable_item.php
@@ -62,8 +62,7 @@ interface playable_item
     public function get_f_link(): string;
 
     /**
-     * get_parent
-     * Return parent `object_type`, `object_id`; null otherwise.
+     * @return null|array{object_type: LibraryItemEnum, object_id: int}
      */
     public function get_parent(): ?array;
 
@@ -85,7 +84,7 @@ interface playable_item
     /**
      * Get all medias from all childrens. Return an array of `object_type`, `object_id` medias.
      *
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array;
 

--- a/src/Repository/Model/playlist_object.php
+++ b/src/Repository/Model/playlist_object.php
@@ -59,7 +59,7 @@ abstract class playlist_object extends database_object implements library_item
 
     /**
      * @return list<array{
-     *  object_type: string,
+     *  object_type: LibraryItemEnum,
      *  object_id: int
      * }>
      */
@@ -119,7 +119,7 @@ abstract class playlist_object extends database_object implements library_item
     }
 
     /**
-     * @return list<array{object_type: string, object_id: int}>
+     * @return list<array{object_type: LibraryItemEnum, object_id: int}>
      */
     public function get_medias(?string $filter_type = null): array
     {
@@ -127,7 +127,7 @@ abstract class playlist_object extends database_object implements library_item
             return array_filter(
                 $this->get_items(),
                 function (array $item) use ($filter_type): bool {
-                    return $item['object_type'] == $filter_type;
+                    return $item['object_type']->value === $filter_type;
                 }
             );
         } else {
@@ -283,18 +283,18 @@ abstract class playlist_object extends database_object implements library_item
             if ($count >= $limit) {
                 return $images;
             }
-            if (InterfaceImplementationChecker::is_library_item($media['object_type'])) {
-                if (!Art::has_db($media['object_id'], $media['object_type'])) {
-                    $className = ObjectTypeToClassNameMapper::map($media['object_type']);
+            if (InterfaceImplementationChecker::is_library_item($media['object_type']->value)) {
+                if (!Art::has_db($media['object_id'], $media['object_type']->value)) {
+                    $className = ObjectTypeToClassNameMapper::map($media['object_type']->value);
                     $libitem   = new $className($media['object_id']);
                     $parent    = $libitem->get_parent();
                     if ($parent !== null) {
                         $media = $parent;
                     }
                 }
-                $art = new Art($media['object_id'], $media['object_type']);
+                $art = new Art($media['object_id'], $media['object_type']->value);
                 if ($art->has_db_info()) {
-                    $link     = $web_path . "/image.php?object_id=" . $media['object_id'] . "&object_type=" . $media['object_type'];
+                    $link     = $web_path . "/image.php?object_id=" . $media['object_id'] . "&object_type=" . $media['object_type']->value;
                     $images[] = ['url' => $link, 'mime' => $art->raw_mime, 'title' => $title];
                 }
             }

--- a/src/Repository/ShoutRepository.php
+++ b/src/Repository/ShoutRepository.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace Ampache\Repository;
 
 use Ampache\Module\Database\DatabaseConnectionInterface;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Shoutbox;
 use Generator;
 use PDO;
@@ -79,12 +80,12 @@ final class ShoutRepository extends BaseRepository implements ShoutRepositoryInt
      * @return Generator<Shoutbox>
      */
     public function getBy(
-        string $objectType,
+        LibraryItemEnum $objectType,
         int $objectId
     ): Generator {
         $result = $this->connection->query(
             'SELECT * FROM `user_shout` WHERE `object_type` = ? AND `object_id` = ? ORDER BY `sticky`, `date` DESC',
-            [$objectType, $objectId]
+            [$objectType->value, $objectId]
         );
         $result->setFetchMode(PDO::FETCH_CLASS, Shoutbox::class, [$this]);
 
@@ -159,7 +160,7 @@ final class ShoutRepository extends BaseRepository implements ShoutRepositoryInt
                     $shout->getText(),
                     (int) $shout->isSticky(),
                     $shout->getObjectId(),
-                    $shout->getObjectType(),
+                    $shout->getObjectType()->value,
                     $shout->getOffset()
                 ]
             );
@@ -174,7 +175,7 @@ final class ShoutRepository extends BaseRepository implements ShoutRepositoryInt
                     $shout->getText(),
                     (int) $shout->isSticky(),
                     $shout->getObjectId(),
-                    $shout->getObjectType(),
+                    $shout->getObjectType()->value,
                     $shout->getOffset(),
                     $shout->getId()
                 ]

--- a/src/Repository/ShoutRepositoryInterface.php
+++ b/src/Repository/ShoutRepositoryInterface.php
@@ -23,6 +23,7 @@
 
 namespace Ampache\Repository;
 
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Shoutbox;
 use Traversable;
 
@@ -37,7 +38,7 @@ interface ShoutRepositoryInterface extends BaseRepositoryInterface
      * @return Traversable<Shoutbox>
      */
     public function getBy(
-        string $objectType,
+        LibraryItemEnum $objectType,
         int $objectId
     ): Traversable;
 

--- a/src/Repository/VideoRepository.php
+++ b/src/Repository/VideoRepository.php
@@ -57,7 +57,7 @@ final class VideoRepository implements VideoRepositoryInterface
     {
         $type = ObjectTypeToClassNameMapper::VIDEO_TYPES[$type];
 
-        $sql        = 'SELECT COUNT(*) AS `count` FROM `' . strtolower((string) $type) . '`;';
+        $sql        = 'SELECT COUNT(*) AS `count` FROM `' . strtolower($type->value) . '`;';
         $db_results = Dba::read($sql);
         if ($results = Dba::fetch_assoc($db_results)) {
             if (array_key_exists('count', $results)) {

--- a/src/Repository/service_definition.php
+++ b/src/Repository/service_definition.php
@@ -25,6 +25,9 @@ declare(strict_types=1);
 
 namespace Ampache\Repository;
 
+use Ampache\Repository\Model\LibraryItemLoader;
+use Ampache\Repository\Model\LibraryItemLoaderInterface;
+
 use function DI\autowire;
 
 return [
@@ -55,4 +58,5 @@ return [
     PodcastEpisodeRepositoryInterface::class => autowire(PodcastEpisodeRepository::class),
     ImageRepositoryInterface::class => autowire(ImageRepository::class),
     AlbumDiskRepositoryInterface::class => autowire(AlbumDiskRepository::class),
+    LibraryItemLoaderInterface::class => autowire(LibraryItemLoader::class),
 ];

--- a/tests/Module/Shout/ShoutCreatorTest.php
+++ b/tests/Module/Shout/ShoutCreatorTest.php
@@ -29,6 +29,7 @@ use Ampache\Config\ConfigContainerInterface;
 use Ampache\Module\User\Activity\UserActivityPosterInterface;
 use Ampache\Module\Util\UtilityFactoryInterface;
 use Ampache\Repository\Model\library_item;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\Model\Shoutbox;
 use Ampache\Repository\Model\User;
@@ -74,7 +75,7 @@ class ShoutCreatorTest extends TestCase
         $libItem = $this->createMock(library_item::class);
         $shout   = $this->createMock(Shoutbox::class);
 
-        $objectType = 'some-type';
+        $objectType = LibraryItemEnum::SONG;
         $text       = '<div>some-text</div>';
         $isSticky   = false;
         $offset     = 666;
@@ -129,7 +130,7 @@ class ShoutCreatorTest extends TestCase
             ->with(
                 $userId,
                 'shout',
-                $objectType,
+                $objectType->value,
                 $objectId,
                 self::callback(static fn (int $value): bool => $value <= time())
             );

--- a/tests/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapterTest.php
+++ b/tests/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapterTest.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Util\Rss\Surrogate;
 
+use Ampache\Repository\Model\LibraryItemLoaderInterface;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\Model\playable_item;
 use Ampache\Repository\Model\User;
@@ -33,6 +34,8 @@ use PHPUnit\Framework\TestCase;
 
 class PlayableItemRssItemAdapterTest extends TestCase
 {
+    private LibraryItemLoaderInterface&MockObject $libraryItemLoader;
+
     private ModelFactoryInterface&MockObject $modelFactory;
 
     private playable_item&MockObject $playable;
@@ -43,11 +46,13 @@ class PlayableItemRssItemAdapterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->modelFactory = $this->createMock(ModelFactoryInterface::class);
-        $this->playable     = $this->createMock(playable_item::class);
-        $this->user         = $this->createMock(User::class);
+        $this->libraryItemLoader = $this->createMock(LibraryItemLoaderInterface::class);
+        $this->modelFactory      = $this->createMock(ModelFactoryInterface::class);
+        $this->playable          = $this->createMock(playable_item::class);
+        $this->user              = $this->createMock(User::class);
 
         $this->subject = new PlayableItemRssItemAdapter(
+            $this->libraryItemLoader,
             $this->modelFactory,
             $this->playable,
             $this->user,

--- a/tests/Repository/Model/LibraryItemLoaderTest.php
+++ b/tests/Repository/Model/LibraryItemLoaderTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=3 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Repository\Model;
+
+use Ampache\Repository\LabelRepositoryInterface;
+use Ampache\Repository\LiveStreamRepositoryInterface;
+use Ampache\Repository\PodcastRepositoryInterface;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class LibraryItemLoaderTest extends TestCase
+{
+    private ContainerInterface&MockObject $dic;
+
+    private LibraryItemLoader $subject;
+
+    protected function setUp(): void
+    {
+        $this->dic = $this->createMock(ContainerInterface::class);
+
+        $this->subject = new LibraryItemLoader(
+            $this->dic,
+        );
+    }
+
+    #[DataProvider(methodName: 'loadDataProvider')]
+    public function testLoadLoads(
+        LibraryItemEnum $itemType,
+        string $repoClassName,
+        string $itemClassName
+    ): void {
+        $objectId = 666;
+
+        $item = $this->createMock($itemClassName);
+        $repo = $this->createMock($repoClassName);
+
+        $item->expects(static::once())
+            ->method('isNew')
+            ->willReturn(false);
+
+        $this->dic->expects(static::once())
+            ->method('get')
+            ->with($repoClassName)
+            ->willReturn($repo);
+
+        $repo->expects(static::once())
+            ->method('findById')
+            ->with($objectId)
+            ->willReturn($item);
+
+        static::assertSame(
+            $item,
+            $this->subject->load($itemType, $objectId, [$itemClassName]),
+        );
+    }
+
+    public static function loadDataProvider(): Generator
+    {
+        yield [LibraryItemEnum::LABEL, LabelRepositoryInterface::class, Label::class];
+
+        yield [LibraryItemEnum::LIVE_STREAM, LiveStreamRepositoryInterface::class, Live_Stream::class];
+
+        yield [LibraryItemEnum::PODCAST, PodcastRepositoryInterface::class, Podcast::class];
+    }
+
+    public function testReturnsNullIfObjectWasNotFound(): void
+    {
+        $objectId = 666;
+
+        $item = $this->createMock(Label::class);
+        $repo = $this->createMock(LabelRepositoryInterface::class);
+
+        $item->expects(static::once())
+            ->method('isNew')
+            ->willReturn(true);
+
+        $this->dic->expects(static::once())
+            ->method('get')
+            ->with(LabelRepositoryInterface::class)
+            ->willReturn($repo);
+
+        $repo->expects(static::once())
+            ->method('findById')
+            ->with($objectId)
+            ->willReturn($item);
+
+        static::assertNull(
+            $this->subject->load(LibraryItemEnum::LABEL, $objectId),
+        );
+    }
+}

--- a/tests/Repository/Model/ShoutboxTest.php
+++ b/tests/Repository/Model/ShoutboxTest.php
@@ -97,9 +97,20 @@ class ShoutboxTest extends TestCase
     public static function setterGetterDataProvider(): Generator
     {
         yield ['getOffset', 'setOffset', 0, 666];
-        yield ['getObjectType', 'setObjectType', '', 'some-type'];
         yield ['getObjectId', 'setObjectId', 0, 666];
         yield ['isSticky', 'setSticky', false, true];
+    }
+
+    public function testGetObjectTypeReturnsSetValue(): void
+    {
+        $objectType = LibraryItemEnum::SONG;
+
+        $this->subject->setObjectType($objectType);
+
+        static::assertSame(
+            $objectType,
+            $this->subject->getObjectType()
+        );
     }
 
     public function testGetUserIdReturnsSetValue(): void

--- a/tests/Repository/ShoutRepositoryTest.php
+++ b/tests/Repository/ShoutRepositoryTest.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace Ampache\Repository;
 
 use Ampache\Module\Database\DatabaseConnectionInterface;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\Shoutbox;
 use DateTime;
 use PDO;
@@ -59,7 +60,7 @@ class ShoutRepositoryTest extends TestCase
 
     public function testGetByYieldsData(): void
     {
-        $objectType = 'some-object-type';
+        $objectType = LibraryItemEnum::SONG;
         $objectId   = 42;
 
         $shoutBox  = $this->createMock(Shoutbox::class);
@@ -69,7 +70,7 @@ class ShoutRepositoryTest extends TestCase
             ->method('query')
             ->with(
                 'SELECT * FROM `user_shout` WHERE `object_type` = ? AND `object_id` = ? ORDER BY `sticky`, `date` DESC',
-                [$objectType, $objectId]
+                [$objectType->value, $objectId]
             )
             ->willReturn($statement);
 
@@ -229,7 +230,7 @@ class ShoutRepositoryTest extends TestCase
         $text       = 'some-text';
         $sticky     = true;
         $objectId   = 123;
-        $objectType = 'snafu';
+        $objectType = LibraryItemEnum::ART;
         $offset     = 567;
 
         $shout->expects(static::once())
@@ -267,7 +268,7 @@ class ShoutRepositoryTest extends TestCase
                     $text,
                     (int) $sticky,
                     $objectId,
-                    $objectType,
+                    $objectType->value,
                     $offset
                 ]
             );
@@ -291,7 +292,7 @@ class ShoutRepositoryTest extends TestCase
         $text       = 'some-text';
         $sticky     = true;
         $objectId   = 123;
-        $objectType = 'snafu';
+        $objectType = LibraryItemEnum::TAG_HIDDEN;
         $offset     = 567;
 
         $shout->expects(static::once())
@@ -332,7 +333,7 @@ class ShoutRepositoryTest extends TestCase
                     $text,
                     (int) $sticky,
                     $objectId,
-                    $objectType,
+                    $objectType->value,
                     $offset,
                     $shoutId
                 ]


### PR DESCRIPTION
This is the successor to ObjectToClassNameMapper and enables generic library objects to be loaded using object-type and object-id tuples. Restrictions can be made using class/interface names.

On this occasion, an enum for all types of library items is also introduced and the whole thing is first used in the share object.