### PR TITLE
Fix wrong id returned by AlbumDisk::check() on a duplicate collision

### DIFF
--- a/src/Repository/Model/AlbumDisk.php
+++ b/src/Repository/Model/AlbumDisk.php
@@ -168,10 +168,7 @@ class AlbumDisk extends database_object implements
             if (isset($row['id'])) {
                 // alter the existing disk after editing
                 if (!Dba::write("UPDATE `album_disk` SET `album_id` = ?, `disk` = ?, `catalog` = ?, `disksubtitle` = ? WHERE `id` = ?;", [$album_id, $disk, $catalog_id, $disksubtitle, $current_id])) {
-                    // Duplicates might collide here. The blocking row is keyed on
-                    // (album_id, disk, catalog) by unique_album_disk and may carry any
-                    // disksubtitle, so match on the unique key alone (filtering by
-                    // disksubtitle here matched nothing when it was empty/null).
+                    // Duplicates might collide here. Match on the unique key alone (filtering by disksubtitle/null.
                     $db_results = Dba::read("SELECT `album_disk`.`id` FROM `album_disk` INNER JOIN `album` ON `album`.`id` = `album_disk`.`album_id` WHERE `album_disk`.`album_id` = ? AND `album_disk`.`disk` = ? AND `album_disk`.`catalog` = CASE WHEN `album`.`catalog` = 0 THEN 0 ELSE ? END;", [$album_id, $disk, $catalog_id]);
                     if ($row = Dba::fetch_assoc($db_results)) {
                         $current_id = (int) $row['id'];

--- a/src/Repository/Model/AlbumDisk.php
+++ b/src/Repository/Model/AlbumDisk.php
@@ -168,8 +168,11 @@ class AlbumDisk extends database_object implements
             if (isset($row['id'])) {
                 // alter the existing disk after editing
                 if (!Dba::write("UPDATE `album_disk` SET `album_id` = ?, `disk` = ?, `catalog` = ?, `disksubtitle` = ? WHERE `id` = ?;", [$album_id, $disk, $catalog_id, $disksubtitle, $current_id])) {
-                    // Duplicates might collide here
-                    $db_results = Dba::read("SELECT `album_disk`.`id` FROM `album_disk` INNER JOIN `album` ON `album`.`id` = `album_disk`.`album_id` WHERE `album_disk`.`album_id` = ? AND `album_disk`.`disk` = ? AND `album_disk`.`catalog` = CASE WHEN `album`.`catalog` = 0 THEN 0 ELSE ? END AND `album_disk`.`disksubtitle` = ?;", [$album_id, $disk, $catalog_id, ($disksubtitle ?: null)]);
+                    // Duplicates might collide here. The blocking row is keyed on
+                    // (album_id, disk, catalog) by unique_album_disk and may carry any
+                    // disksubtitle, so match on the unique key alone (filtering by
+                    // disksubtitle here matched nothing when it was empty/null).
+                    $db_results = Dba::read("SELECT `album_disk`.`id` FROM `album_disk` INNER JOIN `album` ON `album`.`id` = `album_disk`.`album_id` WHERE `album_disk`.`album_id` = ? AND `album_disk`.`disk` = ? AND `album_disk`.`catalog` = CASE WHEN `album`.`catalog` = 0 THEN 0 ELSE ? END;", [$album_id, $disk, $catalog_id]);
                     if ($row = Dba::fetch_assoc($db_results)) {
                         $current_id = (int) $row['id'];
                     }


### PR DESCRIPTION
### Problem

On the edit path of `AlbumDisk::check()`, when the `UPDATE` collides with the `unique_album_disk(album_id, disk, catalog)` key, the code re-fetches the *blocking* row to redirect the return value onto the existing disk:

```php
if (!Dba::write("UPDATE `album_disk` SET ... WHERE `id` = ?;", [...])) {
    // Duplicates might collide here
    $db_results = Dba::read("SELECT `album_disk`.`id` FROM ... WHERE ... AND `album_disk`.`disksubtitle` = ?;", [$album_id, $disk, $catalog_id, ($disksubtitle ?: null)]);
    if ($row = Dba::fetch_assoc($db_results)) {
        $current_id = (int) $row['id'];
    }
}
```

The re-fetch filters by `disksubtitle = ?`, but:

- The blocking row is keyed only on `(album_id, disk, catalog)` by `unique_album_disk` and may carry **any** `disksubtitle`, so filtering by it can miss the actual blocking row.
- When the subtitle is empty the bound value is `null`, and `disksubtitle = NULL` is never true in SQL, so the re-fetch matches nothing. (The initial lookup earlier in the method handles this correctly with `(disksubtitle = '' OR disksubtitle IS NULL)`.)

When the re-fetch finds nothing, `$current_id` is left pointing at the row that just *failed* to update, and `check()` returns that wrong `album_disk` id to its callers (`Song::insert()`, `Album::update()`).

### Fix

Match the blocking row on the unique key `(album_id, disk, catalog)` alone, dropping the `disksubtitle` filter.

### Verification

- PHPStan clean on the file (PHP 8.5).
- Reproduced against a local catalog: give the existing disk a non-empty `disksubtitle` so the first lookup misses, then edit another disk onto the same `(album_id, disk, catalog)`. The `UPDATE` collides and the re-fetch runs. Original code returned the id of the row that failed to update; with the fix it returns the id of the existing blocking row. No row data changed in either case.