### PR TITLE
Use getId() instead of $this->id

### DIFF
--- a/src/Module/Api/OpenSubsonic_Json_Data.php
+++ b/src/Module/Api/OpenSubsonic_Json_Data.php
@@ -852,7 +852,7 @@ class OpenSubsonic_Json_Data
         }
 
         if ($songs) {
-            $allsongs = self::getAlbumRepository()->getSongs($album->getId());;
+            $allsongs = self::getAlbumRepository()->getSongs($album->getId());
             $entries  = [];
             foreach ($allsongs as $song_id) {
                 $entries[] = self::_getChild($song_id, 'song');

--- a/src/Repository/Model/Browse.php
+++ b/src/Repository/Model/Browse.php
@@ -197,7 +197,7 @@ class Browse extends Query
      */
     public function add_supplemental_object(string $class, int $uid): bool
     {
-        $_SESSION['browse']['supplemental'][$this->id][$class] = $uid;
+        $_SESSION['browse']['supplemental'][$this->getId()][$class] = $uid;
 
         return true;
     }
@@ -549,7 +549,7 @@ class Browse extends Query
         $total       = $this->get_total();
         $next_offset = $start + $limit;
         if ($next_offset <= $total) {
-            echo '<a class="jscroll-next" href="' . $dic->get(AjaxUriRetrieverInterface::class)->getAjaxUri() . '?page=browse&action=page&browse_id=' . $this->id . '&start=' . $next_offset . '&xoutput=raw&xoutputnode=' . $this->get_content_div() . '&show_header=false' . $argument_param . '">' . T_('More') . '</a>';
+            echo '<a class="jscroll-next" href="' . $dic->get(AjaxUriRetrieverInterface::class)->getAjaxUri() . '?page=browse&action=page&browse_id=' . $this->getId() . '&start=' . $next_offset . '&xoutput=raw&xoutputnode=' . $this->get_content_div() . '&show_header=false' . $argument_param . '">' . T_('More') . '</a>';
         }
     }
 

--- a/src/Repository/Model/Browse.php
+++ b/src/Repository/Model/Browse.php
@@ -209,7 +209,7 @@ class Browse extends Query
      */
     public function get_supplemental_objects(): array
     {
-        $objects = $_SESSION['browse']['supplemental'][$this->id] ?? '';
+        $objects = $_SESSION['browse']['supplemental'][$this->getId()] ?? '';
 
         if (!is_array($objects)) {
             $objects = [];
@@ -296,8 +296,8 @@ class Browse extends Query
         }
 
         // Set the correct classes based on type
-        $class = "box browse_" . $type . '_' . $this->id;
-        debug_event(self::class, 'show_objects called. browse {' . $this->id . '} type {' . $type . '}', 5);
+        $class = "box browse_" . $type . '_' . $this->getId();
+        debug_event(self::class, 'show_objects called. browse {' . $this->getId() . '} type {' . $type . '}', 5);
 
         // hide some of the useless columns in a browse
         $hide_columns   = [];
@@ -518,7 +518,7 @@ class Browse extends Query
 
             if ($this->is_use_filters()) {
                 echo '<script>';
-                echo Ajax::action('?page=browse&action=get_filters&browse_id=' . $this->id . $argument_param, '');
+                echo Ajax::action('?page=browse&action=get_filters&browse_id=' . $this->getId() . $argument_param, '');
                 echo ';</script>';
             }
         } elseif (!$this->is_use_pages()) {

--- a/src/Repository/Model/Query.php
+++ b/src/Repository/Model/Query.php
@@ -849,7 +849,7 @@ class Query
 
         if (!$this->is_simple()) {
             $sql        = 'SELECT `data`, `object_data` FROM `tmp_browse` WHERE `sid` = ? AND `id` = ?';
-            $db_results = Dba::read($sql, [session_id(), $this->id]);
+            $db_results = Dba::read($sql, [session_id(), $this->getId()]);
             $results    = Dba::fetch_assoc($db_results);
 
             if (array_key_exists('data', $results) && !empty($results['data'])) {
@@ -1344,7 +1344,7 @@ class Query
      */
     public function store(): void
     {
-        $browse_id = $this->id;
+        $browse_id = $this->getId();
         if ($browse_id != 'nocache') {
             $data = $this->_serialize($this->_state);
 
@@ -1369,7 +1369,7 @@ class Query
         if (!$this->is_simple()) {
             $this->_cache = $object_ids;
             $this->set_total(count($object_ids));
-            $browse_id = $this->id;
+            $browse_id = $this->getId();
             if ($browse_id != 'nocache') {
                 $data = $this->_serialize($this->_cache);
 
@@ -1391,7 +1391,7 @@ class Query
             $key .= '_' . $this->_state['extended_key_name'];
         }
 
-        return $key . ('_' . $this->id);
+        return $key . ('_' . $this->getId());
     }
 
     /**


### PR DESCRIPTION
Got error like 
`PHP Fatal error:  Uncaught Error: Typed property Ampache\\Repository\\Model\\Query::$id must not be accessed before initialization in /opt/play.dogmazic.net/src/Repository/Model/Browse.php:521`

id is not always set, and getId() already got a workaround

So I use getId() instead of $this->id , no more errors