### PR TITLE
Fix input to check_int. Use PHP_INT_MAX rather than hardcoded 4294967294

### DIFF
--- a/src/Module/Util/VaInfo.php
+++ b/src/Module/Util/VaInfo.php
@@ -653,7 +653,7 @@ final class VaInfo implements VaInfoInterface
             $info['display_x']     = (!$info['display_x'] && array_key_exists('display_x', $tags)) ? (int)$tags['display_x'] : $info['display_x'];
             $info['display_y']     = (!$info['display_y'] && array_key_exists('display_y', $tags)) ? (int)$tags['display_y'] : $info['display_y'];
             $info['frame_rate']    = (!$info['frame_rate'] && array_key_exists('frame_rate', $tags)) ? (float)$tags['frame_rate'] : $info['frame_rate'];
-            $info['video_bitrate'] = (!$info['video_bitrate'] && array_key_exists('video_bitrate', $tags)) ? Catalog::check_int((int) $tags['video_bitrate'], 4294967294, 0) : $info['video_bitrate'];
+            $info['video_bitrate'] = (!$info['video_bitrate'] && array_key_exists('video_bitrate', $tags)) ? Catalog::check_int((int) $tags['video_bitrate'], PHP_INT_MAX, 0) : $info['video_bitrate'];
             $info['audio_codec']   = (!$info['audio_codec'] && array_key_exists('audio_codec', $tags)) ? trim((string)$tags['audio_codec']) : $info['audio_codec'];
             $info['video_codec']   = (!$info['video_codec'] && array_key_exists('video_codec', $tags)) ? trim((string)$tags['video_codec']) : $info['video_codec'];
             $info['description']   = (!$info['description'] && array_key_exists('description', $tags)) ? trim((string)$tags['description']) : $info['description'];

--- a/src/Repository/Model/Catalog.php
+++ b/src/Repository/Model/Catalog.php
@@ -3061,7 +3061,7 @@ abstract class Catalog extends database_object
         $new_video->display_x     = $results['display_x'];
         $new_video->display_y     = $results['display_y'];
         $new_video->frame_rate    = $results['frame_rate'];
-        $new_video->video_bitrate = self::check_int($results['video_bitrate'], 4294967294, 0);
+        $new_video->video_bitrate = self::check_int($results['video_bitrate'], PHP_INT_MAX, 0);
         $tags                     = Tag::get_object_tags('video', $video->id);
         $video_tags               = [];
         if ($tags) {

--- a/src/Repository/Model/Video.php
+++ b/src/Repository/Model/Video.php
@@ -557,7 +557,7 @@ class Video extends database_object implements
         $disx          = (int) $data['display_x'];
         $disy          = (int) $data['display_y'];
         $frame_rate    = (float) $data['frame_rate'];
-        $video_bitrate = Catalog::check_int($data['video_bitrate'], 4294967294, 0);
+        $video_bitrate = Catalog::check_int($data['video_bitrate'], PHP_INT_MAX, 0);
 
         $sql    = "INSERT INTO `video` (`file`, `catalog`, `title`, `video_codec`, `audio_codec`, `resolution_x`, `resolution_y`, `size`, `time`, `mime`, `release_date`, `addition_time`, `bitrate`, `mode`, `channels`, `display_x`, `display_y`, `frame_rate`, `video_bitrate`) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
         $params = [


### PR DESCRIPTION
After the upgrade to 7.4.2 I get the following exception when upgrading the catalog:
```
sudo -u www-data php -f /var/www/ampache/bin/cli run:updateCatalog -a
Leyendo Catálogo: "My Catalogue"

Empezar a añadir nuevos medios
Reading flac inside /music
TypeError Ampache\Repository\Model\Catalog::check_int(): Argument #2 ($max) must be of type int, float given, called in /var/www/ampache/src/Module/Util/VaInfo.php on line 660
(thrown in /var/www/ampache/src/Repository/Model/Catalog.php:3738)

```
It looks like after introducing type declarations the inputs of check_int in Catalog.php need to be integers. There are a few calls to that function that use 4294967294 as a hard-coded upper limit, which is interpreted as a float. This pull request replaces them by PHP_INT_MAX, which also has the advantage of being platform independent.