### PR TITLE
Missing user in images enum class

### DIFF
--- a/src/Repository/Model/LibraryItemEnum.php
+++ b/src/Repository/Model/LibraryItemEnum.php
@@ -43,4 +43,5 @@ enum LibraryItemEnum: string
     case TAG_HIDDEN      = 'tag_hidden';
     case TAG             = 'tag';
     case VIDEO           = 'video';
+    case USER            = 'user';
 }

--- a/src/Repository/Model/LibraryItemLoader.php
+++ b/src/Repository/Model/LibraryItemLoader.php
@@ -78,6 +78,7 @@ final readonly class LibraryItemLoader implements LibraryItemLoaderInterface
             LibraryItemEnum::SONG_PREVIEW => new Song_Preview($objectId),
             LibraryItemEnum::TAG_HIDDEN, LibraryItemEnum::TAG => new Tag($objectId),
             LibraryItemEnum::VIDEO => new Video($objectId),
+            LibraryItemEnum::USER => new User($objectId),
         };
 
         if (!($object?->isNew())) {


### PR DESCRIPTION
User is allowed in db but not in class.

Caught it because of this error in logs:
`(src/Module/Application/Image/ShowAction.php:94) -> "user" is not a valid backing value for enum Ampache\Repository\Model\LibraryItemEnum`

It fix those links : 

- https://FQDN/image.php?object_type=user&object_id=28496&thumb=4