### PR TITLE
Fix #3761 overrided album name

### DIFF
--- a/src/Repository/Model/Album.php
+++ b/src/Repository/Model/Album.php
@@ -221,13 +221,13 @@ class Album extends database_object implements library_item, CatalogItemInterfac
         }
         $results = array();
         if (empty($this->album_artist) && $this->song_artist_count == 1) {
-            $sql        = "SELECT MIN(`song`.`id`) AS `song_id`, `artist`.`name`, `artist`.`prefix`, MIN(`artist`.`id`) AS `artist_id` FROM `song` INNER JOIN `artist` ON `artist`.`id`=`song`.`artist` WHERE `song`.`album` = " . $this->id . " GROUP BY `song`.`album`, `artist`.`prefix`, `artist`.`name`";
+            $sql        = "SELECT MIN(`song`.`id`) AS `song_id`, `artist`.`name` AS `artist_name`, `artist`.`prefix` AS `artist_prefix`, MIN(`artist`.`id`) AS `artist_id` FROM `song` INNER JOIN `artist` ON `artist`.`id`=`song`.`artist` WHERE `song`.`album` = " . $this->id . " GROUP BY `song`.`album`, `artist`.`prefix`, `artist`.`name`";
             $db_results = Dba::read($sql);
             $results    = Dba::fetch_assoc($db_results);
             // overwrite so you can get something
             $this->album_artist  = $results['artist_id'] ?? null;
-            $this->artist_prefix = $results['prefix'] ?? null;
-            $this->artist_name   = $results['name'] ?? null;
+            $this->artist_prefix = $results['artist_prefix'] ?? null;
+            $this->artist_name   = $results['artist_name'] ?? null;
         }
         $this->has_art();
 


### PR DESCRIPTION
Hi there,
The artist name override the album name because of [the assign foreach here](https://github.com/Simounet/ampache/blob/73ce7cfe743e2a921e63fb954c3fd6fb56d39ab2/src/Repository/Model/Album.php#L439). This behavior doesn't seems to be very predictable to me.
I don't know when when the regression came in. I can search for it if you want me to.
Have a nice day.