### PR TITLE
Reuse TAL view across browse rows instead of new PHPTAL per row

### DIFF
--- a/public/templates/show_album_disks.inc.php
+++ b/public/templates/show_album_disks.inc.php
@@ -136,11 +136,11 @@ foreach ($object_ids as $album_disk_id) {
         <tr id="album_disk_<?php echo $libitem->id; ?>" class="libitem_menu" data-object-type="album_disk" data-object-id="<?php echo $libitem->id; ?>">
             <?php
             // Reassign EVERY key each row. Prev row's value sticks otherwise.
+            // CONFIG omitted: TalView::render() sets it (was overwritten anyway).
             $content = $albumDiskRowView
                     ->setContext('USER_IS_REGISTERED', User::is_registered())
                     ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
                     ->setContext('ALBUMDISK', $guiFactory->createAlbumDiskViewAdapter($gatekeeper, $browse, $libitem))
-                    ->setContext('CONFIG', $guiFactory->createConfigViewAdapter())
                     ->setContext('IS_TABLE_VIEW', $is_table)
                     ->setContext('IS_HIDE_GENRE', $hide_genres)
                     ->setContext('IS_SHOW_PLAYED_TIMES', $show_played_times)

--- a/public/templates/show_album_disks.inc.php
+++ b/public/templates/show_album_disks.inc.php
@@ -121,6 +121,9 @@ if (AmpConfig::get('ratings')) {
     Userflag::build_cache('album_disk', $object_ids);
 }
 /* Foreach through the album_disks */
+// One TAL view reused for all rows
+$albumDiskRowView = $talFactory->createTalView()->setTemplate('album_disk_row.xhtml');
+
 foreach ($object_ids as $album_disk_id) {
     $libitem = new AlbumDisk($album_disk_id);
     if ($libitem->isNew()) {
@@ -131,7 +134,9 @@ foreach ($object_ids as $album_disk_id) {
         $show_playlist_add = $access25 && ($libitem->song_count <= $directplay_limit);
     } ?>
         <tr id="album_disk_<?php echo $libitem->id; ?>" class="libitem_menu" data-object-type="album_disk" data-object-id="<?php echo $libitem->id; ?>">
-            <?php $content = $talFactory->createTalView()
+            <?php
+            // Reassign EVERY key each row. Prev row's value sticks otherwise.
+            $content = $albumDiskRowView
                     ->setContext('USER_IS_REGISTERED', User::is_registered())
                     ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
                     ->setContext('ALBUMDISK', $guiFactory->createAlbumDiskViewAdapter($gatekeeper, $browse, $libitem))
@@ -145,7 +150,6 @@ foreach ($object_ids as $album_disk_id) {
                     ->setContext('CLASS_ARTIST', $cel_artist)
                     ->setContext('CLASS_TAGS', $cel_tags)
                     ->setContext('CLASS_COUNTER', $cel_counter)
-                    ->setTemplate('album_disk_row.xhtml')
                     ->render();
     echo $content; ?>
         </tr>

--- a/public/templates/show_albums.inc.php
+++ b/public/templates/show_albums.inc.php
@@ -136,11 +136,11 @@ foreach ($object_ids as $album_id) {
         <tr id="album_<?php echo $libitem->id; ?>" class="libitem_menu" data-object-type="album" data-object-id="<?php echo $libitem->id; ?>">
             <?php
             // Reassign EVERY key each row. Prev row's value sticks otherwise.
+            // CONFIG omitted: TalView::render() sets it (was overwritten anyway).
             $content = $albumRowView
             ->setContext('USER_IS_REGISTERED', User::is_registered())
             ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
             ->setContext('ALBUM', $guiFactory->createAlbumViewAdapter($gatekeeper, $browse, $libitem))
-            ->setContext('CONFIG', $guiFactory->createConfigViewAdapter())
             ->setContext('IS_TABLE_VIEW', $is_table)
             ->setContext('IS_HIDE_GENRE', $hide_genres)
             ->setContext('IS_SHOW_PLAYED_TIMES', $show_played_times)

--- a/public/templates/show_albums.inc.php
+++ b/public/templates/show_albums.inc.php
@@ -121,6 +121,9 @@ if (AmpConfig::get('ratings')) {
     Userflag::build_cache('album', $object_ids);
 }
 /* Foreach through the albums */
+// One TAL view reused for all rows
+$albumRowView = $talFactory->createTalView()->setTemplate('album_row.xhtml');
+
 foreach ($object_ids as $album_id) {
     $libitem = new Album($album_id);
     if ($libitem->isNew()) {
@@ -131,7 +134,9 @@ foreach ($object_ids as $album_id) {
         $show_playlist_add = $access25 && ($libitem->song_count <= $directplay_limit);
     } ?>
         <tr id="album_<?php echo $libitem->id; ?>" class="libitem_menu" data-object-type="album" data-object-id="<?php echo $libitem->id; ?>">
-            <?php $content = $talFactory->createTalView()
+            <?php
+            // Reassign EVERY key each row. Prev row's value sticks otherwise.
+            $content = $albumRowView
             ->setContext('USER_IS_REGISTERED', User::is_registered())
             ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
             ->setContext('ALBUM', $guiFactory->createAlbumViewAdapter($gatekeeper, $browse, $libitem))
@@ -145,7 +150,6 @@ foreach ($object_ids as $album_id) {
             ->setContext('CLASS_ARTIST', $cel_artist)
             ->setContext('CLASS_TAGS', $cel_tags)
             ->setContext('CLASS_COUNTER', $cel_counter)
-            ->setTemplate('album_row.xhtml')
             ->render();
 
     echo $content; ?>

--- a/public/templates/show_folders.inc.php
+++ b/public/templates/show_folders.inc.php
@@ -100,6 +100,9 @@ $guiFactory = $dic->get(GuiFactoryInterface::class);
 $gatekeeper = $dic->get(GatekeeperFactoryInterface::class)->createGuiGatekeeper();
 
 /* Foreach through the objects e.g. folder-12 song-125 podcast_episode-233 */
+// One TAL view reused for all rows
+$folderRowView = $talFactory->createTalView()->setTemplate('folder_row.xhtml');
+
 foreach ($object_ids as $object) {
     // A bare id is a folder: that is what a collection pinned to folders hands over, having no types to send
     if (preg_match('/^[0-9]+$/', (string) $object)) {
@@ -138,7 +141,9 @@ foreach ($object_ids as $object) {
         $show_temp_add = $access25 && $libitem->playable && ($libitem->object_count > 0 && $libitem->object_count <= $directplay_limit);
     } ?>
             <tr id="<?php echo $object_type . '_' . $libitem->getId(); ?>" class="libitem_menu" data-object-type="<?php echo $object_type; ?>" data-object-id="<?php echo $libitem->getId(); ?>">
-    <?php $content = $talFactory->createTalView()
+    <?php
+            // Reassign EVERY key each row. Prev row's value sticks otherwise.
+            $content = $folderRowView
             ->setContext('USER_IS_REGISTERED', User::is_registered())
             ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
             ->setContext('FOLDER', $guiFactory->createFolderViewAdapter($gatekeeper, $folder, $libitem, $object_type))
@@ -148,7 +153,6 @@ foreach ($object_ids as $object) {
             ->setContext('CLASS_COVER', $cel_cover)
             ->setContext('CLASS_FOLDER', $cel_folder)
             ->setContext('CLASS_COUNTER', $cel_counter)
-            ->setTemplate('folder_row.xhtml')
             ->render();
     echo $content; ?>
             </tr>

--- a/public/templates/show_playlists.inc.php
+++ b/public/templates/show_playlists.inc.php
@@ -105,10 +105,10 @@ foreach ($object_ids as $playlist_id) {
         <tr id="playlist_row_<?php echo $libitem->id; ?>">
             <?php
              // Reassign EVERY key each row. Prev row's value sticks otherwise.
+             // CONFIG omitted: TalView::render() sets it (was overwritten anyway).
             $content = $playlistRowView
                            ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
                            ->setContext('PLAYLIST', $guiFactory->createPlaylistViewAdapter($gatekeeper, $libitem))
-                           ->setContext('CONFIG', $guiFactory->createConfigViewAdapter())
                            ->setContext('IS_SHOW_ART', $show_art)
                            ->setContext('IS_SHOW_PLAYLIST_ADD', $show_playlist_add)
                            ->setContext('CLASS_COVER', $cel_cover)

--- a/public/templates/show_playlists.inc.php
+++ b/public/templates/show_playlists.inc.php
@@ -90,6 +90,10 @@ $talFactory = $dic->get(TalFactoryInterface::class);
 $guiFactory = $dic->get(GuiFactoryInterface::class);
 $gatekeeper = $dic->get(GatekeeperFactoryInterface::class)->createGuiGatekeeper();
 $user_id    = (!empty(Core::get_global('user'))) ? Core::get_global('user')->id : 0;
+
+// One TAL view reused for all rows
+$playlistRowView = $talFactory->createTalView()->setTemplate('playlist_row.xhtml');
+
 foreach ($object_ids as $playlist_id) {
     $libitem = new Playlist($playlist_id);
     if ($libitem->isNew() || (!$libitem->has_collaborate() && $libitem->type === 'private')) {
@@ -99,15 +103,16 @@ foreach ($object_ids as $playlist_id) {
     // Don't show empty playlist if not admin or the owner
     if (Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::ADMIN) || $libitem->get_user_owner() == $user_id || $libitem->get_media_count() > 0) { ?>
         <tr id="playlist_row_<?php echo $libitem->id; ?>">
-            <?php $content = $talFactory->createTalView()
-        ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
-        ->setContext('PLAYLIST', $guiFactory->createPlaylistViewAdapter($gatekeeper, $libitem))
-        ->setContext('CONFIG', $guiFactory->createConfigViewAdapter())
-        ->setContext('IS_SHOW_ART', $show_art)
-        ->setContext('IS_SHOW_PLAYLIST_ADD', $show_playlist_add)
-        ->setContext('CLASS_COVER', $cel_cover)
-        ->setTemplate('playlist_row.xhtml')
-        ->render();
+            <?php
+             // Reassign EVERY key each row. Prev row's value sticks otherwise.
+            $content = $playlistRowView
+                           ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
+                           ->setContext('PLAYLIST', $guiFactory->createPlaylistViewAdapter($gatekeeper, $libitem))
+                           ->setContext('CONFIG', $guiFactory->createConfigViewAdapter())
+                           ->setContext('IS_SHOW_ART', $show_art)
+                           ->setContext('IS_SHOW_PLAYLIST_ADD', $show_playlist_add)
+                           ->setContext('CLASS_COVER', $cel_cover)
+                           ->render();
 
         echo $content; ?>
         </tr>

--- a/public/templates/show_similar_songs.inc.php
+++ b/public/templates/show_similar_songs.inc.php
@@ -95,6 +95,9 @@ $talFactory = $dic->get(TalFactoryInterface::class);
 $guiFactory = $dic->get(GuiFactoryInterface::class);
 $gatekeeper = $dic->get(GatekeeperFactoryInterface::class)->createGuiGatekeeper();
 
+// One TAL view reused for all rows
+$songRowView = $talFactory->createTalView()->setTemplate('song_row.xhtml');
+
 foreach ($object_ids as $song_id) {
     $libitem = new Song($song_id);
     if ($libitem->isNew()) {
@@ -103,7 +106,8 @@ foreach ($object_ids as $song_id) {
             <tr id="song_<?php echo $libitem->id; ?>">
                 <?php
         if ($libitem->enabled || Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::CONTENT_MANAGER)) {
-            $content = $talFactory->createTalView()
+            // Reassign EVERY key each row. Prev row's value sticks otherwise.
+            $content = $songRowView
                 ->setContext('USER_IS_REGISTERED', User::is_registered())
                 ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
                 ->setContext('SONG', $guiFactory->createSongViewAdapter($gatekeeper, $libitem))
@@ -118,7 +122,6 @@ foreach ($object_ids as $song_id) {
                 ->setContext('IS_HIDE_ALBUM', $hide_album)
                 ->setContext('IS_HIDE_YEAR', $hide_year)
                 ->setContext('IS_HIDE_DRAG', (empty($argument) || $hide_drag))
-                ->setTemplate('song_row.xhtml')
                 ->render();
 
             echo $content;

--- a/public/templates/show_similar_songs.inc.php
+++ b/public/templates/show_similar_songs.inc.php
@@ -107,11 +107,11 @@ foreach ($object_ids as $song_id) {
                 <?php
         if ($libitem->enabled || Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::CONTENT_MANAGER)) {
             // Reassign EVERY key each row. Prev row's value sticks otherwise.
+            // CONFIG omitted: TalView::render() sets it (was overwritten anyway).
             $content = $songRowView
                 ->setContext('USER_IS_REGISTERED', User::is_registered())
                 ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
                 ->setContext('SONG', $guiFactory->createSongViewAdapter($gatekeeper, $libitem))
-                ->setContext('CONFIG', $guiFactory->createConfigViewAdapter())
                 ->setContext('ARGUMENT_PARAM', '')
                 ->setContext('IS_TABLE_VIEW', $is_table)
                 ->setContext('IS_ALBUM_GROUP', $is_group)

--- a/public/templates/show_songs.inc.php
+++ b/public/templates/show_songs.inc.php
@@ -241,11 +241,11 @@ foreach ($object_ids as $song_id) {
                     }
 
                     // Reassign EVERY key each row. Prev row's value sticks otherwise.
+                    // CONFIG omitted: TalView::render() sets it (was overwritten anyway).
                     $content = $songRowView
                                 ->setContext('USER_IS_REGISTERED', User::is_registered())
                                 ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
                                 ->setContext('SONG', $guiFactory->createSongViewAdapter($gatekeeper, $libitem))
-                                ->setContext('CONFIG', $guiFactory->createConfigViewAdapter())
                                 ->setContext('ARGUMENT_PARAM', $argument_param)
                                 ->setContext('IS_TABLE_VIEW', $is_table)
                                 ->setContext('IS_ALBUM_GROUP', $is_group)

--- a/public/templates/show_songs.inc.php
+++ b/public/templates/show_songs.inc.php
@@ -221,6 +221,9 @@ if (empty($browse_cached)) {
     Song::build_cache($object_ids);
 }
 
+// One TAL view reused for all rows
+$songRowView = $talFactory->createTalView()->setTemplate('song_row.xhtml');
+
 foreach ($object_ids as $song_id) {
     $libitem = new Song($song_id);
     if ($libitem->isNew()) {
@@ -237,23 +240,23 @@ foreach ($object_ids as $song_id) {
                         echo '<td class="cel_select">' . $checkbox . '</td>';
                     }
 
-                    $content = $talFactory->createTalView()
-                        ->setContext('USER_IS_REGISTERED', User::is_registered())
-                        ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
-                        ->setContext('SONG', $guiFactory->createSongViewAdapter($gatekeeper, $libitem))
-                        ->setContext('CONFIG', $guiFactory->createConfigViewAdapter())
-                        ->setContext('ARGUMENT_PARAM', $argument_param)
-                        ->setContext('IS_TABLE_VIEW', $is_table)
-                        ->setContext('IS_ALBUM_GROUP', $is_group)
-                        ->setContext('IS_SHOW_TRACK', $show_track)
-                        ->setContext('IS_SHOW_LICENSE', $show_license)
-                        ->setContext('IS_HIDE_GENRE', $hide_genres)
-                        ->setContext('IS_HIDE_ARTIST', $hide_artist)
-                        ->setContext('IS_HIDE_ALBUM', $hide_album)
-                        ->setContext('IS_HIDE_YEAR', $hide_year)
-                        ->setContext('IS_HIDE_DRAG', (empty($argument) || $hide_drag))
-                        ->setTemplate('song_row.xhtml')
-                        ->render();
+                    // Reassign EVERY key each row. Prev row's value sticks otherwise.
+                    $content = $songRowView
+                                ->setContext('USER_IS_REGISTERED', User::is_registered())
+                                ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
+                                ->setContext('SONG', $guiFactory->createSongViewAdapter($gatekeeper, $libitem))
+                                ->setContext('CONFIG', $guiFactory->createConfigViewAdapter())
+                                ->setContext('ARGUMENT_PARAM', $argument_param)
+                                ->setContext('IS_TABLE_VIEW', $is_table)
+                                ->setContext('IS_ALBUM_GROUP', $is_group)
+                                ->setContext('IS_SHOW_TRACK', $show_track)
+                                ->setContext('IS_SHOW_LICENSE', $show_license)
+                                ->setContext('IS_HIDE_GENRE', $hide_genres)
+                                ->setContext('IS_HIDE_ARTIST', $hide_artist)
+                                ->setContext('IS_HIDE_ALBUM', $hide_album)
+                                ->setContext('IS_HIDE_YEAR', $hide_year)
+                                ->setContext('IS_HIDE_DRAG', (empty($argument) || $hide_drag))
+                                ->render();
 
                     echo $content;
                 } ?>

--- a/public/templates/show_top_tracks.inc.php
+++ b/public/templates/show_top_tracks.inc.php
@@ -95,6 +95,9 @@ $talFactory = $dic->get(TalFactoryInterface::class);
 $guiFactory = $dic->get(GuiFactoryInterface::class);
 $gatekeeper = $dic->get(GatekeeperFactoryInterface::class)->createGuiGatekeeper();
 
+// One TAL view reused for all rows
+$songRowView = $talFactory->createTalView()->setTemplate('song_row.xhtml');
+
 foreach ($object_ids as $song_id) {
     $libitem = new Song($song_id);
     if ($libitem->isNew()) {
@@ -103,7 +106,8 @@ foreach ($object_ids as $song_id) {
             <tr id="song_<?php echo $libitem->id; ?>">
                 <?php
         if ($libitem->enabled || Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::CONTENT_MANAGER)) {
-            $content = $talFactory->createTalView()
+            // Reassign EVERY key each row. Prev row's value sticks otherwise.
+            $content = $songRowView
                 ->setContext('USER_IS_REGISTERED', User::is_registered())
                 ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
                 ->setContext('SONG', $guiFactory->createSongViewAdapter($gatekeeper, $libitem))
@@ -118,7 +122,6 @@ foreach ($object_ids as $song_id) {
                 ->setContext('IS_HIDE_ALBUM', $hide_album)
                 ->setContext('IS_HIDE_YEAR', $hide_year)
                 ->setContext('IS_HIDE_DRAG', (empty($argument) || $hide_drag))
-                ->setTemplate('song_row.xhtml')
                 ->render();
 
             echo $content;

--- a/public/templates/show_top_tracks.inc.php
+++ b/public/templates/show_top_tracks.inc.php
@@ -107,11 +107,11 @@ foreach ($object_ids as $song_id) {
                 <?php
         if ($libitem->enabled || Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::CONTENT_MANAGER)) {
             // Reassign EVERY key each row. Prev row's value sticks otherwise.
+            // CONFIG omitted: TalView::render() sets it (was overwritten anyway).
             $content = $songRowView
                 ->setContext('USER_IS_REGISTERED', User::is_registered())
                 ->setContext('USING_RATINGS', User::is_registered() && (AmpConfig::get('ratings')))
                 ->setContext('SONG', $guiFactory->createSongViewAdapter($gatekeeper, $libitem))
-                ->setContext('CONFIG', $guiFactory->createConfigViewAdapter())
                 ->setContext('ARGUMENT_PARAM', '')
                 ->setContext('IS_TABLE_VIEW', $is_table)
                 ->setContext('IS_ALBUM_GROUP', $is_group)

--- a/src/Module/Util/Ui.php
+++ b/src/Module/Util/Ui.php
@@ -65,6 +65,9 @@ class Ui implements UiInterface
     /** @var array<string, array{attrs: string, viewbox: string, inner: string}|null> parsed material symbol source files */
     private static array $_symbol_cache = [];
 
+    /** @var array<string, string> resolved template paths, keyed by theme|extern|template */
+    private static array $_template_cache = [];
+
     private static int $_ticker = 0;
 
     /** @var array<string, bool> material symbols referenced on the current page (sprite content) */
@@ -156,18 +159,25 @@ class Ui implements UiInterface
      */
     public static function find_template(string $template, bool $extern = false): string
     {
-        $path      = AmpConfig::get('theme_path', '/themes/reborn') . '/templates/' . $template;
+        // Path only depends on theme + extern + template name, so resolve once per request.
+        $theme    = (string) AmpConfig::get('theme_path', '/themes/reborn');
+        $cacheKey = $theme . '|' . ($extern ? '1' : '0') . '|' . $template;
+        if (isset(self::$_template_cache[$cacheKey])) {
+            return self::$_template_cache[$cacheKey];
+        }
+
+        $path      = $theme . '/templates/' . $template;
         $realpath  = __DIR__ . '/../../../public/' . $path;
         $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
         if (($extension !== 'php' || AmpConfig::get('allow_php_themes')) && file_exists($realpath) && is_file($realpath)) {
-            return $path;
+            return self::$_template_cache[$cacheKey] = $path;
         }
 
         if ($extern) {
-            return '/templates/' . $template;
+            return self::$_template_cache[$cacheKey] = '/templates/' . $template;
         }
 
-        return __DIR__ . '/../../../public/templates/' . $template;
+        return self::$_template_cache[$cacheKey] = __DIR__ . '/../../../public/templates/' . $template;
     }
 
     /**


### PR DESCRIPTION
Move `createTalView()` and `setTemplate()` out of the row loop and reassign contexts each iteration.

This is allowed by PHPTAL https://phptal.org/manual/en/split/execute.html

Building the PHPTAL engine once instead of per row skips redundant object instantiations + config/realpath calls.
