### PR TITLE
Lessen rfc 3514

### DIFF
--- a/public/templates/error_page.inc.php
+++ b/public/templates/error_page.inc.php
@@ -43,8 +43,6 @@ $dir       = $dir ?? 'ltr'; ?>
 <link rel="stylesheet" href="templates/install.css" type="text/css" media="screen" />
 </head>
 <body>
-<!-- rfc3514 implementation -->
-    <div id="rfc3514" style="display: none;">0x0</div>
     <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
         <div class="container" style="height: 70px;">
             <a class="navbar-brand" href="#">

--- a/public/templates/test_error_page.inc.php
+++ b/public/templates/test_error_page.inc.php
@@ -41,8 +41,6 @@ $dir       = $dir ?? 'ltr'; ?>
 <link rel="stylesheet" href="templates/install.css" type="text/css" media="screen" />
 </head>
 <body>
-<!-- rfc3514 implementation -->
-    <div id="rfc3514" style="display: none;">0x0</div>
     <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
         <div class="container" style="height: 70px;">
             <a class="navbar-brand" href="#">

--- a/src/Application/Api/Ajax/Handler/BrowseAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/BrowseAjaxHandler.php
@@ -255,7 +255,6 @@ final readonly class BrowseAjaxHandler implements AjaxHandlerInterface
                 }
                 break;
             default:
-                $results['rfc3514'] = '0x1';
                 break;
         } // switch on action;
 

--- a/src/Application/Api/Ajax/Handler/CatalogAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/CatalogAjaxHandler.php
@@ -74,7 +74,6 @@ final readonly class CatalogAjaxHandler implements AjaxHandlerInterface
 
                 break;
             default:
-                $results['rfc3514'] = '0x1';
                 break;
         } // switch on action;
 

--- a/src/Application/Api/Ajax/Handler/DefaultAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/DefaultAjaxHandler.php
@@ -76,7 +76,6 @@ final readonly class DefaultAjaxHandler implements AjaxHandlerInterface
                 break;
             case 'basket_refresh':
                 $results['rightbar'] = Ui::ajax_include('rightbar.inc.php');
-                $results['rfc3514']  = '0x0';
                 break;
             case 'basket':
                 // Handle the users basketcases...
@@ -178,8 +177,6 @@ final readonly class DefaultAjaxHandler implements AjaxHandlerInterface
                     $key           = "rating_" . filter_input(INPUT_GET, 'object_id', FILTER_SANITIZE_NUMBER_INT) . "_" . Core::get_get('rating_type');
                     $results[$key] = ob_get_contents();
                     ob_end_clean();
-                } else {
-                    $results['rfc3514'] = '0x1';
                 }
                 break;
             case 'set_userflag':
@@ -194,8 +191,6 @@ final readonly class DefaultAjaxHandler implements AjaxHandlerInterface
                     $key           = "userflag_" . $flag_id . "_" . $flagtype;
                     $results[$key] = ob_get_contents();
                     ob_end_clean();
-                } else {
-                    $results['rfc3514'] = '0x1';
                 }
                 break;
             case 'action_buttons':
@@ -214,7 +209,6 @@ final readonly class DefaultAjaxHandler implements AjaxHandlerInterface
                 ob_end_clean();
                 break;
             default:
-                $results['rfc3514'] = '0x1';
                 break;
         } // end switch action
 

--- a/src/Application/Api/Ajax/Handler/DemocraticPlaybackAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/DemocraticPlaybackAjaxHandler.php
@@ -80,7 +80,7 @@ final readonly class DemocraticPlaybackAjaxHandler implements AjaxHandlerInterfa
                 }
 
                 $_SESSION['iframe']['target'] = AmpConfig::get('web_path') . '/stream.php?action=democratic&democratic_id=' . scrub_out($_REQUEST['democratic_id']);
-                $results['rfc3514']           = '<script>' . Core::get_reloadutil() . '("' . $_SESSION['iframe']['target'] . '")</script>';
+                $results['reload']            = '<script>' . Core::get_reloadutil() . '("' . $_SESSION['iframe']['target'] . '")</script>';
                 break;
             case 'clear_playlist':
                 if (!Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::ADMIN)) {

--- a/src/Application/Api/Ajax/Handler/DemocraticPlaybackAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/DemocraticPlaybackAjaxHandler.php
@@ -68,8 +68,6 @@ final readonly class DemocraticPlaybackAjaxHandler implements AjaxHandlerInterfa
                 break;
             case 'delete':
                 if ($user->has_access(AccessLevelEnum::MANAGER)) {
-                    echo xoutput_from_array(array('rfc3514' => '0x1'));
-
                     return;
                 }
 
@@ -78,8 +76,6 @@ final readonly class DemocraticPlaybackAjaxHandler implements AjaxHandlerInterfa
                 break;
             case 'send_playlist':
                 if (!Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER)) {
-                    echo (string) xoutput_from_array(array('rfc3514' => '0x1'));
-
                     return;
                 }
 
