### PR TITLE
Add Shoutbox::getUser() method

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4911,6 +4911,11 @@ parameters:
 			path: src/Module/Application/Playback/PlayAction.php
 
 		-
+			message: "#^Property Ampache\\\\Module\\\\Application\\\\Playlist\\\\SetTrackNumbersAction\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: src/Module/Application/Playlist/SetTrackNumbersAction.php
+
+		-
 			message: "#^Parameter \\#1 \\$recipient of method Ampache\\\\Module\\\\User\\\\PrivateMessage\\\\PrivateMessageCreatorInterface\\:\\:create\\(\\) expects Ampache\\\\Repository\\\\Model\\\\User, Ampache\\\\Repository\\\\Model\\\\User\\|null given\\.$#"
 			count: 1
 			path: src/Module/Application/PrivateMessage/AddMessageAction.php

--- a/public/templates/show_manage_shoutbox.inc.php
+++ b/public/templates/show_manage_shoutbox.inc.php
@@ -26,7 +26,6 @@ declare(strict_types=0);
 use Ampache\Config\AmpConfig;
 use Ampache\Module\Shout\ShoutObjectLoaderInterface;
 use Ampache\Repository\Model\Shoutbox;
-use Ampache\Repository\Model\User;
 use Ampache\Module\Util\Ui;
 
 /** @var ShoutObjectLoaderInterface $shoutObjectLoader */
