### PR TITLE
Fix AlbumDisk::check() returning album id instead of album_disk id

### DIFF
--- a/src/Repository/Model/AlbumDisk.php
+++ b/src/Repository/Model/AlbumDisk.php
@@ -190,7 +190,7 @@ class AlbumDisk extends database_object implements
             return 0;
         }
 
-        $album_disk_id = Dba::insert_id();
+        $album_disk_id = (int) Dba::insert_id();
 
         // count a new song on the new disk right away
         $sql = "UPDATE `album_disk` SET `song_count` = `song_count` + 1 WHERE `id` = ?;";
@@ -201,7 +201,7 @@ class AlbumDisk extends database_object implements
             Dba::write($sql, [$disksubtitle, $album_disk_id]);
         }
 
-        return $album_id;
+        return $album_disk_id;
     }
 
     /**


### PR DESCRIPTION
## Description

`AlbumDisk::check()` returns the **input `\$album_id`** on the *create* path instead of the newly-created **`\$album_disk_id`**:

https://github.com/ampache/ampache/blob/develop8/src/Repository/Model/AlbumDisk.php#L204

Every other return path in the method returns the album_disk id (existing row, edited row) or `0` (failure), and both callers rely on that contract:

- `Song::insert()` stores the result as `\$album_disk_id` and writes it straight into the song's `album_disk` foreign-key column.
- `Album::update()` compares the result against an existing album_disk id.

So the **first song of each newly-created album_disk** gets linked to the wrong `album_disk` value (the album id). This is the corruption that `Migration710005` was added to repair after the fact:

```sql
UPDATE `song`, (SELECT `id`, `album_id`, `disk` FROM `album_disk`) AS `album_disk`
SET `song`.`album_disk` = `album_disk`.`id`
WHERE `song`.`album_disk` != `album_disk`.`id`
  AND `song`.`album` = `album_disk`.`album_id`
  AND `song`.`disk` = `album_disk`.`disk`;
```

This fixes the **root cause** so newly imported songs get the correct `album_disk` immediately, rather than relying on the repair migration.

## Change

```diff
-        $album_disk_id = Dba::insert_id();
+        $album_disk_id = (int) Dba::insert_id();
...
-        return $album_id;
+        return $album_disk_id;
```

The `(int)` cast also resolves the un-cast `Dba::insert_id()` (which returns a string).

## Testing

- Deleted an album's `song` + `album_disk` rows (keeping the `album` row) to force the create path, then rescanned the catalog. The re-imported song now gets `album_disk` = the new `album_disk.id` (verified a value distinct from `album_id`, so the fix is unambiguous). Before the fix it was set to `album_id`.
- PHPStan (level 8) clean on `src/Repository/Model/AlbumDisk.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)