@@ -88,8 +84,6 @@ final readonly class DemocraticPlaybackAjaxHandler implements AjaxHandlerInterfa
                 break;
             case 'clear_playlist':
                 if (!Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::ADMIN)) {
-                    echo (string) xoutput_from_array(array('rfc3514' => '0x1'));
-
                     return;
                 }
 
@@ -100,7 +94,6 @@ final readonly class DemocraticPlaybackAjaxHandler implements AjaxHandlerInterfa
                 $show_browse = true;
                 break;
             default:
-                $results['rfc3514'] = '0x1';
                 break;
         } // switch on action;
 

--- a/src/Application/Api/Ajax/Handler/IndexAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/IndexAjaxHandler.php
@@ -433,7 +433,6 @@ final readonly class IndexAjaxHandler implements AjaxHandlerInterface
                 ob_end_clean();
                 break;
             default:
-                $results['rfc3514'] = '0x1';
                 break;
         } // switch on action;
 

--- a/src/Application/Api/Ajax/Handler/LocalPlayAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/LocalPlayAjaxHandler.php
@@ -225,7 +225,6 @@ final readonly class LocalPlayAjaxHandler implements AjaxHandlerInterface
 
                 break;
             default:
-                $results['rfc3514'] = '0x1';
                 break;
         } // switch on action;
 

--- a/src/Application/Api/Ajax/Handler/PlayerAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/PlayerAjaxHandler.php
@@ -82,7 +82,6 @@ final readonly class PlayerAjaxHandler implements AjaxHandlerInterface
                 }
                 break;
             default:
-                $results['rfc3514'] = '0x1';
                 break;
         } // switch on action;
 

--- a/src/Application/Api/Ajax/Handler/PlaylistAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/PlaylistAjaxHandler.php
@@ -129,7 +129,7 @@ final readonly class PlaylistAjaxHandler implements AjaxHandlerInterface
                     debug_event('playlist.ajax', 'Items added successfully!', 5);
                     ob_start();
                     display_notification(T_('Added to playlist'));
-                    $results['rfc3514'] = ob_get_clean();
+                    $results['reload'] = ob_get_clean();
                 } else {
                     debug_event('playlist.ajax', 'No item to add. Aborting...', 5);
                 }

--- a/src/Application/Api/Ajax/Handler/PlaylistAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/PlaylistAjaxHandler.php
@@ -135,7 +135,6 @@ final readonly class PlaylistAjaxHandler implements AjaxHandlerInterface
                 }
                 break;
             default:
-                $results['rfc3514'] = '0x1';
                 break;
         }
 

--- a/src/Application/Api/Ajax/Handler/PodcastAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/PodcastAjaxHandler.php
@@ -93,7 +93,5 @@ final readonly class PodcastAjaxHandler implements AjaxHandlerInterface
                 }
                 break;
         }
-
-        echo xoutput_from_array(['rfc3514' => '0x1']);
     }
 }

--- a/src/Application/Api/Ajax/Handler/RandomAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/RandomAjaxHandler.php
@@ -56,7 +56,6 @@ final readonly class RandomAjaxHandler implements AjaxHandlerInterface
             case 'song':
                 $songs = Random::get_default((int)AmpConfig::get('offset_limit', 50), $user);
                 if (!count($songs)) {
-                    $results['rfc3514'] = '0x1';
                     break;
                 }
 
@@ -72,7 +71,6 @@ final readonly class RandomAjaxHandler implements AjaxHandlerInterface
                 );
 
                 if (empty($album_id)) {
-                    $results['rfc3514'] = '0x1';
                     break;
                 }
 
@@ -88,7 +86,6 @@ final readonly class RandomAjaxHandler implements AjaxHandlerInterface
             case 'artist':
                 $artist_id = Random::artist();
                 if (!$artist_id) {
-                    $results['rfc3514'] = '0x1';
                     break;
                 }
 
