### PR TITLE
Tiny performance gain for develop8

### DIFF
--- a/public/templates/footer.inc.php
+++ b/public/templates/footer.inc.php
@@ -30,6 +30,7 @@ use Ampache\Module\System\Core;
 use Ampache\Module\Util\Ui;
 
 ?>
+                <?php echo Ui::material_symbol_sprite(); ?>
                 </div>
                 <div style="clear:both;">
                 </div>
@@ -94,5 +95,6 @@ if (!isset($_SESSION['login']) || !$_SESSION['login']) {
                 });
             }
         </script>
+        <?php echo Ui::material_symbol_sprite(); ?>
     </body>
 </html>

--- a/public/templates/install_footer.inc.php
+++ b/public/templates/install_footer.inc.php
@@ -15,5 +15,6 @@
                 echo $js;
             }
         } ?>
+    <?php echo \Ampache\Module\Util\Ui::material_symbol_sprite(); ?>
     </body>
 </html>

--- a/public/templates/show_html5_player.inc.php
+++ b/public/templates/show_html5_player.inc.php
@@ -626,6 +626,7 @@ if ($isVideo === false) {
     require_once Ui::find_template('uberviz.inc.php');
 } ?>
 <?php if ($isShare === false) { ?>
+<?php echo Ui::material_symbol_sprite(); ?>
 </body>
     </html>
 <?php } ?>

--- a/public/templates/show_share.inc.php
+++ b/public/templates/show_share.inc.php
@@ -268,5 +268,6 @@ if (!$embed) { ?>
     <?php } ?>
 </div>
 <?php } ?>
+<?php echo Ui::material_symbol_sprite(); ?>
 </body>
 </html>

--- a/public/templates/show_test.inc.php
+++ b/public/templates/show_test.inc.php
@@ -71,5 +71,6 @@ use Ampache\Module\Util\Ui;
                 <?php require __DIR__ . '/show_test_table.inc.php'; ?>
             </table>
         </div>
+    <?php echo Ui::material_symbol_sprite(); ?>
     </body>
 </html>

