### PR TITLE
Fix the run:updateCatalog default actions

### DIFF
--- a/src/Module/Cli/UpdateCatalogCommand.php
+++ b/src/Module/Cli/UpdateCatalogCommand.php
@@ -44,7 +44,7 @@ final class UpdateCatalogCommand extends Command
     public function __construct(
         UpdateCatalogInterface $updateCatalog
     ) {
-        parent::__construct('run:updateCatalog', T_('Perform catalog actions for all files of a catalog. If no options are given, the defaults actions -ceag are assumed'));
+        parent::__construct('run:updateCatalog', T_('Perform catalog actions for all files of a catalog. If no options are given, the defaults actions -ceagt are assumed'));
 
         $this->updateCatalog = $updateCatalog;
 


### PR DESCRIPTION
It looks like now the default actions for run:updateCatalog cli command are -ceagt. But this has not been reflected in the documentation.
This PR fixes that.