### PR TITLE
Fix "Unable to locate package software-properties-common" when building docker images

### DIFF
--- a/docker/Dockerfilephp82
+++ b/docker/Dockerfilephp82
@@ -5,9 +5,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN     sh -c 'echo "Types: deb\n# http://snapshot.debian.org/archive/debian/20230612T000000Z\nURIs: http://deb.debian.org/debian\nSuites: stable stable-updates\nComponents: main contrib non-free\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\nTypes: deb\n# http://snapshot.debian.org/archive/debian-security/20230612T000000Z\nURIs: http://deb.debian.org/debian-security\nSuites: stable-security\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n" > /etc/apt/sources.list.d/debian.sources' \
     &&  apt-get -q -q update \
-    &&  apt-get -q -q -y install --no-install-recommends wget lsb-release ca-certificates curl libdvd-pkg \
-    &&  curl -sSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg \
-    &&  sh -c 'echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php2.list' \
+    &&  apt-get -q -q -y install --no-install-recommends wget lsb-release ca-certificates curl libdvd-pkg extrepo \
+    &&  extrepo enable sury \
     &&  apt-get update \
     &&  apt-get -q -q -y install --no-install-recommends \
           apache2 \
@@ -63,9 +62,11 @@ RUN     sh -c 'echo "Types: deb\n# http://snapshot.debian.org/archive/debian/202
     &&  sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
     &&  locale-gen \
     &&  apt-get -qq purge \
+          extrepo \
           libdvd-pkg \
           lsb-release \
           unzip \
+          wget \
     &&  apt-get -qq autoremove \
     &&  pecl install xdebug \
     &&  echo "zend_extension=$(find /usr/lib/php/ -name xdebug.so)" > /etc/php/8.2/apache2/conf.d/xdebug.ini \

--- a/docker/Dockerfilephp82
+++ b/docker/Dockerfilephp82
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN     sh -c 'echo "Types: deb\n# http://snapshot.debian.org/archive/debian/20230612T000000Z\nURIs: http://deb.debian.org/debian\nSuites: stable stable-updates\nComponents: main contrib non-free\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\nTypes: deb\n# http://snapshot.debian.org/archive/debian-security/20230612T000000Z\nURIs: http://deb.debian.org/debian-security\nSuites: stable-security\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n" > /etc/apt/sources.list.d/debian.sources' \
     &&  apt-get -q -q update \
-    &&  apt-get -q -q -y install --no-install-recommends wget lsb-release ca-certificates curl software-properties-common libdvd-pkg \
+    &&  apt-get -q -q -y install --no-install-recommends wget lsb-release ca-certificates curl libdvd-pkg \
     &&  curl -sSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg \
     &&  sh -c 'echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php2.list' \
     &&  apt-get update \
@@ -65,7 +65,6 @@ RUN     sh -c 'echo "Types: deb\n# http://snapshot.debian.org/archive/debian/202
     &&  apt-get -qq purge \
           libdvd-pkg \
           lsb-release \
-          software-properties-common \
           unzip \
     &&  apt-get -qq autoremove \
     &&  pecl install xdebug \

--- a/docker/Dockerfilephp83
+++ b/docker/Dockerfilephp83
@@ -5,9 +5,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN     sh -c 'echo "Types: deb\n# http://snapshot.debian.org/archive/debian/20230612T000000Z\nURIs: http://deb.debian.org/debian\nSuites: stable stable-updates\nComponents: main contrib non-free\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\nTypes: deb\n# http://snapshot.debian.org/archive/debian-security/20230612T000000Z\nURIs: http://deb.debian.org/debian-security\nSuites: stable-security\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n" > /etc/apt/sources.list.d/debian.sources' \
     &&  apt-get -q -q update \
-    &&  apt-get -q -q -y install --no-install-recommends wget lsb-release ca-certificates curl libdvd-pkg \
-    &&  curl -sSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg \
-    &&  sh -c 'echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php2.list' \
+    &&  apt-get -q -q -y install --no-install-recommends wget lsb-release ca-certificates curl libdvd-pkg extrepo \
+    &&  extrepo enable sury \
     &&  apt-get update \
     &&  apt-get -q -q -y install --no-install-recommends \
           apache2 \
@@ -63,9 +62,11 @@ RUN     sh -c 'echo "Types: deb\n# http://snapshot.debian.org/archive/debian/202
     &&  sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
     &&  locale-gen \
     &&  apt-get -qq purge \
+          extrepo \
           libdvd-pkg \
           lsb-release \
           unzip \
+          wget \
     &&  apt-get -qq autoremove \
     &&  pecl install xdebug \
     &&  echo "zend_extension=$(find /usr/lib/php/ -name xdebug.so)" > /etc/php/8.3/apache2/conf.d/xdebug.ini \

