### PR TITLE
Check for find action when deciding default actions

### DIFF
--- a/src/Module/Cli/UpdateCatalogCommand.php
+++ b/src/Module/Cli/UpdateCatalogCommand.php
@@ -76,6 +76,7 @@ final class UpdateCatalogCommand extends Command
             empty($values['add']) &&
             empty($values['art']) &&
             empty($values['verify']) &&
+            empty($values['find']) &&
             empty($values['update']) &&
             empty($values['import']) &&
             empty($values['optimize']) &&


### PR DESCRIPTION
This small change just checks for the "find" action in the run:updateCatalog command when deciding for the default actions to take. It was simply missing from the list.