### PR TITLE
Add connect/read timeouts to UPnP device cURL requests

### DIFF
--- a/src/Module/Playback/Localplay/Upnp/UPnPDevice.php
+++ b/src/Module/Playback/Localplay/Upnp/UPnPDevice.php
@@ -106,6 +106,8 @@ class UPnPDevice
         curl_setopt($curl, CURLOPT_HEADER, true);
         curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
         curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($curl, CURLOPT_TIMEOUT, 30);
 
         $response = curl_exec($curl);
         //debug_event('upnpdevice', 'sendRequestToDevice response: ' . $response, 5);
@@ -134,6 +136,8 @@ class UPnPDevice
 
         curl_setopt($curl, CURLOPT_URL, $descriptionUrl);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($curl, CURLOPT_TIMEOUT, 30);
         $response = curl_exec($curl);
         //!!debug_event('upnpdevice', 'parseDescriptionUrl response: ' . $response, 5);
 


### PR DESCRIPTION
The two active cURL requests in UPnPDevice (sendRequestToDevice and parseDescriptionUrl) never set CURLOPT_TIMEOUT or CURLOPT_CONNECTTIMEOUT, so a UPnP renderer that stops responding mid-transfer hangs the request until the server's own max_execution_time kicks in, tying up a PHP worker. Since the host comes from device discovery and the stored description URL, an unreachable or misbehaving renderer stalls playback control. I added a 5s connect timeout and a 30s overall timeout to both handles, matching the timeouts already used in PlaylistUrlResolver and SubsonicClient. No behavior change for devices that respond normally.