--- a/docker/Dockerfilephp83
+++ b/docker/Dockerfilephp83
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN     sh -c 'echo "Types: deb\n# http://snapshot.debian.org/archive/debian/20230612T000000Z\nURIs: http://deb.debian.org/debian\nSuites: stable stable-updates\nComponents: main contrib non-free\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\nTypes: deb\n# http://snapshot.debian.org/archive/debian-security/20230612T000000Z\nURIs: http://deb.debian.org/debian-security\nSuites: stable-security\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n" > /etc/apt/sources.list.d/debian.sources' \
     &&  apt-get -q -q update \
-    &&  apt-get -q -q -y install --no-install-recommends wget lsb-release ca-certificates curl software-properties-common libdvd-pkg \
+    &&  apt-get -q -q -y install --no-install-recommends wget lsb-release ca-certificates curl libdvd-pkg \
     &&  curl -sSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg \
     &&  sh -c 'echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php2.list' \
     &&  apt-get update \
@@ -65,7 +65,6 @@ RUN     sh -c 'echo "Types: deb\n# http://snapshot.debian.org/archive/debian/202
     &&  apt-get -qq purge \
           libdvd-pkg \
           lsb-release \
-          software-properties-common \
           unzip \
     &&  apt-get -qq autoremove \
     &&  pecl install xdebug \

--- a/docker/Dockerfilephp84
+++ b/docker/Dockerfilephp84
@@ -5,9 +5,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN     sh -c 'echo "Types: deb\n# http://snapshot.debian.org/archive/debian/20230612T000000Z\nURIs: http://deb.debian.org/debian\nSuites: stable stable-updates\nComponents: main contrib non-free\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\nTypes: deb\n# http://snapshot.debian.org/archive/debian-security/20230612T000000Z\nURIs: http://deb.debian.org/debian-security\nSuites: stable-security\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n" > /etc/apt/sources.list.d/debian.sources' \
     &&  apt-get -q -q update \
-    &&  apt-get -q -q -y install --no-install-recommends wget lsb-release ca-certificates curl libdvd-pkg \
-    &&  curl -sSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg \
-    &&  sh -c 'echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php2.list' \
+    &&  apt-get -q -q -y install --no-install-recommends wget lsb-release ca-certificates curl libdvd-pkg extrepo \
+    &&  extrepo enable sury \
     &&  apt-get update \
     &&  apt-get -q -q -y install --no-install-recommends \
           apache2 \
@@ -63,9 +62,11 @@ RUN     sh -c 'echo "Types: deb\n# http://snapshot.debian.org/archive/debian/202
     &&  sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
     &&  locale-gen \
     &&  apt-get -qq purge \
+          extrepo \
           libdvd-pkg \
           lsb-release \
           unzip \
+          wget \
     &&  apt-get -qq autoremove \
     &&  pecl install xdebug \
     &&  echo "zend_extension=$(find /usr/lib/php/ -name xdebug.so)" > /etc/php/8.4/apache2/conf.d/xdebug.ini \

--- a/docker/Dockerfilephp84
+++ b/docker/Dockerfilephp84
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN     sh -c 'echo "Types: deb\n# http://snapshot.debian.org/archive/debian/20230612T000000Z\nURIs: http://deb.debian.org/debian\nSuites: stable stable-updates\nComponents: main contrib non-free\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\nTypes: deb\n# http://snapshot.debian.org/archive/debian-security/20230612T000000Z\nURIs: http://deb.debian.org/debian-security\nSuites: stable-security\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n" > /etc/apt/sources.list.d/debian.sources' \
     &&  apt-get -q -q update \
-    &&  apt-get -q -q -y install --no-install-recommends wget lsb-release ca-certificates curl software-properties-common libdvd-pkg \
+    &&  apt-get -q -q -y install --no-install-recommends wget lsb-release ca-certificates curl libdvd-pkg \
     &&  curl -sSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg \
     &&  sh -c 'echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php2.list' \
     &&  apt-get update \
@@ -65,7 +65,6 @@ RUN     sh -c 'echo "Types: deb\n# http://snapshot.debian.org/archive/debian/202
     &&  apt-get -qq purge \
           libdvd-pkg \
           lsb-release \
-          software-properties-common \
           unzip \
     &&  apt-get -qq autoremove \
     &&  pecl install xdebug \


### PR DESCRIPTION
Fixes an error message when running `docker compose up`:

```
1.810 E: Unable to locate package software-properties-common
```

Apparently this package is not part of Debian Trixie (the current Debian Stable) anymore:
https://packages.debian.org/search?searchon=sourcenames&keywords=software-properties