### PR TITLE
Fixes js-cookie copying since #4358

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "copy:contextmenu": "copyfiles --up 3 \"node_modules/jquery-contextmenu/dist/*\" public/lib/components/jquery-contextmenu",
     "copy:datetimepicker": "copyfiles --up 3 node_modules/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js node_modules/jquery-datetimepicker/build/jquery.datetimepicker.min.css public/lib/components/datetimepicker",
     "copy:filepond": "copyfiles --up 3 node_modules/filepond/dist/filepond.min.js node_modules/filepond/dist/filepond.min.css public/lib/components/filepond",
-    "copy:jscookie": "copyfiles --up 3 node_modules/js-cookie/src/js.cookie.js public/lib/components/js-cookie",
+    "copy:jscookie": "copyfiles --up 3 node_modules/js-cookie/dist/js.cookie.js public/lib/components/js-cookie",
     "copy:jscroll": "copyfiles --up 3 \"node_modules/jscroll/dist/**/*\" public/lib/components/jscroll",
     "copy:jquery": "copyfiles --up 3 node_modules/jquery/dist/jquery.min.js public/lib/components/jquery",
     "copy:jqueryui": "copyfiles --up 3 \"node_modules/jquery-ui/dist/*\" public/lib/components/jquery-ui",


### PR DESCRIPTION
I'm building ampache using ` npm install` in the process, the `js.cookie.js` file couldn't be loaded since 7.9.5 because the file changed places. Which was breaking the web player.

This MR simply fixes the path of the file in newer version of js-cookie.