### PR TITLE
Direct call to image.php

### DIFF
--- a/public/image.php
+++ b/public/image.php
@@ -34,6 +34,13 @@ use Psr\Container\ContainerInterface;
 define('NO_SESSION', '1');
 define('OUTDATED_DATABASE_OK', 1);
 
+if (empty($_REQUEST)) {
+    // You should always call this file with some parameters
+    echo 'Status: 400 Missing parameters';
+    http_response_code(400);
+    die();
+}
+
 /** @var ContainerInterface $dic */
 $dic = require __DIR__ . '/../src/Config/Init.php';
 


### PR DESCRIPTION
If you call image.php without parameters: 
```
2025-06-21T19:55:30+00:00 [-1] (src/Repository/Model/Art.php:267) -> Typed property Ampache\Repository\Model\Art::$object_type must not be accessed before initialization
```

So, I added a dumb fix to handle dumb bot and not having error in my log.

I'm pretty sure you'll want to handle this another way, feel free to trash this PR