@@ -104,7 +101,6 @@ final readonly class RandomAjaxHandler implements AjaxHandlerInterface
                 $playlist_id = Random::playlist();
 
                 if (!$playlist_id) {
-                    $results['rfc3514'] = '0x1';
                     break;
                 }
 
@@ -122,7 +118,6 @@ final readonly class RandomAjaxHandler implements AjaxHandlerInterface
                 $results['rfc3514']           = '<script>' . Core::get_reloadutil() . '("' . $_SESSION['iframe']['target'] . '")</script>';
                 break;
             default:
-                $results['rfc3514'] = '0x1';
                 break;
         } // switch on action;
 

--- a/src/Application/Api/Ajax/Handler/RandomAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/RandomAjaxHandler.php
@@ -115,7 +115,7 @@ final readonly class RandomAjaxHandler implements AjaxHandlerInterface
                 break;
             case 'send_playlist':
                 $_SESSION['iframe']['target'] = AmpConfig::get('web_path') . '/stream.php?action=random' . '&random_type=' . scrub_out($_REQUEST['random_type']) . '&random_id=' . scrub_out($_REQUEST['random_id']);
-                $results['rfc3514']           = '<script>' . Core::get_reloadutil() . '("' . $_SESSION['iframe']['target'] . '")</script>';
+                $results['reload']            = '<script>' . Core::get_reloadutil() . '("' . $_SESSION['iframe']['target'] . '")</script>';
                 break;
             default:
                 break;

--- a/src/Application/Api/Ajax/Handler/SearchAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/SearchAjaxHandler.php
@@ -297,8 +297,6 @@ final readonly class SearchAjaxHandler implements AjaxHandlerInterface
                 break;
             case 'search_random':
                 if (!Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER)) {
-                    echo (string) xoutput_from_array(array('rfc3514' => '0x1'));
-
                     return;
                 }
 
@@ -306,7 +304,6 @@ final readonly class SearchAjaxHandler implements AjaxHandlerInterface
                 $results['rfc3514']           = '<script>' . Core::get_reloadutil() . '("' . $_SESSION['iframe']['target'] . '")</script>';
                 break;
             default:
-                $results['rfc3514'] = '0x1';
                 break;
         } // switch on action;
 

--- a/src/Application/Api/Ajax/Handler/SearchAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/SearchAjaxHandler.php
@@ -301,7 +301,7 @@ final readonly class SearchAjaxHandler implements AjaxHandlerInterface
                 }
 
                 $_SESSION['iframe']['target'] = AmpConfig::get('web_path') . '/stream.php?action=search_random&search_id=' . scrub_out($_REQUEST['playlist_id']);
-                $results['rfc3514']           = '<script>' . Core::get_reloadutil() . '("' . $_SESSION['iframe']['target'] . '")</script>';
+                $results['reload']            = '<script>' . Core::get_reloadutil() . '("' . $_SESSION['iframe']['target'] . '")</script>';
                 break;
             default:
                 break;

--- a/src/Application/Api/Ajax/Handler/SongAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/SongAjaxHandler.php
@@ -101,7 +101,6 @@ final readonly class SongAjaxHandler implements AjaxHandlerInterface
                 $results['shouts_data'] = ob_get_clean();
                 break;
             default:
-                $results['rfc3514'] = '0x1';
                 break;
         } // switch on action;
 

--- a/src/Application/Api/Ajax/Handler/StreamAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/StreamAjaxHandler.php
@@ -49,7 +49,6 @@ final readonly class StreamAjaxHandler implements AjaxHandlerInterface
             case 'set_play_type':
                 // Make sure they have the rights to do this
                 if (!Preference::has_access('play_type')) {
-                    $results['rfc3514'] = '0x1';
                     break;
                 }
 
@@ -59,7 +58,6 @@ final readonly class StreamAjaxHandler implements AjaxHandlerInterface
                     case 'democratic':
                         $key = 'allow_' . Core::get_post('type') . '_playback';
                         if (!AmpConfig::get($key)) {
-                            $results['rfc3514'] = '0x1';
                             break 2;
                         }
                         $new = Core::get_post('type');
@@ -68,7 +66,6 @@ final readonly class StreamAjaxHandler implements AjaxHandlerInterface
                         $new = 'web_player';
                         break;
                     default:
