### PR TITLE
Fix TypeError in Album::check() when a cached insert-id (string) is returned

### DIFF
--- a/src/Repository/Model/Album.php
+++ b/src/Repository/Model/Album.php
@@ -353,7 +353,7 @@ class Album extends database_object implements
             return 0;
         }
 
-        $album_id = Dba::insert_id();
+        $album_id = (int) Dba::insert_id();
         if (!$album_id) {
             return 0;
         }


### PR DESCRIPTION
## Problem

Running a catalog scan on `develop8` crashes with:

```
TypeError: Ampache\Repository\Model\Album::check(): Return value must be of type int, string returned
  thrown in src/Repository/Model/Album.php on line 236
  Album::check(0, 'Unknown (Orphaned)', 0, NULL, NULL, 2)
```

`Album::check()` is declared `: int`. After inserting a new album it stores the id in the static `$_mapcache` (line 379) using the value from `Dba::insert_id()`, **which returns a string**. The immediate `return` casts it to int (line 381), so the first call is fine — but a later cache hit returns the raw string via line 236, violating the return type.

### How to reproduce
Scan a catalog containing two files that resolve to the **same** album — easiest with two files that have no album tag, so both map to `Unknown (Orphaned)`. The first is inserted; the second hits the cache and throws, aborting the scan.

## Fix

Cast the insert id to `int` at the source so the cache and every return path are consistently typed:

```php
$album_id = (int) Dba::insert_id();
```

## Testing

- Before: catalog scan aborts on the second album-less file.
- After: full scan completes (24 mixed mp3/ogg files imported cleanly, including tag-less ones).
- `phpstan analyse src/Repository/Model/Album.php` — no errors.
