### PR TITLE
Fix stats recent_album_artist by user

### DIFF
--- a/src/Module/Statistics/Stats.php
+++ b/src/Module/Statistics/Stats.php
@@ -742,7 +742,7 @@ class Stats
     {
         $type           = self::validate_type($input_type);
         $ordersql       = ($newest === true) ? 'DESC' : 'ASC';
-        $user_sql       = ($user !== null) ? " AND `user` = '" . $user->getId() . "'" : '';
+        $user_sql       = ($user !== null) ? " AND `object_count`.`user` = '" . $user->getId() . "'" : '';
         $catalog_filter = (AmpConfig::get('catalog_filter'));
         $filter_user    = ($user ?? Core::get_global('user'));
 


### PR DESCRIPTION
When browsing

https://FQDN/stats.php?action=recent_album_artist&by_user=1

Broken page and error in ampache.log
```
2025-09-20T08:32:17+00:00 [-1] (Ampache\Module\System\Dba) -> Error_query MSG: SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'user' in WHERE is ambiguous
2025-09-20T08:32:17+00:00 [-1] (Ampache\Module\System\Dba) -> Error_query SQL: SELECT `object_id` AS `id`, MAX(`date`) AS `date` FROM `object_count` LEFT JOIN `artist` ON `artist`.`id` = `object_id` AND `object_type` = 'artist' WHERE `artist`.`album_count` > 0 AND `object_type` = 'artist' AND `count_type` = 'stream' AND `user` = '-1' GROUP BY `object_count`.`object_id` ORDER BY MAX(`date`) DESC, `object_count`.`object_id`  []
2025-09-20T08:32:17+00:00 [-1] (Ampache\Module\System\Dba) -> Error_query MSG: SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'user' in WHERE is ambiguous
```

This patch fix the query