### PR TITLE
Restore functionality to broadcast playback; closes #3441

### DIFF
--- a/src/Module/Playback/Stream_Playlist.php
+++ b/src/Module/Playback/Stream_Playlist.php
@@ -35,6 +35,7 @@ use Ampache\Module\System\Session;
 use Ampache\Module\Util\ObjectTypeToClassNameMapper;
 use Ampache\Module\Util\Ui;
 use Ampache\Repository\Model\Art;
+use Ampache\Repository\Model\Broadcast;
 use Ampache\Repository\Model\Democratic;
 use Ampache\Repository\Model\library_item;
 use Ampache\Repository\Model\LibraryItemEnum;
@@ -45,7 +46,6 @@ use Ampache\Repository\Model\Song;
 use Ampache\Repository\Model\Song_Preview;
 use Ampache\Repository\Model\User;
 use Ampache\Repository\Model\Video;
-use Ampache\Repository\Model\Broadcast;
 
 /**
  * Stream_Playlist Class
@@ -305,14 +305,14 @@ class Stream_Playlist
         $url['type'] = $type->value;
 
         if (!isset($object->enabled) || make_bool($object->enabled)) {
-            $url['url'] = $object->play_url($additional_params);
+            $url['url']  = $object->play_url($additional_params);
             $api_session = (AmpConfig::get('require_session')) ? Stream::get_session() : null;
 
-            $url['author'] = 'Ampache';
+            $url['author']    = 'Ampache';
             $url['info_url']  = $object->get_f_link();
-            $url['title'] = Stream_Url::get_title($url['url']);
-            $url['time']  = -1;
-            $surl = new Stream_Url($url);
+            $url['title']     = Stream_Url::get_title($url['url']);
+            $url['time']      = -1;
+            $surl             = new Stream_Url($url);
         }
 
         return $surl;

--- a/src/Module/Playback/Stream_Playlist.php
+++ b/src/Module/Playback/Stream_Playlist.php
@@ -45,6 +45,7 @@ use Ampache\Repository\Model\Song;
 use Ampache\Repository\Model\Song_Preview;
 use Ampache\Repository\Model\User;
 use Ampache\Repository\Model\Video;
+use Ampache\Repository\Model\Broadcast;
 
 /**
  * Stream_Playlist Class
@@ -284,9 +285,37 @@ class Stream_Playlist
 
         if ($object instanceof Media) {
             return self::media_object_to_url($object, $additional_params, $urltype, $user);
+        } elseif ($object instanceof Broadcast) {
+            return self::broadcast_object_to_url($object, $additional_params, $urltype, $user);
         }
 
         return null;
+    }
+
+    private static function broadcast_object_to_url(Broadcast $object, string $additional_params = '', string $urltype = 'web', ?User $user = null): ?Stream_Url
+    {
+        $surl = null;
+        $url  = self::STREAM_PLAYLIST_ROW;
+        if (!$user) {
+            $user = Core::get_global('user');
+        }
+
+        $type = $object->getMediaType();
+
+        $url['type'] = $type->value;
+
+        if (!isset($object->enabled) || make_bool($object->enabled)) {
+            $url['url'] = $object->play_url($additional_params);
+            $api_session = (AmpConfig::get('require_session')) ? Stream::get_session() : null;
+
+            $url['author'] = 'Ampache';
+            $url['info_url']  = $object->get_f_link();
+            $url['title'] = Stream_Url::get_title($url['url']);
+            $url['time']  = -1;
+            $surl = new Stream_Url($url);
+        }
+
+        return $surl;
     }
 
     private static function media_object_to_url(Media $object, string $additional_params = '', string $urltype = 'web', ?User $user = null): ?Stream_Url


### PR DESCRIPTION
After trying to utilize the broadcast feature myself and finding #3441, I decided to take a look into the problem. It turns out Broadcast does not implement the Media interface, which causes the call to media_object_to_url to be skipped and the playback URL for any Broadcast object to end up empty. 

I got the broadcast feature working for myself by adding an alternative version of the media_object_to_url function which accepts the Broadcast object. I suspect Broadcast should eventually implement the Media interface, but this allows a Broadcast object to be played regardless.