### PR TITLE
Rework of get_themes() to let PHP handle most of the work

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -111,11 +111,6 @@ parameters:
 			path: src/Config/Init/InitializationHandlerConfig.php
 
 		-
-			message: "#^Cannot access offset 'path' on array\\|false\\.$#"
-			count: 1
-			path: src/Config/functions.php
-
-		-
 			message: "#^Function apache_request_headers\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Config/functions.php

--- a/public/templates/show_form_search.inc.php
+++ b/public/templates/show_form_search.inc.php
@@ -107,6 +107,7 @@ Ui::show_box_top(T_('Search Ampache') . "...", 'box box_advanced_search'); ?>
 <?php require Ui::find_template('show_rules.inc.php'); ?>
 
 <div class="formValidation">
+    <a href="<?php echo $web_path.'/search.php?type='.$currentType.'&'.http_build_query($_POST);?>" target=_blank><?php echo T_('Permalink'); ?></a>
     <input class="button" type="submit" value="<?php echo T_('Search'); ?>" />&nbsp;&nbsp;
 <?php if ($currentType == 'song' && Access::check('interface', 25)) { ?>
     <input id="savesearchbutton" class="button" type="submit" value="<?php echo T_('Save as Smart Playlist'); ?>" onClick="$('#hiddenaction').val('save_as_smartplaylist');" />&nbsp;&nbsp;

--- a/public/templates/show_form_search.inc.php
+++ b/public/templates/show_form_search.inc.php
@@ -107,7 +107,6 @@ Ui::show_box_top(T_('Search Ampache') . "...", 'box box_advanced_search'); ?>
 <?php require Ui::find_template('show_rules.inc.php'); ?>
 
 <div class="formValidation">
-    <a href="<?php echo $web_path.'/search.php?type='.$currentType.'&'.http_build_query($_POST);?>" target=_blank><?php echo T_('Permalink'); ?></a>
     <input class="button" type="submit" value="<?php echo T_('Search'); ?>" />&nbsp;&nbsp;
 <?php if ($currentType == 'song' && Access::check('interface', 25)) { ?>
     <input id="savesearchbutton" class="button" type="submit" value="<?php echo T_('Save as Smart Playlist'); ?>" onClick="$('#hiddenaction').val('save_as_smartplaylist');" />&nbsp;&nbsp;

--- a/src/Config/functions.php
+++ b/src/Config/functions.php
@@ -1191,19 +1191,19 @@ function nT_($original, $plural, $value): string
  */
 function get_themes(): array
 {
+    $results = array();
+
     $lst_files = glob(__DIR__ . '/../../public/themes/*/theme.cfg.php');
-
-    $results=array();
-    foreach ($lst_files as $file){
-        debug_event('themes', "Checking $file", 5);
-        $cfg = get_theme($file);
-        if (is_null($cfg)) {
-            debug_event('themes', "Warning: them $file is empty", 5);
+    foreach ($lst_files as $cfg_file) {
+        $name = basename(dirname($cfg_file)); // Get last dirname (name of the theme)
+        debug_event('themes', "Checking $name", 5);
+        $theme_cfg = get_theme($name, $cfg_file);
+        if (is_null($theme_cfg)) {
+            debug_event('themes', "Warning: $name theme config is empty", 1);
             continue;
-	}
+        }
 
-        $theme = basename(dirname($file)); // Get last dirname (name of the theme)
-        $results[$theme]=$cfg;
+        $results[$name] = $theme_cfg;
     }
 
     // Sort by the theme name
@@ -1234,17 +1234,22 @@ function get_theme($name)
 
     $config_file = __DIR__ . "/../../public/themes/" . $name . "/theme.cfg.php";
     if (file_exists($config_file)) {
-        $results         = parse_ini_file($config_file);
-        $results['path'] = $name;
-        $results['base'] = explode(',', (string) $results['base']);
-        $nbbases         = count($results['base']);
-        for ($count = 0; $count < $nbbases; $count++) {
-            $results['base'][$count] = explode('|', $results['base'][$count]);
+        $results = parse_ini_file($config_file);
+        if (is_array($results)) {
+            $results['path'] = $name;
+            $results['base'] = explode(',', (string)$results['base']);
+            $nbbases         = count($results['base']);
+            for ($count = 0; $count < $nbbases; $count++) {
+                $results['base'][$count] = explode('|', $results['base'][$count]);
+            }
+            $results['colors'] = explode(',', (string)$results['colors']);
+        } else {
+            $results = null;
         }
-        $results['colors'] = explode(',', (string) $results['colors']);
     } else {
         $results = null;
     }
+
     $_mapcache[$name] = $results;
 
     return $results;

--- a/src/Config/functions.php
+++ b/src/Config/functions.php
@@ -1194,6 +1194,12 @@ function get_themes(): array
     $results = array();
 
     $lst_files = glob(__DIR__ . '/../../public/themes/*/theme.cfg.php');
+    if (!$lst_files) {
+        debug_event('themes', 'Failed to open /themes directory', 2);
+
+        return $results;
+    }
+
     foreach ($lst_files as $cfg_file) {
         $name = basename(dirname($cfg_file)); // Get last dirname (name of the theme)
         debug_event('themes', "Checking $name", 5);

--- a/src/Config/functions.php
+++ b/src/Config/functions.php
@@ -1197,7 +1197,7 @@ function get_themes(): array
     foreach ($lst_files as $cfg_file) {
         $name = basename(dirname($cfg_file)); // Get last dirname (name of the theme)
         debug_event('themes', "Checking $name", 5);
-        $theme_cfg = get_theme($name, $cfg_file);
+        $theme_cfg = get_theme($name);
         if (is_null($theme_cfg)) {
             debug_event('themes', "Warning: $name theme config is empty", 1);
             continue;

--- a/src/Config/functions.php
+++ b/src/Config/functions.php
@@ -1191,25 +1191,21 @@ function nT_($original, $plural, $value): string
  */
 function get_themes(): array
 {
-    /* Open the themes dir and start reading it */
-    $handle = opendir(__DIR__ . '/../../public/themes');
+    $lst_files = glob(__DIR__ . '/../../public/themes/*/theme.cfg.php');
 
-    if (!is_resource($handle)) {
-        debug_event('themes', 'Failed to open /themes directory', 2);
+    $results=array();
+    foreach ($lst_files as $file){
+        debug_event('themes', "Checking $file", 5);
+        $cfg = get_theme($file);
+        if (is_null($cfg)) {
+            debug_event('themes', "Warning: them $file is empty", 5);
+            continue;
+	}
 
-        return array();
+        $theme = basename(dirname($file)); // Get last dirname (name of the theme)
+        $results[$theme]=$cfg;
     }
 
-    $results = array();
-    while (($file = readdir($handle)) !== false) {
-        if ((string) $file !== '.' && (string) $file !== '..') {
-            debug_event('themes', "Checking $file", 5);
-            $cfg = get_theme($file);
-            if ($cfg !== null) {
-                $results[$cfg['name']] = $cfg;
-            }
-        }
-    } // end while directory
     // Sort by the theme name
     ksort($results);
 

--- a/src/Repository/Model/Preference.php
+++ b/src/Repository/Model/Preference.php
@@ -1245,8 +1245,8 @@ class Preference extends database_object
         $results['theme_path'] = '/themes/' . $results['theme_name'];
 
         // Load theme settings
-        $themecfg                  = get_theme($results['theme_name']);
-        $results['theme_css_base'] = $themecfg['base'];
+        $theme_cfg                 = get_theme($results['theme_name']);
+        $results['theme_css_base'] = $theme_cfg['base'];
 
         if (array_key_exists('theme_color', $results) && strlen((string)$results['theme_color']) > 0) {
             // In case the color was removed
@@ -1257,7 +1257,7 @@ class Preference extends database_object
             unset($results['theme_color']);
         }
         if (!isset($results['theme_color'])) {
-            $results['theme_color'] = strtolower((string)$themecfg['colors'][0]);
+            $results['theme_color'] = strtolower((string)$theme_cfg['colors'][0]);
         }
 
         AmpConfig::set_by_array($results, true);


### PR DESCRIPTION
Instead of using `opendir()`/`readir()` I used `glob()`, so we get only directory with a `theme.cfg.php` file.

If themes dir have some trash in it (like `.htaccess` or anything else), it won't show.

I think I could even get rid of the `ksort()`, but I let it.