### PR TITLE
Cacheprocess

### DIFF
--- a/src/Module/Catalog/Catalog.php
+++ b/src/Module/Catalog/Catalog.php
@@ -49,6 +49,7 @@ use Ampache\Module\Statistics\Stats;
 use Ampache\Module\Statistics\Userflag;
 use Ampache\Module\System\AmpError;
 use Ampache\Module\System\Core;
+use Ampache\Module\System\Dba;
 use Ampache\Module\System\Plugin\Plugin;
 use Ampache\Module\System\Plugin\PluginTypeEnum;
 use Ampache\Module\User\Activity\Useractivity;
@@ -203,7 +204,13 @@ abstract class Catalog extends database_object
                         $catalog->cache_catalog_proc();
                     }
 
-                    $catalog_dirs = new RecursiveDirectoryIterator($cache_path);
+                    // only walk this catalog's own cache directory
+                    $catalog_cache_dir = rtrim(trim($cache_path), '/') . '/' . $catalogid;
+                    if (!is_dir($catalog_cache_dir)) {
+                        continue;
+                    }
+
+                    $catalog_dirs = new RecursiveDirectoryIterator($catalog_cache_dir);
                     $dir_files    = new RecursiveIteratorIterator($catalog_dirs);
                     $cache_files  = new RegexIterator($dir_files, sprintf('/\.%s/i', $cache_target));
                     debug_event(self::class, 'cache_catalogs: cleaning old files', 5);
@@ -215,15 +222,29 @@ abstract class Catalog extends database_object
                     $remote_catalog = ($catalog instanceof Catalog_remote || $catalog instanceof Catalog_subsonic);
                     $remote_cache   = (bool) AmpConfig::get('cache_remote', false);
 
