### PR TITLE
Fix PHP8.4 errors

### DIFF
--- a/src/Repository/Model/Catalog.php
+++ b/src/Repository/Model/Catalog.php
@@ -1048,7 +1048,7 @@ abstract class Catalog extends database_object
     /**
      * Run the cache_catalog_proc() on music catalogs.
      */
-    public static function cache_catalogs(Interactor $interactor = null): void
+    public static function cache_catalogs(?Interactor $interactor = null): void
     {
         $path   = (string)AmpConfig::get('cache_path', '');
         $target = (string)AmpConfig::get('cache_target', '');
@@ -3525,7 +3525,7 @@ abstract class Catalog extends database_object
      * @param string[] $gather_types
      * @return array<string, mixed>
      */
-    public function get_media_tags(Podcast_Episode|Video|Song $media, array $gather_types, string $sort_pattern, string $rename_pattern, string $file_override = null): array
+    public function get_media_tags(Podcast_Episode|Video|Song $media, array $gather_types, string $sort_pattern, string $rename_pattern, ?string $file_override = null): array
     {
         // Check for patterns
         if (!$sort_pattern || !$rename_pattern) {

--- a/src/Repository/Model/Song.php
+++ b/src/Repository/Model/Song.php
@@ -811,7 +811,7 @@ class Song extends database_object implements
      * gets the catalog_number of $this->album, allows passing of id
      * @param int|null $album_id
      */
-    public function get_album_catalog_number(int $album_id = null): ?string
+    public function get_album_catalog_number(?int $album_id = null): ?string
     {
         if ($album_id === null) {
             $album_id = $this->album;
@@ -827,7 +827,7 @@ class Song extends database_object implements
      * gets the original_year of $this->album, allows passing of id
      * @param int|null $album_id
      */
-    public function get_album_original_year(int $album_id = null): ?int
+    public function get_album_original_year(?int $album_id = null): ?int
     {
         if ($album_id === null) {
             $album_id = $this->album;
@@ -843,7 +843,7 @@ class Song extends database_object implements
      * gets the barcode of $this->album, allows passing of id
      * @param int|null $album_id
      */
-    public function get_album_barcode(int $album_id = null): ?string
+    public function get_album_barcode(?int $album_id = null): ?string
     {
         if (!$album_id) {
             $album_id = $this->album;


### PR DESCRIPTION
Debian Trixie here, with PHP8.4

Some warning in the logs

```
     22  (log.lib) -> [Error] Ampache\Repository\Model\Catalog::cache_catalogs(): Implicitly marking parameter $interactor as nullable is deprecated, the explicit nullable type must be used instead in file src/Repository/Model/Catalog.php(1051)
     22  (log.lib) -> [Error] Ampache\Repository\Model\Catalog::get_media_tags(): Implicitly marking parameter $file_override as nullable is deprecated, the explicit nullable type must be used instead in file src/Repository/Model/Catalog.php(3528)
     22  (log.lib) -> [Error] Ampache\Repository\Model\Song::get_album_barcode(): Implicitly marking parameter $album_id as nullable is deprecated, the explicit nullable type must be used instead in file src/Repository/Model/Song.php(846)
     22  (log.lib) -> [Error] Ampache\Repository\Model\Song::get_album_catalog_number(): Implicitly marking parameter $album_id as nullable is deprecated, the explicit nullable type must be used instead in file src/Repository/Model/Song.php(814)
     22  (log.lib) -> [Error] Ampache\Repository\Model\Song::get_album_original_year(): Implicitly marking parameter $album_id as nullable is deprecated, the explicit nullable type must be used instead in file src/Repository/Model/Song.php(830)
```