### PR TITLE
fix: remove deprecated xml_set_object() call in AmazonSearch

### DIFF
--- a/src/Module/Util/AmazonSearch.php
+++ b/src/Module/Util/AmazonSearch.php
@@ -145,8 +145,6 @@ class AmazonSearch
 
         xml_parser_set_option($this->_parser, XML_OPTION_CASE_FOLDING, 0);
 
-        xml_set_object($this->_parser, $this);
-
         xml_set_element_handler($this->_parser, [$this, 'startElement'], [$this, 'endElement']);
 
         xml_set_character_data_handler($this->_parser, [$this, 'cdata']);


### PR DESCRIPTION
most error of #4314 are already fixed in develop, but there was still one 

xml_set_object() is deprecated since PHP 8.4 and logged an error on every Amazon art search. The XML handlers already use array callables ([$this, 'startElement'], etc.), so xml_set_object() is redundant and can be dropped without any behaviour change.

Fixes #4314