### PR TITLE
Album name added to songs search

### DIFF
--- a/public/templates/base.css
+++ b/public/templates/base.css
@@ -225,10 +225,14 @@ a.tag_size4 { text-decoration: none; }
     float: left;
 }
 
+.ui-menu .ui-menu-item.ui-menu-item a {
+    display: flex;
+    align-items: center;
+}
+
 .searchitemtxt {
     display: inline-block;
     vertical-align: middle;
-    height: 32px;
     color: #222;
 }
 

--- a/public/themes/reborn/templates/default.css
+++ b/public/themes/reborn/templates/default.css
@@ -408,6 +408,7 @@ div#autoupdate > span {
 
 #ui-id-1 {
     min-width: 20%;
+    max-width: 630px;
 }
 
 /* --------------------------

--- a/src/Application/Api/Ajax/Handler/SearchAjaxHandler.php
+++ b/src/Application/Api/Ajax/Handler/SearchAjaxHandler.php
@@ -184,6 +184,7 @@ final readonly class SearchAjaxHandler implements AjaxHandlerInterface
                             'value' => scrub_out($song->title),
                             'rels' => scrub_out($song->get_artist_fullname()),
                             'image' => (string)Art::url($art_object, $art_type, null, 10),
+                            'album' => $song->get_album_fullname(),
                         ];
                     }
                 }

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -9,7 +9,7 @@ $.widget( "custom.catcomplete", $.ui.autocomplete, {
         if (item.image !== '') {
             itemhtml += "<img src='" + item.image + "' class='searchart' alt=''>";
         }
-        itemhtml += "<span class='searchitemtxt'>" + item.label + ((item.rels === '') ? "" : " - " + item.rels) + "</span>";
+        itemhtml += "<span class='searchitemtxt'>" + item.label + (item.album ? " - " + item.album : "") + ((item.rels === '') ? "" : " - " + item.rels) + "</span>";
         itemhtml += "</a>";
 
         return $( "<li class='ui-menu-item'>" )


### PR DESCRIPTION
Hi there,
On the search bar, when you have more than one version of a same song (studio album, lives…) I thought it could be handy to display the album name.
I made a CSS adjustment to improve the styling on long line result.

I would also make a PR to reorder CSS loading. Seems weird to me that components CSS loads after ours.

Before:
```css
<link rel="stylesheet" href="https://ampache.simou.net/templates/base.css" type="text/css" media="screen">
<link rel="stylesheet" href="/templates/jquery-ui.custom.css" type="text/css" media="screen">
```


After:
```css
<link rel="stylesheet" href="/templates/jquery-ui.custom.css" type="text/css" media="screen">
<link rel="stylesheet" href="https://ampache.simou.net/templates/base.css" type="text/css" media="screen">
```

It would be easier to override default styling instead of duplicating a class to have an higher specificity, just like here with the `.ui-menu-item.ui-menu-item` class.