-                        $results['rfc3514'] = '0x1';
                         break 2;
                 } // end switch
 
@@ -83,7 +80,6 @@ final readonly class StreamAjaxHandler implements AjaxHandlerInterface
                     $results['rightbar'] = Ui::ajax_include('rightbar.inc.php');
                 }
 
-                $results['rfc3514'] = '0x0';
                 break;
             case 'directplay':
                 $object_type = Core::get_request('object_type');
@@ -134,7 +130,6 @@ final readonly class StreamAjaxHandler implements AjaxHandlerInterface
                 $results['rfc3514'] = '<script>' . Core::get_reloadutil() . '(\'' . $web_path . '/util.php\');</script>';
                 break;
             default:
-                $results['rfc3514'] = '0x1';
                 break;
         } // switch on action;
 

--- a/src/Application/Api/Ajax/Handler/StreamAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/StreamAjaxHandler.php
@@ -109,7 +109,7 @@ final readonly class StreamAjaxHandler implements AjaxHandlerInterface
                     if (AmpConfig::get('play_type') == 'localplay') {
                         $_SESSION['iframe']['target'] .= '&client=' . AmpConfig::get('localplay_controller');
                     }
-                    $results['rfc3514'] = '<script>' . Core::get_reloadutil() . '(\'' . $web_path . '/util.php\');</script>';
+                    $results['reload'] = '<script>' . Core::get_reloadutil() . '(\'' . $web_path . '/util.php\');</script>';
                 }
                 break;
             case 'basket':
@@ -127,7 +127,7 @@ final readonly class StreamAjaxHandler implements AjaxHandlerInterface
                 $_SESSION['iframe']['target'] = (array_key_exists('playlist_method', $_REQUEST))
                     ? $web_path . '/stream.php?action=basket&playlist_method=' . scrub_out($_REQUEST['playlist_method'])
                     : $web_path . '/stream.php?action=basket';
-                $results['rfc3514'] = '<script>' . Core::get_reloadutil() . '(\'' . $web_path . '/util.php\');</script>';
+                $results['reload'] = '<script>' . Core::get_reloadutil() . '(\'' . $web_path . '/util.php\');</script>';
                 break;
             default:
                 break;

--- a/src/Application/Api/Ajax/Handler/TagAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/TagAjaxHandler.php
@@ -83,7 +83,6 @@ final readonly class TagAjaxHandler implements AjaxHandlerInterface
                 // Retrieve current objects of type based on combined filters
                 break;
             default:
-                $results['rfc3514'] = '0x1';
                 break;
         } // switch on action;
 

--- a/src/Application/Api/Ajax/Handler/UserAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/UserAjaxHandler.php
@@ -72,7 +72,6 @@ final readonly class UserAjaxHandler implements AjaxHandlerInterface
                 }
                 break;
             default:
-                $results['rfc3514'] = '0x1';
                 break;
         } // switch on action;
 

--- a/src/Module/Api/Edit/AbstractEditAction.php
+++ b/src/Module/Api/Edit/AbstractEditAction.php
@@ -113,8 +113,6 @@ abstract class AbstractEditAction implements ApplicationActionInterface
 
         // Make sure they got them rights
         if (!Access::check(AccessTypeEnum::INTERFACE, $level) || $this->configContainer->isFeatureEnabled(ConfigurationKeyEnum::DEMO_MODE) === true) {
-            echo (string) xoutput_from_array(array('rfc3514' => '0x1'));
-
             return null;
         }
 

--- a/src/Module/Authentication/AuthenticationManager.php
+++ b/src/Module/Authentication/AuthenticationManager.php
@@ -137,7 +137,7 @@ final class AuthenticationManager implements AuthenticationManagerInterface
             xoutput_headers();
 
             $results            = array();
-            $results['rfc3514'] = '<script>reloadRedirect("' . $target . '")</script>';
+            $results['reload']  = '<script>reloadRedirect("' . $target . '")</script>';
             echo (string)xoutput_from_array($results);
         } else {
             /* Redirect them to the login page */


### PR DESCRIPTION
Removes the superfluous use of the [evil bit](https://en.wikipedia.org/wiki/Evil_bit), keeping just one unobtrusive reference in the [header](https://github.com/ampache/ampache/blob/31088e92252c61eb4aaa8d8484c9c7fd86a2a870/public/templates/header.inc.php#L107). 

It was also being used for actual output so those have been renamed.

(sorry to whoever implemented this originally)