@@ -49,9 +48,15 @@ $web_path = (string)AmpConfig::get('web_path', ''); ?>
         foreach ($shouts as $libitem) {
 
             $object = $shoutObjectLoader->loadByShout($libitem);
-            $client = new User($libitem->getUserId());
+            $client = $libitem->getUser();
 
-            require Ui::find_template('show_shout_row.inc.php'); ?>
+            if (
+                $client !== null &&
+                $object !== null
+            ) {
+                require Ui::find_template('show_shout_row.inc.php');
+            }
+            ?>
         <?php
         } ?>
         <?php if ($shouts === []) { ?>

--- a/src/Module/Api/Json4_Data.php
+++ b/src/Module/Api/Json4_Data.php
@@ -1053,15 +1053,15 @@ class Json4_Data
         $JSON = [];
         /** @var Shoutbox $shout */
         foreach ($shouts as $shout) {
-            $user = new User($shout->getUserId());
+            $user = $shout->getUser();
 
             $JSON[] = [
                 'id' => (string) $shout->getId(),
                 'date' => $shout->getDate()->getTimestamp(),
                 'text' => $shout->getText(),
                 'user' => [
-                    'id' => (string)$user->getId(),
-                    'username' => $user->getUsername()
+                    'id' => (string) ($user?->getId() ?? 0),
+                    'username' => $user?->getUsername() ?? ''
                 ]
             ];
         }

--- a/src/Module/Api/Json5_Data.php
+++ b/src/Module/Api/Json5_Data.php
@@ -1214,15 +1214,15 @@ class Json5_Data
 
         /** @var Shoutbox $shout */
         foreach ($shouts as $shout) {
-            $user = new User($shout->getUserId());
+            $user = $shout->getUser();
 
             $JSON[] = [
                 "id" => (string) $shout->getId(),
                 "date" => $shout->getDate()->getTimestamp(),
                 "text" => $shout->getText(),
                 "user" => array(
-                    "id" => (string) $user->getId(),
-                    "username" => $user->getUsername()
+                    "id" => (string) ($user?->getId() ?? 0),
+                    "username" => $user?->getUsername() ?? '',
                 )
             ];
         }

--- a/src/Module/Api/Json_Data.php
+++ b/src/Module/Api/Json_Data.php
@@ -1720,15 +1720,15 @@ class Json_Data
         $JSON = [];
 
         foreach ($shouts as $shout) {
-            $user = new User($shout->getUserId());
+            $user = $shout->getUser();
 
             $JSON[] = [
                 'id' => (string) $shout->getId(),
                 'date' => $shout->getDate()->getTimestamp(),
                 'text' => $shout->getText(),
                 'user' => array(
-                    'id' => (string) $user->getId(),
-                    'username' => $user->getUsername()
+                    'id' => (string) ($user?->getId() ?? 0),
+                    'username' => $user?->getUsername() ?? '',
                 )
             ];
         }

--- a/src/Module/Api/Xml3_Data.php
+++ b/src/Module/Api/Xml3_Data.php
@@ -625,9 +625,9 @@ class Xml3_Data
 
         /** @var Shoutbox $shout */
         foreach ($shouts as $shout) {
-            $user  = new User($shout->getUserId());
+            $user = $shout->getUser();
             $string .= "\t<shout id=\"" . $shout->getId() . "\">\n\t\t<date>" . $shout->getDate()->getTimestamp() . "</date>\n\t\t<text><![CDATA[" . $shout->getText() . "]]></text>\n";
-            if ($user->isNew() === false) {
+            if ($user !== null) {
                 $string .= "\t\t<username><![CDATA[" . $user->getUsername() . "]]></username>";
             }
             $string .= "\t</shout>n";

--- a/src/Module/Api/Xml4_Data.php
+++ b/src/Module/Api/Xml4_Data.php
@@ -893,9 +893,9 @@ class Xml4_Data
         $string = "<shouts>\n";
         /** @var Shoutbox $shout */
         foreach ($shouts as $shout) {
-            $user  = new User($shout->getUserId());
+            $user = $shout->getUser();
             $string .= "\t<shout id=\"" . $shout->getId() . "\">\n\t\t<date>" . $shout->getDate()->getTimestamp() . "</date>\n\t\t<text><![CDATA[" . $shout->getText() . "]]></text>\n";
-            if ($user->isNew() === false) {
+            if ($user !== null) {
                 $string .= "\t\t<user id=\"" . $user->getId() . "\">\n\t\t\t<username><![CDATA[" . $user->getUsername() . "]]></username>\n\t\t</user>\n";
             }
             $string .= "\t</shout>\n";

--- a/src/Module/Api/Xml5_Data.php
+++ b/src/Module/Api/Xml5_Data.php
@@ -1032,9 +1032,9 @@ class Xml5_Data
         $string = "";
         /** @var Shoutbox $shout */
         foreach ($shouts as $shout) {
-            $user  = new User($shout->getUserId());
+            $user = $shout->getUser();
             $string .= "\t<shout id=\"" . $shout->getId() . "\">\n\t\t<date>" . $shout->getDate()->getTimestamp() . "</date>\n\t\t<text><![CDATA[" . $shout->getText() . "]]></text>\n";
-            if ($user->isNew() === false) {
+            if ($user !== null) {
                 $string .= "\t\t<user id=\"" . $user->getId() . "\">\n\t\t\t<username><![CDATA[" . $user->getUsername() . "]]></username>\n\t\t</user>\n";
             }
             $string .= "\t</shout>\n";

--- a/src/Module/Api/Xml_Data.php
+++ b/src/Module/Api/Xml_Data.php
@@ -1455,9 +1455,9 @@ class Xml_Data
         $string = "";
 
         foreach ($shouts as $shout) {
-            $user  = new User($shout->getUserId());
+            $user = $shout->getUser();
             $string .= "\t<shout id=\"" . $shout->getId() . "\">\n\t\t<date>" . $shout->getDate()->getTimestamp() . "</date>\n\t\t<text><![CDATA[" . $shout->getText() . "]]></text>\n";
-            if ($user->isNew() === false) {
+            if ($user !== null) {
                 $string .= "\t\t<user id=\"" . $user->getId() . "\">\n\t\t\t<username><![CDATA[" . $user->getUsername() . "]]></username>\n\t\t</user>\n";
             }
             $string .= "\t</shout>\n";

--- a/src/Module/Application/Admin/Shout/DeleteAction.php
+++ b/src/Module/Application/Admin/Shout/DeleteAction.php
@@ -37,24 +37,15 @@ use Ampache\Repository\ShoutRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-final class DeleteAction implements ApplicationActionInterface
+final readonly class DeleteAction implements ApplicationActionInterface
 {
     public const REQUEST_KEY = 'delete';
 
-    private UiInterface $ui;
-
-    private ConfigContainerInterface $configContainer;
-
-    private ShoutRepositoryInterface $shoutRepository;
-
     public function __construct(
-        UiInterface $ui,
-        ConfigContainerInterface $configContainer,
-        ShoutRepositoryInterface $shoutRepository
+        private UiInterface $ui,
+        private ConfigContainerInterface $configContainer,
+        private ShoutRepositoryInterface $shoutRepository
     ) {
-        $this->ui              = $ui;
-        $this->configContainer = $configContainer;
-        $this->shoutRepository = $shoutRepository;
     }
 
     public function run(ServerRequestInterface $request, GuiGatekeeperInterface $gatekeeper): ?ResponseInterface

--- a/src/Module/Application/Admin/Shout/EditShoutAction.php
+++ b/src/Module/Application/Admin/Shout/EditShoutAction.php
@@ -39,20 +39,14 @@ use Psr\Http\Message\ServerRequestInterface;
 /**
  * Edits a ShoutBox item
  */
-final class EditShoutAction implements ApplicationActionInterface
+final readonly class EditShoutAction implements ApplicationActionInterface
 {
     public const REQUEST_KEY = 'edit_shout';
 
-    private UiInterface $ui;
-
-    private ShoutRepositoryInterface $shoutRepository;
-
     public function __construct(
-        UiInterface $ui,
-        ShoutRepositoryInterface $shoutRepository
+        private UiInterface $ui,
+        private ShoutRepositoryInterface $shoutRepository
     ) {
-        $this->ui              = $ui;
-        $this->shoutRepository = $shoutRepository;
     }
 
     public function run(ServerRequestInterface $request, GuiGatekeeperInterface $gatekeeper): ?ResponseInterface

--- a/src/Module/Application/Admin/Shout/ShowAction.php
+++ b/src/Module/Application/Admin/Shout/ShowAction.php
@@ -35,20 +35,14 @@ use Ampache\Module\Util\UiInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-final class ShowAction implements ApplicationActionInterface
+final readonly class ShowAction implements ApplicationActionInterface
 {
     public const REQUEST_KEY = 'show';
 
-    private UiInterface $ui;
-
-    private ModelFactoryInterface $modelFactory;
-
     public function __construct(
-        UiInterface $ui,
-        ModelFactoryInterface $modelFactory
+        private UiInterface $ui,
+        private ModelFactoryInterface $modelFactory
     ) {
-        $this->ui           = $ui;
-        $this->modelFactory = $modelFactory;
     }
 
     public function run(ServerRequestInterface $request, GuiGatekeeperInterface $gatekeeper): ?ResponseInterface

--- a/src/Module/Application/Admin/Shout/ShowEditAction.php
+++ b/src/Module/Application/Admin/Shout/ShowEditAction.php
@@ -33,7 +33,6 @@ use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Shout\ShoutObjectLoaderInterface;
 use Ampache\Module\Util\UiInterface;
-use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\ShoutRepositoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -41,28 +40,15 @@ use Psr\Http\Message\ServerRequestInterface;
 /**
  * Displays the shouts edit-view
  */
-final class ShowEditAction implements ApplicationActionInterface
+final readonly class ShowEditAction implements ApplicationActionInterface
 {
     public const REQUEST_KEY = 'show_edit';
 
-    private UiInterface $ui;
-
-    private ShoutRepositoryInterface $shoutRepository;
-
-    private ModelFactoryInterface $modelFactory;
-
-    private ShoutObjectLoaderInterface $shoutObjectLoader;
-
     public function __construct(
-        UiInterface $ui,
-        ModelFactoryInterface $modelFactory,
-        ShoutObjectLoaderInterface $shoutObjectLoader,
-        ShoutRepositoryInterface $shoutRepository
+        private UiInterface $ui,
+        private ShoutObjectLoaderInterface $shoutObjectLoader,
+        private ShoutRepositoryInterface $shoutRepository
     ) {
-        $this->ui                = $ui;
-        $this->modelFactory      = $modelFactory;
-        $this->shoutObjectLoader = $shoutObjectLoader;
-        $this->shoutRepository   = $shoutRepository;
     }
 
     public function run(ServerRequestInterface $request, GuiGatekeeperInterface $gatekeeper): ?ResponseInterface
@@ -85,11 +71,10 @@ final class ShowEditAction implements ApplicationActionInterface
         }
 
         // load the used who created the shout
-        $shoutUserId = $shout->getUserId();
+        $user = $shout->getUser();
 
-        $user = $this->modelFactory->createUser($shoutUserId);
-        if ($user->isNew()) {
-            throw new ObjectNotFoundException($shoutUserId);
+        if ($user === null) {
+            throw new ObjectNotFoundException();
         }
 
         $this->ui->showHeader();

--- a/src/Module/Application/Exception/ObjectNotFoundException.php
+++ b/src/Module/Application/Exception/ObjectNotFoundException.php
@@ -39,7 +39,7 @@ final class ObjectNotFoundException extends ApplicationException
     /**
      * @param int|string $objectId The requested objectId
      */
-    public function __construct($objectId)
+    public function __construct($objectId = 0)
     {
         $this->objectId = $objectId;
     }

--- a/src/Module/Shout/ShoutCreator.php
+++ b/src/Module/Shout/ShoutCreator.php
@@ -32,37 +32,24 @@ use Ampache\Module\Util\Mailer;
 use Ampache\Module\Util\UtilityFactoryInterface;
 use Ampache\Repository\Model\library_item;
 use Ampache\Repository\Model\LibraryItemEnum;
-use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\Model\User;
 use Ampache\Repository\ShoutRepositoryInterface;
+use Ampache\Repository\UserRepositoryInterface;
 use DateTime;
 use PHPMailer\PHPMailer\Exception;
 
 /**
  * Creates a new shout item
  */
-final class ShoutCreator implements ShoutCreatorInterface
+final readonly class ShoutCreator implements ShoutCreatorInterface
 {
-    private UserActivityPosterInterface $userActivityPoster;
-
-    private ConfigContainerInterface $configContainer;
-
-    private ShoutRepositoryInterface $shoutRepository;
-    private UtilityFactoryInterface $utilityFactory;
-    private ModelFactoryInterface $modelFactory;
-
     public function __construct(
-        UserActivityPosterInterface $userActivityPoster,
-        ConfigContainerInterface $configContainer,
-        ShoutRepositoryInterface $shoutRepository,
-        UtilityFactoryInterface $utilityFactory,
-        ModelFactoryInterface $modelFactory
+        private UserActivityPosterInterface $userActivityPoster,
+        private ConfigContainerInterface $configContainer,
+        private ShoutRepositoryInterface $shoutRepository,
+        private UtilityFactoryInterface $utilityFactory,
+        private UserRepositoryInterface $userRepository,
     ) {
-        $this->userActivityPoster = $userActivityPoster;
-        $this->configContainer    = $configContainer;
-        $this->shoutRepository    = $shoutRepository;
-        $this->utilityFactory     = $utilityFactory;
-        $this->modelFactory       = $modelFactory;
     }
 
     /**
@@ -103,11 +90,11 @@ final class ShoutCreator implements ShoutCreatorInterface
         );
 
         // send email to the item owner
-        $item_owner_id = $libItem->get_user_owner();
-        if ($item_owner_id) {
-            $item_owner = $this->modelFactory->createUser($item_owner_id);
-            if ($item_owner->getPreferenceValue(ConfigurationKeyEnum::NOTIFY_EMAIL)) {
-                $emailAddress = $item_owner->email;
+        $itemOwnerId = $libItem->get_user_owner();
+        if ($itemOwnerId) {
+            $itemOwner = $this->userRepository->findById($itemOwnerId);
+            if ($itemOwner?->getPreferenceValue(ConfigurationKeyEnum::NOTIFY_EMAIL)) {
+                $emailAddress = $itemOwner->email;
 
                 if (!empty($emailAddress) && Mailer::is_mail_enabled()) {
                     /* HINT: %1 username %2 item name being commented on */
@@ -129,7 +116,7 @@ final class ShoutCreator implements ShoutCreatorInterface
 
                     $this->utilityFactory->createMailer()
                         ->set_default_sender()
-                        ->setRecipient($emailAddress, (string) $item_owner->get_fullname())
+                        ->setRecipient($emailAddress, (string) $itemOwner->get_fullname())
                         ->setSubject(T_('New shout on your content'))
                         ->setMessage($message)
                         ->send();

--- a/src/Module/Shout/ShoutObjectLoader.php
+++ b/src/Module/Shout/ShoutObjectLoader.php
@@ -44,7 +44,6 @@ final readonly class ShoutObjectLoader implements ShoutObjectLoaderInterface
     public function __construct(
         private LibraryItemLoaderInterface $libraryItemLoader
     ) {
-
     }
 
     /**

--- a/src/Module/Shout/ShoutRenderer.php
+++ b/src/Module/Shout/ShoutRenderer.php
@@ -32,31 +32,18 @@ use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Authorization\Check\PrivilegeCheckerInterface;
 use Ampache\Module\Util\Ui;
 use Ampache\Repository\Model\Art;
-use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\Model\Shoutbox;
 
 /**
  * Renders a shout within the ui
  */
-final class ShoutRenderer implements ShoutRendererInterface
+final readonly class ShoutRenderer implements ShoutRendererInterface
 {
-    private PrivilegeCheckerInterface $privilegeChecker;
-
-    private ConfigContainerInterface $configContainer;
-
-    private ModelFactoryInterface $modelFactory;
-    private ShoutObjectLoaderInterface $shoutObjectLoader;
-
     public function __construct(
-        PrivilegeCheckerInterface $privilegeChecker,
-        ConfigContainerInterface $configContainer,
-        ModelFactoryInterface $modelFactory,
-        ShoutObjectLoaderInterface $shoutObjectLoader
+        private PrivilegeCheckerInterface $privilegeChecker,
+        private ConfigContainerInterface $configContainer,
+        private ShoutObjectLoaderInterface $shoutObjectLoader
     ) {
-        $this->privilegeChecker  = $privilegeChecker;
-        $this->configContainer   = $configContainer;
-        $this->modelFactory      = $modelFactory;
-        $this->shoutObjectLoader = $shoutObjectLoader;
     }
 
     /**
@@ -114,8 +101,8 @@ final class ShoutRenderer implements ShoutRendererInterface
         }
         $html .= "<div class='shoutbox-user'>" . T_('by') . " ";
 
-        if ($shout->getUserId() > 0) {
-            $user = $this->modelFactory->createUser($shout->getUserId());
+        $user = $shout->getUser();
+        if ($user !== null) {
             if ($details) {
                 $html .= $user->get_f_link();
             } else {

--- a/src/Repository/Model/Shoutbox.php
+++ b/src/Repository/Model/Shoutbox.php
@@ -27,6 +27,7 @@ namespace Ampache\Repository\Model;
 
 use Ampache\Repository\ShoutRepository;
 use Ampache\Repository\ShoutRepositoryInterface;
+use Ampache\Repository\UserRepositoryInterface;
 use DateTime;
 use DateTimeInterface;
 
@@ -58,12 +59,12 @@ class Shoutbox extends BaseModel
     /** @var string|null Offset position in songs */
     private ?string $data = null;
 
-    private ShoutRepositoryInterface $shoutRepository;
+    private ?User $user_object = null;
 
     public function __construct(
-        ShoutRepositoryInterface $shoutRepository
+        private readonly ShoutRepositoryInterface $shoutRepository,
+        private readonly UserRepositoryInterface $userRepository,
     ) {
-        $this->shoutRepository = $shoutRepository;
     }
 
     /**
@@ -191,9 +192,22 @@ class Shoutbox extends BaseModel
      */
     public function setUser(User $user): Shoutbox
     {
-        $this->user = $user->getId();
+        $this->user        = $user->getId();
+        $this->user_object = $user;
 
         return $this;
+    }
+
+    /**
+     * Returns the shout-creator user
+     */
+    public function getUser(): ?User
+    {
+        if ($this->user_object === null) {
+            $this->user_object = $this->userRepository->findById($this->user);
+        }
+
+        return $this->user_object;
     }
 
     /**

--- a/src/Repository/ShoutRepository.php
+++ b/src/Repository/ShoutRepository.php
@@ -41,16 +41,11 @@ use Psr\Log\LoggerInterface;
  */
 final class ShoutRepository extends BaseRepository implements ShoutRepositoryInterface
 {
-    protected DatabaseConnectionInterface $connection;
-
-    private LoggerInterface $logger;
-
     public function __construct(
-        DatabaseConnectionInterface $connection,
-        LoggerInterface $logger
+        protected DatabaseConnectionInterface $connection,
+        private UserRepositoryInterface $userRepository,
+        private LoggerInterface $logger,
     ) {
-        $this->connection   = $connection;
-        $this->logger       = $logger;
     }
 
     /**
@@ -66,7 +61,10 @@ final class ShoutRepository extends BaseRepository implements ShoutRepositoryInt
      */
     protected function getPrototypeParameters(): array
     {
-        return [$this];
+        return [
+            $this,
+            $this->userRepository,
+        ];
     }
 
     protected function getTableName(): string
@@ -87,7 +85,7 @@ final class ShoutRepository extends BaseRepository implements ShoutRepositoryInt
             'SELECT * FROM `user_shout` WHERE `object_type` = ? AND `object_id` = ? ORDER BY `sticky`, `date` DESC',
             [$objectType->value, $objectId]
         );
-        $result->setFetchMode(PDO::FETCH_CLASS, Shoutbox::class, [$this]);
+        $result->setFetchMode(PDO::FETCH_CLASS, Shoutbox::class, $this->getPrototypeParameters());
 
         while ($shout = $result->fetch()) {
             yield $shout;
@@ -195,7 +193,7 @@ final class ShoutRepository extends BaseRepository implements ShoutRepositoryInt
     {
         $result = $this->connection->query('SELECT * FROM `user_shout` WHERE `sticky` = 1 ORDER BY `date` DESC');
 
-        $result->setFetchMode(PDO::FETCH_CLASS, Shoutbox::class, [$this]);
+        $result->setFetchMode(PDO::FETCH_CLASS, Shoutbox::class, $this->getPrototypeParameters());
 
         while ($shout = $result->fetch()) {
             /** @var Shoutbox $shout */
@@ -240,7 +238,7 @@ final class ShoutRepository extends BaseRepository implements ShoutRepositoryInt
             $params
         );
 
-        $result->setFetchMode(PDO::FETCH_CLASS, Shoutbox::class, [$this]);
+        $result->setFetchMode(PDO::FETCH_CLASS, Shoutbox::class, $this->getPrototypeParameters());
 
         while ($shout = $result->fetch()) {
             /** @var Shoutbox $shout */

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -26,10 +26,10 @@ declare(strict_types=1);
 namespace Ampache\Repository;
 
 use Ampache\Config\AmpConfig;
-use Ampache\Repository\Model\User;
 use Ampache\Module\System\Dba;
+use Ampache\Repository\Model\User;
 
-final class UserRepository implements UserRepositoryInterface
+final readonly class UserRepository implements UserRepositoryInterface
 {
     /**
      * This returns a built user from a rsstoken
@@ -41,6 +41,19 @@ final class UserRepository implements UserRepositoryInterface
         $db_results = Dba::read($sql, array($rssToken));
         if ($results = Dba::fetch_assoc($db_results)) {
             $user = new User((int) $results['id']);
+        }
+
+        return $user;
+    }
+
+    /**
+     * Finds a user by its id
+     */
+    public function findById(int $id): ?User
+    {
+        $user = new User($id);
+        if ($user->isNew()) {
+            return null;
         }
 
         return $user;

--- a/src/Repository/UserRepositoryInterface.php
+++ b/src/Repository/UserRepositoryInterface.php
@@ -33,6 +33,11 @@ interface UserRepositoryInterface
     public function getByRssToken(string $rssToken): ?User;
 
     /**
+     * Finds a user by its id
+     */
+    public function findById(int $id): ?User;
+
+    /**
      * Lookup for a user id with a certain name
      */
     public function idByUsername(string $username): int;

--- a/tests/Module/Application/Admin/Shout/ShowEditActionTest.php
+++ b/tests/Module/Application/Admin/Shout/ShowEditActionTest.php
@@ -33,7 +33,6 @@ use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Shout\ShoutObjectLoaderInterface;
 use Ampache\Module\Util\UiInterface;
 use Ampache\Repository\Model\library_item;
-use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\Model\Shoutbox;
 use Ampache\Repository\Model\User;
 use Ampache\Repository\ShoutRepositoryInterface;
@@ -44,8 +43,6 @@ use Psr\Http\Message\ServerRequestInterface;
 class ShowEditActionTest extends TestCase
 {
     private UiInterface&MockObject $ui;
-
-    private ModelFactoryInterface&MockObject $modelFactory;
 
     private ShoutObjectLoaderInterface&MockObject $shoutObjectLoader;
 
@@ -60,13 +57,11 @@ class ShowEditActionTest extends TestCase
     protected function setUp(): void
     {
         $this->ui                = $this->createMock(UiInterface::class);
-        $this->modelFactory      = $this->createMock(ModelFactoryInterface::class);
         $this->shoutObjectLoader = $this->createMock(ShoutObjectLoaderInterface::class);
         $this->shoutRepository   = $this->createMock(ShoutRepositoryInterface::class);
 
         $this->subject = new ShowEditAction(
             $this->ui,
-            $this->modelFactory,
             $this->shoutObjectLoader,
             $this->shoutRepository,
         );
@@ -127,11 +122,9 @@ class ShowEditActionTest extends TestCase
     public function testRunErrorsIfShoutUserWasNotFound(): void
     {
         $shoutId = 666;
-        $userId  = 42;
 
         $shout       = $this->createMock(Shoutbox::class);
         $libraryItem = $this->createMock(library_item::class);
-        $user        = $this->createMock(User::class);
 
         $this->gatekeeper->expects(static::once())
             ->method('mayAccess')
@@ -153,17 +146,8 @@ class ShowEditActionTest extends TestCase
             ->willReturn($libraryItem);
 
         $shout->expects(static::once())
-            ->method('getUserId')
-            ->willReturn($userId);
-
-        $this->modelFactory->expects(static::once())
-            ->method('createUser')
-            ->with($userId)
-            ->willReturn($user);
-
-        $user->expects(static::once())
-            ->method('isNew')
-            ->willReturn(true);
+            ->method('getUser')
+            ->willReturn(null);
 
         static::expectException(ObjectNotFoundException::class);
 
@@ -199,17 +183,8 @@ class ShowEditActionTest extends TestCase
             ->willReturn($libraryItem);
 
         $shout->expects(static::once())
-            ->method('getUserId')
-            ->willReturn($userId);
-
-        $this->modelFactory->expects(static::once())
-            ->method('createUser')
-            ->with($userId)
+            ->method('getUser')
             ->willReturn($user);
-
-        $user->expects(static::once())
-            ->method('isNew')
-            ->willReturn(false);
 
         $this->ui->expects(static::once())
             ->method('showHeader');

--- a/tests/Module/Shout/ShoutCreatorTest.php
+++ b/tests/Module/Shout/ShoutCreatorTest.php
@@ -30,10 +30,10 @@ use Ampache\Module\User\Activity\UserActivityPosterInterface;
 use Ampache\Module\Util\UtilityFactoryInterface;
 use Ampache\Repository\Model\library_item;
 use Ampache\Repository\Model\LibraryItemEnum;
-use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\Model\Shoutbox;
 use Ampache\Repository\Model\User;
 use Ampache\Repository\ShoutRepositoryInterface;
+use Ampache\Repository\UserRepositoryInterface;
 use DateTimeInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -48,7 +48,7 @@ class ShoutCreatorTest extends TestCase
 
     private UtilityFactoryInterface&MockObject $utilityFactory;
 
-    private ModelFactoryInterface&MockObject $modelFactory;
+    private UserRepositoryInterface&MockObject $userRepository;
 
     private ShoutCreator $subject;
 
@@ -58,14 +58,14 @@ class ShoutCreatorTest extends TestCase
         $this->configContainer    = $this->createMock(ConfigContainerInterface::class);
         $this->shoutRepository    = $this->createMock(ShoutRepositoryInterface::class);
         $this->utilityFactory     = $this->createMock(UtilityFactoryInterface::class);
-        $this->modelFactory       = $this->createMock(ModelFactoryInterface::class);
+        $this->userRepository     = $this->createMock(UserRepositoryInterface::class);
 
         $this->subject = new ShoutCreator(
             $this->userActivityPoster,
             $this->configContainer,
             $this->shoutRepository,
             $this->utilityFactory,
-            $this->modelFactory
+            $this->userRepository,
         );
     }
 

--- a/tests/Repository/Model/ShoutboxTest.php
+++ b/tests/Repository/Model/ShoutboxTest.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace Ampache\Repository\Model;
 
 use Ampache\Repository\ShoutRepositoryInterface;
+use Ampache\Repository\UserRepositoryInterface;
 use DateTime;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -36,14 +37,18 @@ class ShoutboxTest extends TestCase
 {
     private ShoutRepositoryInterface&MockObject $shoutRepository;
 
+    private UserRepositoryInterface&MockObject $userRepository;
+
     private Shoutbox $subject;
 
     protected function setUp(): void
     {
         $this->shoutRepository = $this->createMock(ShoutRepositoryInterface::class);
+        $this->userRepository  = $this->createMock(UserRepositoryInterface::class);
 
         $this->subject = new Shoutbox(
             $this->shoutRepository,
+            $this->userRepository,
         );
     }
 
@@ -133,6 +138,21 @@ class ShoutboxTest extends TestCase
         static::assertSame(
             $userId,
             $this->subject->getUserId()
+        );
+    }
+
+    public function testGetUserReturnsUser(): void
+    {
+        $user = $this->createMock(User::class);
+
+        $this->userRepository->expects(static::once())
+            ->method('findById')
+            ->with(0)
+            ->willReturn($user);
+
+        static::assertSame(
+            $user,
+            $this->subject->getUser()
         );
     }
 

--- a/tests/Repository/ShoutRepositoryTest.php
+++ b/tests/Repository/ShoutRepositoryTest.php
@@ -45,15 +45,19 @@ class ShoutRepositoryTest extends TestCase
 
     private LoggerInterface&MockObject $logger;
 
+    private UserRepositoryInterface&MockObject $userRepository;
+
     private ShoutRepository $subject;
 
     protected function setUp(): void
     {
-        $this->connection   = $this->createMock(DatabaseConnectionInterface::class);
-        $this->logger       = $this->createMock(LoggerInterface::class);
+        $this->connection     = $this->createMock(DatabaseConnectionInterface::class);
+        $this->logger         = $this->createMock(LoggerInterface::class);
+        $this->userRepository = $this->createMock(UserRepositoryInterface::class);
 
         $this->subject = new ShoutRepository(
             $this->connection,
+            $this->userRepository,
             $this->logger,
         );
     }
@@ -76,7 +80,14 @@ class ShoutRepositoryTest extends TestCase
 
         $statement->expects(static::once())
             ->method('setFetchMode')
-            ->with(PDO::FETCH_CLASS, Shoutbox::class, [$this->subject]);
+            ->with(
+                PDO::FETCH_CLASS,
+                Shoutbox::class,
+                [
+                    $this->subject,
+                    $this->userRepository,
+                ]
+            );
         $statement->expects(static::exactly(2))
             ->method('fetch')
             ->willReturn($shoutBox, false);
@@ -103,7 +114,7 @@ class ShoutRepositoryTest extends TestCase
 
         $result->expects(static::once())
             ->method('setFetchMode')
-            ->with(PDO::FETCH_CLASS, Shoutbox::class, [$this->subject]);
+            ->with(PDO::FETCH_CLASS, Shoutbox::class, [$this->subject, $this->userRepository]);
         $result->expects(static::once())
             ->method('fetch')
             ->willReturn(false);
@@ -130,7 +141,7 @@ class ShoutRepositoryTest extends TestCase
 
         $result->expects(static::once())
             ->method('setFetchMode')
-            ->with(PDO::FETCH_CLASS, Shoutbox::class, [$this->subject]);
+            ->with(PDO::FETCH_CLASS, Shoutbox::class, [$this->subject, $this->userRepository]);
         $result->expects(static::once())
             ->method('fetch')
             ->willReturn($shout);
@@ -384,14 +395,28 @@ class ShoutRepositoryTest extends TestCase
 
         $result1->expects(static::once())
             ->method('setFetchMode')
-            ->with(PDO::FETCH_CLASS, Shoutbox::class, [$this->subject]);
+            ->with(
+                PDO::FETCH_CLASS,
+                Shoutbox::class,
+                [
+                    $this->subject,
+                    $this->userRepository,
+                ]
+            );
         $result1->expects(static::once())
             ->method('fetch')
             ->willReturn($shout1, false);
 
         $result2->expects(static::once())
             ->method('setFetchMode')
-            ->with(PDO::FETCH_CLASS, Shoutbox::class, [$this->subject]);
+            ->with(
+                PDO::FETCH_CLASS,
+                Shoutbox::class,
+                [
+                    $this->subject,
+                    $this->userRepository,
+                ]
+            );
         $result2->expects(static::exactly(2))
             ->method('fetch')
             ->willReturn($shout2, false);
@@ -423,7 +448,7 @@ class ShoutRepositoryTest extends TestCase
         $this->runFindByIdTrait(
             'user_shout',
             Shoutbox::class,
-            [$this->subject]
+            [$this->subject, $this->userRepository]
         );
     }
 }


### PR DESCRIPTION
Allows to retrieve the shout creator user instead of letting every location querying it directly