### PR TITLE
Fix implicit conversion

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9781,16 +9781,6 @@ parameters:
 			path: src/Module/Util/Captcha/easy_captcha_graphic_image_waved.php
 
 		-
-			message: "#^Parameter \\#1 \\$min of function rand expects int, float given\\.$#"
-			count: 4
-			path: src/Module/Util/Captcha/easy_captcha_graphic_image_waved.php
-
-		-
-			message: "#^Parameter \\#2 \\$max of function rand expects int, float given\\.$#"
-			count: 4
-			path: src/Module/Util/Captcha/easy_captcha_graphic_image_waved.php
-
-		-
 			message: "#^Parameter \\#4 \\$color of function imagesetpixel expects int, int\\|false given\\.$#"
 			count: 3
 			path: src/Module/Util/Captcha/easy_captcha_graphic_image_waved.php

--- a/src/Module/Util/Captcha/easy_captcha_graphic_image_waved.php
+++ b/src/Module/Util/Captcha/easy_captcha_graphic_image_waved.php
@@ -118,12 +118,12 @@ class easy_captcha_graphic_image_waved extends easy_captcha_graphic
             imagesetthickness($this->img, rand(1, 2));
             imagearc(
                 $this->img,
-                rand( (int) (0.1 * $x), (int) (0.9 * $x)),
-                rand( (int) (0.1 * $y), (int) (0.9 * $y)),  // x,y
-                rand( (int) (0.1 * $x), (int) (0.3 * $x)),
-                rand( (int) (0.1 * $y),(int) (0.3 * $y)),  // w,h
+                rand((int)(0.1 * $x), (int)(0.9 * $x)),
+                rand((int)(0.1 * $y), (int)(0.9 * $y)),  // x,y
+                rand((int)(0.1 * $x), (int)(0.3 * $x)),
+                rand((int)(0.1 * $y), (int)(0.3 * $y)),  // w,h
                 $s,
-                rand( (int) ($s + 5), (int) ($s + 90)),     // s,e
+                rand((int)($s + 5), (int)($s + 90)),     // s,e
                 rand(0, 1) ? 0xFFFFFF : 0x000000   // col
             );
         }

--- a/src/Module/Util/Captcha/easy_captcha_graphic_image_waved.php
+++ b/src/Module/Util/Captcha/easy_captcha_graphic_image_waved.php
@@ -118,12 +118,12 @@ class easy_captcha_graphic_image_waved extends easy_captcha_graphic
             imagesetthickness($this->img, rand(1, 2));
             imagearc(
                 $this->img,
-                rand(0.1 * $x, 0.9 * $x),
-                rand(0.1 * $y, 0.9 * $y),  // x,y
-                rand(0.1 * $x, 0.3 * $x),
-                rand(0.1 * $y, 0.3 * $y),  // w,h
+                rand( (int) (0.1 * $x), (int) (0.9 * $x)),
+                rand( (int) (0.1 * $y), (int) (0.9 * $y)),  // x,y
+                rand( (int) (0.1 * $x), (int) (0.3 * $x)),
+                rand( (int) (0.1 * $y),(int) (0.3 * $y)),  // w,h
                 $s,
-                rand($s + 5, $s + 90),     // s,e
+                rand( (int) ($s + 5), (int) ($s + 90)),     // s,e
                 rand(0, 1) ? 0xFFFFFF : 0x000000   // col
             );
         }


### PR DESCRIPTION
Captcha generation generate lot a noise because of implicit conversion. I don't like noise, it's noisy.

```
[Error] Implicit conversion from float 6.7 to int loses precision in file src/Module/Util/Captcha/easy_captcha_graphic_image_waved.php(122)
[Error] Implicit conversion from float 60.300000000000004 to int loses precision in file src/Module/Util/Captcha/easy_captcha_graphic_image_waved.php(122)
[Error] Implicit conversion from float 21.900000000000002 to int loses precision in file src/Module/Util/Captcha/easy_captcha_graphic_image_waved.php(123)
[Error] Implicit conversion from float 65.7 to int loses precision in file src/Module/Util/Captcha/easy_captcha_graphic_image_waved.php(123)
[Error] Implicit conversion from float 6.7 to int loses precision in file src/Module/Util/Captcha/easy_captcha_graphic_image_waved.php(124)
[Error] Implicit conversion from float 20.099999999999998 to int loses precision in file src/Module/Util/Captcha/easy_captcha_graphic_image_waved.php(124)
```

