### PR TITLE
Fix undefined array key in AlbumDisk::check() collision branch

### DIFF
--- a/src/Repository/Model/AlbumDisk.php
+++ b/src/Repository/Model/AlbumDisk.php
@@ -166,6 +166,8 @@ class AlbumDisk extends database_object implements
             $db_results = Dba::read("SELECT * FROM `album_disk` WHERE `id` = ?;", [$current_id]);
             $row        = Dba::fetch_assoc($db_results);
             if (isset($row['id'])) {
+                // remember the current disk before a collision re-fetch can clobber $row
+                $old_disk = (int) $row['disk'];
                 // alter the existing disk after editing
                 if (!Dba::write("UPDATE `album_disk` SET `album_id` = ?, `disk` = ?, `catalog` = ?, `disksubtitle` = ? WHERE `id` = ?;", [$album_id, $disk, $catalog_id, $disksubtitle, $current_id])) {
                     // Duplicates might collide here
@@ -176,8 +178,8 @@ class AlbumDisk extends database_object implements
                 }
 
                 // Update songs when you edit an album_disk object
-                if ($row['disk'] !== $disk) {
-                    Dba::write("UPDATE `song` SET `disk` = ? WHERE `album` = ? AND `disk` = ?;", [$disk, $album_id, $row['disk']]);
+                if ($old_disk !== $disk) {
+                    Dba::write("UPDATE `song` SET `disk` = ? WHERE `album` = ? AND `disk` = ?;", [$disk, $album_id, $old_disk]);
                 }
 
                 return $current_id;


### PR DESCRIPTION
### Problem

On the edit path of `AlbumDisk::check()`, the existing row is fetched with `SELECT *`, so `$row` has a `disk` column. But if the subsequent `UPDATE` collides with the `unique_album_disk(album_id, disk, catalog)` key, `$row` is re-fetched from a query that selects **only `id`**, clobbering the `disk` key.

The code then does:

```php
if ($row['disk'] !== $disk) {
    Dba::write("UPDATE `song` SET `disk` = ? WHERE `album` = ? AND `disk` = ?;", [$disk, $album_id, $row['disk']]);
}
```

In the collision branch this causes two problems:

1. `$row['disk']` is undefined → an `Undefined array key "disk"` warning (twice).
2. The guard compared a string (`$row['disk']`) against an int (`$disk`) with `!==`, so it was **always true**; and in the collision branch the re-pointing `UPDATE` runs with a `null` disk, matching no rows.

### Fix

Capture the original disk value (cast to `int`) right after the row is confirmed, before the collision re-fetch can clobber `$row`, and use it for both the comparison and the `UPDATE`.

### Verification

- PHPStan clean on the file (PHP 8.5).
- Reproduced the collision branch against a local catalog (a `disksubtitle` mismatch makes the first lookup miss while the unique key still collides): the original code emitted 2× `Undefined array key "disk"`; with the fix, 0 warnings. Return value and row data unchanged in both cases.