### PR TITLE
Add type annotation for $jsEnd variable in install template

### DIFF
--- a/public/templates/install_footer.inc.php
+++ b/public/templates/install_footer.inc.php
@@ -8,6 +8,7 @@
     <script src="<?php echo $web_path; ?>/lib/components/jquery/jquery.min.js"></script>
     <script src="<?php echo $web_path; ?>/lib/components/bootstrap/js/bootstrap.min.js"></script>
     <?php
+        /** @var array $jsEnd */
         if (!empty($jsEnd) && is_array($jsEnd)) {
             foreach ($jsEnd as $js) {
                 echo $js;


### PR DESCRIPTION
## 问题背景

在 `public/templates/install_footer.inc.php` 模板文件中，变量 `$jsEnd` 在使用前缺少明确的类型声明。这会降低代码的可读性和静态分析的效率，不利于长期维护。

## 修改内容

本次修改为变量 `$jsEnd` 添加了 PHPDoc 风格的类型注解 (`/** @var array $jsEnd */`)。

这个注解明确了变量应为数组类型，与下方的 `is_array($jsEnd)` 检查逻辑保持一致。添加注解不会改变任何运行时行为，它仅用于为开发者和 IDE 提供更好的上下文信息。

## 验证方式

1.  **功能验证**：正常执行应用程序的安装流程，特别是最后一步，确保页面底部的额外 JavaScript 文件（通过 `$jsEnd` 数组加载）能被正确输出和执行，功能无异常。
2.  **代码检查**：确认添加的注解格式正确，且与文件中现有的注释风格保持一致。

此次修改遵循了最小化改动原则，仅添加了必要的类型信息，未引入任何依赖或改变公共 API。