+                    // fetch all song paths in one query
+                    $cache_list = [];
                     foreach ($cache_files as $file) {
+                        $cache_list[] = (string) $file;
+                    }
+                    $song_files = [];
+                    $song_ids   = array_values(array_unique(array_map(static fn ($file) => (int) pathinfo($file, PATHINFO_FILENAME), $cache_list)));
+                    foreach (array_chunk($song_ids, 500) as $chunk) {
+                        $idlist     = implode(',', $chunk);
+                        $db_results = Dba::read("SELECT `id`, `file` FROM `song` WHERE `id` IN (" . $idlist . ");");
+                        while ($row = Dba::fetch_assoc($db_results)) {
+                            $song_files[(int) $row['id']] = (string) $row['file'];
+                        }
+                    }
+
+                    foreach ($cache_list as $file) {
                         $pathinfo  = pathinfo((string) $file);
                         $song_id   = (int) $pathinfo['filename'];
-                        $song      = new Song($song_id);
-                        $song_path = ($song->isNew() === false && $song->file)
-                            ? pathinfo($song->file)
-                            : ['extension' => ''];
-                        $extension = $song_path['extension'] ?? '';
-                        if ($song->isNew() || $extension === '') {
+                        $song_file = $song_files[$song_id] ?? '';
+                        $extension = ($song_file !== '')
+                            ? (pathinfo($song_file, PATHINFO_EXTENSION) ?: '')
+                            : '';
+                        if ($song_file === '' || $extension === '') {
                             unlink($file);
                             debug_event(self::class, 'cache_catalogs: removed (not in database) {' . $file . '}', 4);
                             $interactor?->info(
@@ -259,9 +280,9 @@ abstract class Catalog extends database_object
                             && !(AmpConfig::get('cache_' . $extension, false))
                         ) {
                             unlink($file);
-                            debug_event(self::class, 'cache_catalogs: removed (cache_' . $extension . ' ' . $song->file . ') {' . $file . '}', 4);
+                            debug_event(self::class, 'cache_catalogs: removed (cache_' . $extension . ' ' . $song_file . ') {' . $file . '}', 4);
                             $interactor?->info(
-                                sprintf('cache_catalogs: removed (cache_%s %s) {%s}', $extension, $song->file, $file),
+                                sprintf('cache_catalogs: removed (cache_%s %s) {%s}', $extension, $song_file, $file),
                                 true
                             );
                         }

--- a/src/Module/Catalog/Catalog.php
+++ b/src/Module/Catalog/Catalog.php
@@ -228,7 +228,7 @@ abstract class Catalog extends database_object
                         $cache_list[] = (string) $file;
                     }
                     $song_files = [];
-                    $song_ids   = array_values(array_unique(array_map(static fn ($file) => (int) pathinfo($file, PATHINFO_FILENAME), $cache_list)));
+                    $song_ids   = array_values(array_unique(array_map(static fn($file) => (int) pathinfo($file, PATHINFO_FILENAME), $cache_list)));
                     foreach (array_chunk($song_ids, 500) as $chunk) {
                         $idlist     = implode(',', $chunk);
                         $db_results = Dba::read("SELECT `id`, `file` FROM `song` WHERE `id` IN (" . $idlist . ");");

--- a/src/Module/Catalog/Catalog_local.php
+++ b/src/Module/Catalog/Catalog_local.php
@@ -37,6 +37,7 @@ use Ampache\Module\Podcast\PodcastSyncerInterface;
 use Ampache\Module\Statistics\Rating;
 use Ampache\Module\System\AmpError;
 use Ampache\Module\System\Core;
+use Ampache\Module\System\Dba;
 use Ampache\Module\Util\ObjectTypeToClassNameMapper;
 use Ampache\Module\Util\Recommendation;
 use Ampache\Module\Util\Ui;
@@ -748,6 +749,16 @@ class Catalog_local extends Catalog
 
         $results = self::getSongRepository()->getIdsByCatalogAndExtension($this->getId(), $extensions);
 
+        // fetch all song paths and times in one query
+        $song_rows = [];
+        foreach (array_chunk($results, 500) as $chunk) {
+            $idlist     = implode(',', array_map('intval', $chunk));
+            $db_results = Dba::read("SELECT `id`, `file`, `time` FROM `song` WHERE `id` IN (" . $idlist . ");");
+            while ($row = Dba::fetch_assoc($db_results)) {
+                $song_rows[(int) $row['id']] = ['file' => (string) $row['file'], 'time' => (int) $row['time']];
+            }
+        }
+
         foreach ($results as $song_id) {
             $target_file     = Catalog::get_cache_path($song_id, $this->getId(), $cache_path, $cache_target);
             $old_target_file = rtrim(trim($cache_path), '/') . '/' . $this->getId() . '/' . $song_id . '.' . $cache_target;
@@ -758,20 +769,28 @@ class Catalog_local extends Catalog
             }
 
             $file_exists = ($target_file !== null && is_file($target_file));
-            $media       = new Song($song_id);
+            $song_file   = $song_rows[$song_id]['file'] ?? '';
+            $song_time   = $song_rows[$song_id]['time'] ?? 0;
 
             if (
-                $media->isNew()
-                || !$media->file
-                || !is_file($media->file)
+                $song_file === ''
+                || !is_file($song_file)
             ) {
-                debug_event('local.catalog', sprintf('Not Found: %s', $media->file), 3);
+                debug_event('local.catalog', sprintf('Not Found: %s', $song_file), 3);
 
-                return false;
+                // skip, don't abort the run
+                continue;
             }
 
             // check the old path too
             if ($file_exists) {
+                // skip the expensive tag parse when the source is older than the cache
+                $source_mtime = filemtime($song_file);
+                $cache_mtime  = filemtime($target_file);
+                if ($source_mtime !== false && $cache_mtime !== false && $cache_mtime >= $source_mtime) {
+                    continue;
+                }
+
                 // get the time for the cached file and compare
                 $vainfo = $this->getUtilityFactory()->createVaInfo(
                     $target_file,
@@ -781,18 +800,28 @@ class Catalog_local extends Catalog
                     (string) $this->sort_pattern,
                     (string) $this->rename_pattern
                 );
-                if ($media->time > 0 && !$vainfo->check_time($media->time)) {
-                    debug_event('local.catalog', 'check_time FAILED for: ' . $media->id, 5);
+                if ($song_time > 0 && !$vainfo->check_time($song_time)) {
+                    debug_event('local.catalog', 'check_time FAILED for: ' . $song_id, 5);
                     unlink($target_file);
                     $file_exists = false;
                 }
             }
 
             if (!$file_exists) {
-                // transcode to the new path
+                // transcode to .tmp, only promote on success
+                $media              = new Song($song_id);
                 $transcode_settings = $media->get_transcode_settings($cache_target);
-                Stream::start_transcode($media, $transcode_settings, (string) $target_file);
-                debug_event('local.catalog', 'Saved: ' . $song_id . ' to: {' . $target_file . '}', 5);
+                $tmp_file           = $target_file . '.tmp';
+                Stream::start_transcode($media, $transcode_settings, $tmp_file);
+                if (is_file($tmp_file) && filesize($tmp_file) > 0) {
+                    rename($tmp_file, (string) $target_file);
+                    debug_event('local.catalog', 'Saved: ' . $song_id . ' to: {' . $target_file . '}', 5);
+                } else {
+                    if (is_file($tmp_file)) {
+                        unlink($tmp_file);
+                    }
+                    debug_event('local.catalog', 'Transcode failed for: ' . $song_id . ' {' . $tmp_file . '}', 3);
+                }
             }
         }
 


### PR DESCRIPTION
- skip the expensive tag parse when the source is older than the cache
- transcode to .tmp, only promote on success
- bugfix: song with a missing source file no longer aborts the whole cache run
- only walk this catalog's own cache directory
- fetch all song paths in one query

On my Ampache, tests were made launching `echo 3 > /proc/sys/vm/drop_caches` as root between test.

I went from ≈ 30s (sometimes more) to ≈ 2s.
