### PR TITLE
Use ISO8601 to format date in the logs to properly display timezone

### DIFF
--- a/src/Module/System/LegacyLogger.php
+++ b/src/Module/System/LegacyLogger.php
@@ -173,7 +173,7 @@ final class LegacyLogger implements LoggerInterface
 
         /* Set it up here to make sure it's _always_ the same */
         $time       = time();
-        $log_time   = date("c", $time);
+        $log_time   = date(DATE_ISO8601, $time);
         $event_name = $context[self::CONTEXT_TYPE] ?? '';
 
         $log_filename = $this->configContainer->get('log_filename');


### PR DESCRIPTION
This small PR simply changes the format of the timestamps in the ampache logs to show the timezone. It uses the international standard ISO 8601 for that.

I found this useful while looking at the logs since currently the timestamps are ambiguous in terms of which timezone they refer to.