### PR TITLE
Fix pause across tabs

### DIFF
--- a/public/templates/show_html5_player.inc.php
+++ b/public/templates/show_html5_player.inc.php
@@ -163,7 +163,7 @@ echo implode(',', $solutions); ?>",
                 playlist = jplaylist.playlist;
             var pos = $(".jp-playlist-current").position().top + $(".jp-playlist").scrollTop();
             $(".jp-playlist").scrollTop(pos);
-            <?php if ($iframed && AmpConfig::get('webplayer_confirmclose')) { ?>
+            <?php if ($iframed && AmpConfig::get('webplayer_pausetabs')) { ?>
             localStorage.setItem('ampache-current-webplayer', jpuqid);
             <?php } ?>
 

--- a/public/templates/show_html5_player_headers.inc.php
+++ b/public/templates/show_html5_player_headers.inc.php
@@ -587,7 +587,7 @@ if ($iframed) { ?>
         return null;
     }
     <?php } ?>
-    <?php if ($iframed && AmpConfig::get('webplayer_confirmclose') && !$isShare) { ?>
+    <?php if ($iframed && AmpConfig::get('webplayer_pausetabs') && !$isShare) { ?>
     window.addEventListener('storage', function (event) {
         if (event.key == 'ampache-current-webplayer') {
             // The latest used webplayer is not this player, pause song if playing


### PR DESCRIPTION
This works as intended now, while a song is playing open a new tab and play a new song in that tab, the player in first tab will pause itself.