--- a/src/Module/Api/Ajax.php
+++ b/src/Module/Api/Ajax.php
@@ -94,9 +94,6 @@ class Ajax
         string $class = '',
         string $confirm = '',
     ): string {
-        // Get the correct action
-        $ajax_string = self::action($action, $source, $post);
-
         // If they passed a span class
         if ($class) {
             $class = ' class="' . $class . '"';
@@ -104,14 +101,23 @@ class Ajax
 
         $string = Ui::get_material_symbol($icon, $alt);
 
+        // Instead of emitting one inline <script> observer per button,
+        // carry the action in data-* attributes. A single delegated click
+        // handler (see src/js/ajax.js) replays the exact same logic
+        // (update_action() + ajaxPut/ajaxPost with the element id as source),
+        // including for buttons injected dynamically through AJAX.
+        $attributes = ' data-ajax="1" data-ajax-url="' . scrub_out(self::url($action)) . '"';
+        if ($post !== '') {
+            $attributes .= ' data-ajax-post="' . scrub_out($post) . '"';
+        }
+        if ($confirm !== '') {
+            $attributes .= ' data-ajax-confirm="' . scrub_out($confirm) . '"';
+        }
+
         // Generate an <a> so that it's more compliant with older
         // browsers (ie :hover actions) and also to unify linkbuttons
         // (w/o ajax) display
-        $string = "<a href=\"javascript:void(0);\" id=\"$source\" $class>" . $string . "</a>\n";
-
-        $string .= self::observe($source, 'click', $ajax_string, $confirm);
-
-        return $string;
+        return "<a href=\"javascript:void(0);\" id=\"" . scrub_out($source) . "\"$attributes $class>" . $string . "</a>\n";
     }
 
     /**

--- a/src/Module/Util/Ui.php
+++ b/src/Module/Util/Ui.php
@@ -59,6 +59,15 @@ class Ui implements UiInterface
     /** @var array<string, string> $_image_cache */
     private static array $_image_cache = [];
 
+    /** @var array<string, array{attrs: string, viewbox: string, inner: string}|null> parsed material symbol source files */
+    private static array $_symbol_cache = [];
+
+    /** @var array<string, bool> material symbols referenced on the current page (sprite content) */
+    private static array $_used_symbols = [];
+
+    /** @var array<string, bool> material symbols already emitted in a sprite for the current page */
+    private static array $_emitted_symbols = [];
+
     private static int $_ticker = 0;
 
     public function __construct(
@@ -334,14 +343,121 @@ class Ui implements UiInterface
      */
     public static function get_material_symbol(string $name, ?string $title = null, ?string $id_attrib = null, ?string $class_attrib = null): string
     {
-        $title ??= T_(ucfirst($name));
-        $filepath = __DIR__ . '/../../../resources/images/material-symbols/' . $name . '.svg';
+        $title      = $title ?? T_(ucfirst($name));
+        $symbol_key = $name;
+        $filepath   = __DIR__ . '/../../../resources/images/material-symbols/' . $name . '.svg';
         if (!is_file($filepath)) {
             // fall back to error icon if icon is missing
             debug_event(self::class, 'Runtime Error: icon ' . $name . ' not found.', 1);
-            $filepath = __DIR__ . '/../../../resources/images/icon_error.svg';
+            $symbol_key = 'icon_error';
+            $filepath   = __DIR__ . '/../../../resources/images/icon_error.svg';
         }
 
+        if (defined('AJAX_INCLUDE')) {
+            return self::_inline_material_symbol($name, $filepath, $title, $id_attrib, $class_attrib);
+        }
+
+        $symbol = self::_load_symbol_parts($symbol_key, $filepath);
+        if ($symbol === null) {
+            return '';
+        }
+
+        self::$_used_symbols[$symbol_key] = true;
+
+        $tag = '<svg' . $symbol['attrs'];
+        if (!empty($id_attrib)) {
+            $tag .= ' id="' . scrub_out($id_attrib) . '"';
+        }
+        $tag .= ' class="material-symbol material-symbol-' . scrub_out($name) . ' ' . scrub_out((string)$class_attrib) . '">';
+        $tag .= '<title>' . scrub_out($title) . '</title>';
+        $tag .= '<desc>' . scrub_out($title) . '</desc>';
+        $tag .= '<use href="#ms-' . scrub_out($symbol_key) . '" xlink:href="#ms-' . scrub_out($symbol_key) . '"></use>';
+
+        return $tag . '</svg>';
+    }
+
+    /**
+     * material_symbol_sprite
+     *
+     * Returns a single hidden <svg> sprite containing one <symbol> per
+     * material symbol rendered on the current page. Must be echoed once,
+     * right before </body>. Returns an empty string when no icon was used.
+     */
+    public static function material_symbol_sprite(): string
+    {
+        // Incremental: only emit symbols that were not part of a previous
+        // sprite. The main layout may call this more than once (e.g. at the
+        // end of the content block and again before </body>) to catch icons
+        // rendered after the first call (footer, web player controls).
+        $pending = array_diff_key(self::$_used_symbols, self::$_emitted_symbols);
+        if ($pending === []) {
+            return '';
+        }
+
+        $sprite = '<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" style="position:absolute" aria-hidden="true">';
+        foreach (array_keys($pending) as $symbol_key) {
+            self::$_emitted_symbols[$symbol_key] = true;
+            $symbol                              = self::$_symbol_cache[$symbol_key] ?? null;
+            if ($symbol === null) {
+                continue;
+            }
+            // The viewBox of the source file is carried by the <symbol>
+            // (see _load_symbol_parts for why it must not stay on the
+            // per-icon <svg> tag).
+            $viewbox = ($symbol['viewbox'] !== '')
+                ? ' viewBox="' . $symbol['viewbox'] . '"'
+                : '';
+            $sprite .= '<symbol id="ms-' . scrub_out((string)$symbol_key) . '"' . $viewbox . '>' . $symbol['inner'] . '</symbol>';
+        }
+
+        return $sprite . '</svg>';
+    }
+
+    /**
+     * _load_symbol_parts
+     *
+     * Splits an svg icon file into: its root attributes without viewBox
+     * (kept on the per-icon <svg> tag), its viewBox (moved onto the
+     * <symbol> in the page sprite) and its inner content (moved once into
+     * the sprite).
+     *
+     * The viewBox MUST be on the <symbol> and MUST NOT be on the outer
+     * <svg>: material symbols draw in "0 -960 960 960" (negative Y) and
+     * the nested viewport created by <use> lands in the 0..960 region of
+     * the outer coordinate system - with the original viewBox kept on the
+     * outer <svg>, the whole drawing sits outside the visible area.
+     *
+     * @return array{attrs: string, viewbox: string, inner: string}|null
+     */
+    private static function _load_symbol_parts(string $symbol_key, string $filepath): ?array
+    {
+        if (!array_key_exists($symbol_key, self::$_symbol_cache)) {
+            $content = file_get_contents($filepath);
+            if ($content !== false && preg_match('/<svg([^>]*)>(.*)<\/svg>/s', $content, $matches)) {
+                $viewbox = (preg_match('/\sviewBox="([^"]*)"/', $matches[1], $vb_match))
+                    ? $vb_match[1]
+                    : '';
+                self::$_symbol_cache[$symbol_key] = [
+                    'attrs' => rtrim((string)preg_replace('/\sviewBox="[^"]*"/', '', $matches[1])),
+                    'viewbox' => $viewbox,
+                    'inner' => trim($matches[2]),
+                ];
+            } else {
+                self::$_symbol_cache[$symbol_key] = null;
+            }
+        }
+
+        return self::$_symbol_cache[$symbol_key];
+    }
+
+    /**
+     * _inline_material_symbol
+     *
+     * Legacy rendering: the full icon body is inlined in the returned tag.
+     * Still used for AJAX fragments, which cannot rely on the page sprite.
+     */
+    private static function _inline_material_symbol(string $name, string $filepath, string $title, ?string $id_attrib, ?string $class_attrib): string
+    {
         $tag = '';
         // load svg file
         $svgicon = simplexml_load_file($filepath);

--- a/src/Module/Util/Ui.php
+++ b/src/Module/Util/Ui.php
@@ -353,10 +353,6 @@ class Ui implements UiInterface
             $filepath   = __DIR__ . '/../../../resources/images/icon_error.svg';
         }
 
-        if (defined('AJAX_INCLUDE')) {
-            return self::_inline_material_symbol($name, $filepath, $title, $id_attrib, $class_attrib);
-        }
-
         $symbol = self::_load_symbol_parts($symbol_key, $filepath);
         if ($symbol === null) {
             return '';
@@ -364,7 +360,23 @@ class Ui implements UiInterface
 
         self::$_used_symbols[$symbol_key] = true;
 
-        $tag = '<svg' . $symbol['attrs'];
+        // In AJAX fragments there is no page sprite emitted before </body>,
+        // and each fragment is injected into its own DOM node via innerHTML,
+        // so it must be self-contained. Emit the hidden <symbol> inline the
+        // first time an icon appears in this response; every later occurrence
+        // is just a <use>. Duplicate ids are ignored by the browser, so this
+        // is safe even when the page sprite already holds the same symbol.
+        $prefix = '';
+        if (defined('AJAX_INCLUDE') && !isset(self::$_emitted_symbols[$symbol_key])) {
+            self::$_emitted_symbols[$symbol_key] = true;
+            $viewbox                             = ($symbol['viewbox'] !== '')
+                ? ' viewBox="' . $symbol['viewbox'] . '"'
+                : '';
+            $prefix = '<svg xmlns="http://www.w3.org/2000/svg" width="0" height="0" style="position:absolute" aria-hidden="true">' .
+                '<symbol id="ms-' . scrub_out($symbol_key) . '"' . $viewbox . '>' . $symbol['inner'] . '</symbol></svg>';
+        }
+
+        $tag = $prefix . '<svg' . $symbol['attrs'];
         if (!empty($id_attrib)) {
             $tag .= ' id="' . scrub_out($id_attrib) . '"';
         }
@@ -448,46 +460,6 @@ class Ui implements UiInterface
         }
 
         return self::$_symbol_cache[$symbol_key];
-    }
-
-    /**
-     * _inline_material_symbol
-     *
-     * Legacy rendering: the full icon body is inlined in the returned tag.
-     * Still used for AJAX fragments, which cannot rely on the page sprite.
-     */
-    private static function _inline_material_symbol(string $name, string $filepath, string $title, ?string $id_attrib, ?string $class_attrib): string
-    {
-        $tag = '';
-        // load svg file
-        $svgicon = simplexml_load_file($filepath);
-        if ($svgicon !== false) {
-            if (empty($svgicon->title)) {
-                $svgicon->addChild('title', $title);
-            } else {
-                $svgicon->title = $title;
-            }
-
-            if (empty($svgicon->desc)) {
-                $svgicon->addChild('desc', $title);
-            } else {
-                $svgicon->desc = $title;
-            }
-
-            if (!in_array($id_attrib, [null, '', '0'], true)) {
-                $svgicon->addAttribute('id', $id_attrib);
-            }
-
-            if (in_array($class_attrib, [null, '', '0'], true)) {
-                $class_attrib = '';
-            }
-
-            $svgicon->addAttribute('class', 'material-symbol material-symbol-' . $name . " " . $class_attrib);
-
-            $tag = explode("\n", (string) $svgicon->asXML(), 3)[1];
-        }
-
-        return $tag;
     }
 
     /**

--- a/src/Plugin/AmpacheMatomo.php
+++ b/src/Plugin/AmpacheMatomo.php
@@ -78,6 +78,9 @@ class AmpacheMatomo extends AmpachePlugin implements PluginDisplayOnFooterInterf
         echo "<!-- Matomo -->\n";
         echo "<script>\n";
         echo "var _paq = _paq || [];\n";
+        // Defer all tracking work until after the page has fully loaded so the
+        // beacon and matomo.js fetch stay off the critical rendering path.
+        echo "window.addEventListener('load', function() {\n";
         echo "_paq.push(['trackLink', '" . $currentUrl . "', 'link']);\n";
         echo "_paq.push(['enableLinkTracking']);\n";
         echo "(function() {\n";
@@ -91,6 +94,7 @@ class AmpacheMatomo extends AmpachePlugin implements PluginDisplayOnFooterInterf
         echo "var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];\n";
         echo "g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);\n";
         echo "})();\n";
+        echo "});\n";
         echo "</script>\n";
         echo "<noscript><p><img src='" . scrub_out($this->matomo_url) . "matomo.php?idsite=" . scrub_out($this->site_id) . "' style='border:0;' alt= '' /></p></noscript>\n";
         echo "<!-- End Matomo Code -->\n";

--- a/src/Plugin/AmpachePiwik.php
+++ b/src/Plugin/AmpachePiwik.php
@@ -78,6 +78,9 @@ class AmpachePiwik extends AmpachePlugin implements PluginDisplayOnFooterInterfa
         echo "<!-- Piwik -->\n";
         echo "<script>\n";
         echo "var _paq = _paq || [];\n";
+        // Defer all tracking work until after the page has fully loaded so the
+        // beacon and piwik.js fetch stay off the critical rendering path.
+        echo "window.addEventListener('load', function() {\n";
         echo "_paq.push(['trackLink', '" . $currentUrl . "', 'link']);\n";
         echo "_paq.push(['enableLinkTracking']);\n";
         echo "(function() {\n";
@@ -91,6 +94,7 @@ class AmpachePiwik extends AmpachePlugin implements PluginDisplayOnFooterInterfa
         echo "var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];\n";
         echo "g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);\n";
         echo "})();\n";
+        echo "});\n";
         echo "</script>\n";
         echo "<noscript><p><img src='" . scrub_out($this->piwik_url) . "piwik.php?idsite=" . scrub_out($this->site_id) . "' style='border:0;' alt= '' /></p></noscript>\n";
         echo "<!-- End Piwik Code -->\n";

--- a/src/Repository/Model/Art.php
+++ b/src/Repository/Model/Art.php
@@ -290,7 +290,7 @@ class Art extends database_object
             }
         }
 
-        echo "<img src=\"" . $imgurl . "\" alt=\"" . $name . "\" height=\"" . $size['height'] . "\" width=\"" . $size['width'] . "\" />";
+        echo "<img src=\"" . $imgurl . "\" alt=\"" . $name . "\" height=\"" . $size['height'] . "\" width=\"" . $size['width'] . "\" loading=\"lazy\" decoding=\"async\" />";
 
         $item_art_play = ($size['height'] == 150)
             ? "<div class=\"item_art_play_150\">"

--- a/src/js/ajax.js
+++ b/src/js/ajax.js
@@ -25,6 +25,36 @@ function hasScriptableUrlScheme(url) {
     return /^(?:javascript|data|vbscript):/i.test(scheme);
 }
 
+// Delegated click handler for Ajax buttons rendered by Ajax::button()
+// with data-* attributes. This replaces the per-button inline <script>
+// observers and replays exactly the same logic: update_action() first,
+// then optional confirm(), then ajaxPost()/ajaxPut() with the element
+// id as source. Delegating on document also covers buttons injected
+// dynamically through AJAX content updates.
+$(document).on("click", "a[data-ajax='1']", function (event) {
+    event.preventDefault();
+
+    var $link = $(this);
+    var url = $link.attr("data-ajax-url");
+    var post = $link.attr("data-ajax-post");
+    var confirmText = $link.attr("data-ajax-confirm");
+    var source = this.id || "";
+
+    // Keep the historical order: update_action() runs before confirm().
+    // Use the window function so template overrides (html5 player) apply.
+    window.update_action();
+
+    if (confirmText && !window.confirm(confirmText)) {
+        return;
+    }
+
+    if (post) {
+        ajaxPost(url, post, source);
+    } else {
+        ajaxPut(url, source);
+    }
+});
+
 // Some cutesy flashing thing while we run
 $(document).ajaxSend(function () {
     $("#ajax-loading").show();


### PR DESCRIPTION
Rework of https://github.com/ampache/ampache/pull/4403 for ampache 8

Perf improvement
- adding lazy loading for art img
- pages got lot of <script> inline, sometimes hundred. Reduce them.
- reduce HTML size by stopping repeating svg content inline
- defer piwik/matomo js loading 


