### PR TITLE
Allow to display song even if no data in song_data table

### DIFF
--- a/src/Repository/Model/Preference.php
+++ b/src/Repository/Model/Preference.php
@@ -251,7 +251,7 @@ class Preference extends database_object
         //debug_event(self::class, 'Getting preference {' . $pref_name . '} for user identifier {' . $user_id . '}...', 5);
         $pref_id = self::id_from_name($pref_name);
 
-        if (parent::is_cached('get_by_user-' . $pref_name, $user_id) && is_array((parent::get_from_cache('get_by_user-' . $pref_name, $user_id)))) {
+        if (parent::is_cached('get_by_user-' . $pref_name, $user_id)) {
             return (parent::get_from_cache('get_by_user-' . $pref_name, $user_id))['value'];
         }
 

--- a/src/Repository/Model/Song.php
+++ b/src/Repository/Model/Song.php
@@ -544,7 +544,7 @@ class Song extends database_object implements
      */
     private function has_info($song_id): array
     {
-        if (parent::is_cached('song', $song_id) && !empty(parent::get_from_cache('song', $song_id)['disk'])) {
+        if (parent::is_cached('song', $song_id)) {
             return parent::get_from_cache('song', $song_id);
         }
 
@@ -628,9 +628,9 @@ class Song extends database_object implements
      * This function gathers information from the song_ext_info table and adds it to the
      * current object
      * @param string $select
-     * @return array|false
+     * @return array
      */
-    public function _get_ext_info($select = ''): array|false
+    public function _get_ext_info($select = '')
     {
         $song_id = (int) ($this->id);
         $columns = (!empty($select)) ? Dba::escape($select) : '*';
@@ -641,7 +641,9 @@ class Song extends database_object implements
 
         $sql        = "SELECT $columns FROM `song_data` WHERE `song_id` = ?";
         $db_results = Dba::read($sql, array($song_id));
-
+        if (!$db_results) {
+            return array();
+        }
         $results = Dba::fetch_assoc($db_results);
 
         parent::add_to_cache('song_data', $song_id, $results);

--- a/src/Repository/Model/Song.php
+++ b/src/Repository/Model/Song.php
@@ -628,9 +628,9 @@ class Song extends database_object implements
      * This function gathers information from the song_ext_info table and adds it to the
      * current object
      * @param string $select
-     * @return array
+     * @return array|false
      */
-    public function _get_ext_info($select = ''): array
+    public function _get_ext_info($select = ''): array|false
     {
         $song_id = (int) ($this->id);
         $columns = (!empty($select)) ? Dba::escape($select) : '*';

--- a/src/Repository/Model/database_object.php
+++ b/src/Repository/Model/database_object.php
@@ -126,9 +126,9 @@ abstract class database_object
      * This attempts to retrieve the specified object from the cache we've got here
      * @param string $index
      * @param int|string $object_id
-     * @return array
+     * @return array|false
      */
-    public static function get_from_cache($index, $object_id): array
+    public static function get_from_cache($index, $object_id): array|false
     {
         // Check if the object is set
         if (isset(self::$object_cache[$index][$object_id])) {

--- a/src/Repository/Model/database_object.php
+++ b/src/Repository/Model/database_object.php
@@ -118,7 +118,7 @@ abstract class database_object
             return false;
         }
 
-        return array_key_exists($object_id, self::$object_cache[$index]);
+        return array_key_exists($object_id, self::$object_cache[$index]) && !empty(self::$object_cache[$index][$object_id]);
     }
 
     /**
@@ -126,12 +126,12 @@ abstract class database_object
      * This attempts to retrieve the specified object from the cache we've got here
      * @param string $index
      * @param int|string $object_id
-     * @return array|false
+     * @return array
      */
-    public static function get_from_cache($index, $object_id): array|false
+    public static function get_from_cache($index, $object_id)
     {
         // Check if the object is set
-        if (isset(self::$object_cache[$index][$object_id])) {
+        if (isset(self::$object_cache[$index][$object_id]) && is_array(self::$object_cache[$index][$object_id])) {
             self::$cache_hit++;
 
             return self::$object_cache[$index][$object_id];


### PR DESCRIPTION
Can't display a song if it doesn't have any data in song_data table

Example : if 'select *  FROM `song_data` WHERE `song_id` = 57170;' is empty, the cache isn't populated.

It return false, and it must be an array

This patch allow false and array as return value.