### PR TITLE
Serialize artist/album creation, parallel uploads created duplicates

### DIFF
--- a/src/Module/System/DbLock.php
+++ b/src/Module/System/DbLock.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Module\System;
+
+use Ampache\Config\AmpConfig;
+
+/**
+ * Named database lock (MySQL GET_LOCK) serializing check-then-insert sections
+ * across concurrent requests, e.g. parallel uploads creating the same artist.
+ * Best effort: a failed acquisition does not block the caller.
+ */
+final class DbLock
+{
+    private const TIMEOUT = 10;
+
+    public static function acquire(string $key): bool
+    {
+        $statement = Dba::read('SELECT GET_LOCK(?, ?);', [self::name($key), self::TIMEOUT]);
+
+        return ($statement !== null && $statement->fetchColumn() == 1);
+    }
+
+    public static function release(string $key): void
+    {
+        Dba::read('SELECT RELEASE_LOCK(?);', [self::name($key)]);
+    }
+
+    private static function name(string $key): string
+    {
+        // GET_LOCK names are limited to 64 characters and shared server-wide
+        return 'ampache_' . md5(AmpConfig::get('database_name', '') . '|' . $key);
+    }
+}

--- a/src/Repository/Model/Album.php
+++ b/src/Repository/Model/Album.php
@@ -35,6 +35,7 @@ use Ampache\Module\Statistics\Rating;
 use Ampache\Module\Statistics\Stats;
 use Ampache\Module\Statistics\Userflag;
 use Ampache\Module\System\Core;
+use Ampache\Module\System\DbLock;
 use Ampache\Module\Wanted\WantedManagerInterface;
 use Ampache\Repository\AlbumDiskRepositoryInterface;
 use Ampache\Repository\AlbumRepositoryInterface;
@@ -272,7 +273,22 @@ class Album extends database_object implements
             return 0;
         }
 
+        // lock, then look again: a parallel request may just have created it
+        $lock = 'album_check|' . ($prefix ?? '') . '|' . $name . '|' . $year . '|' . ($album_artist ?? '');
+        if (!DbLock::acquire($lock)) {
+            debug_event(self::class, 'check album: could not lock {' . $name . '}, inserting unguarded', 3);
+        } else {
+            $album_id = self::getAlbumRepository()->findByProperties($properties);
+            if ($album_id > 0) {
+                DbLock::release($lock);
+                self::$_mapcache[$name][$year][$album_artist ?? ''][$mbid ?? ''][$mbid_group ?? ''][$release_type ?? ''][$release_status ?? ''][$original_year ?? ''][$barcode ?? ''][$catalog_number ?? ''][$version ?? ''] = $album_id;
+
+                return $album_id;
+            }
+        }
+
         $album_id = self::getAlbumRepository()->create($properties, time());
+        DbLock::release($lock);
         if (!$album_id) {
             return 0;
         }

--- a/src/Repository/Model/Artist.php
+++ b/src/Repository/Model/Artist.php
@@ -34,6 +34,7 @@ use Ampache\Module\Label\LabelListUpdaterInterface;
 use Ampache\Module\Statistics\Rating;
 use Ampache\Module\Statistics\Stats;
 use Ampache\Module\Statistics\Userflag;
+use Ampache\Module\System\DbLock;
 use Ampache\Module\System\Plugin\Plugin;
 use Ampache\Module\Util\VaInfo;
 use Ampache\Plugin\AmpacheMusicBrainz;
@@ -210,23 +211,29 @@ class Artist extends database_object implements
         }
 
         $artistRepository = self::getArtistRepository();
-        if ($mbid !== null && $mbid !== '' && $mbid !== '0') {
-            // check for artists by mbid (there should only ever be one sent here); the name match below never
-            // supplies the id, it only back-fills the mbid onto rows that were stored without one
-            $artist_id = $artistRepository->findIdByMbid($mbid) ?? 0;
+        $lookup           = static function () use ($artistRepository, $name, $full_name, $mbid, $readonly): int {
+            if ($mbid !== null && $mbid !== '' && $mbid !== '0') {
+                // check for artists by mbid (there should only ever be one sent here); the name match below never
+                // supplies the id, it only back-fills the mbid onto rows that were stored without one
+                $artist_id = $artistRepository->findIdByMbid($mbid) ?? 0;
 
-            // still missing? Match on the name and update the mbid
-            if (!$readonly) {
-                foreach ($artistRepository->findIdsByNameWithoutMbid($name, $full_name) as $matched_id) {
-                    $artistRepository->setField($matched_id, ArtistFieldEnum::MBID, $mbid);
+                // still missing? Match on the name and update the mbid
+                if (!$readonly) {
+                    foreach ($artistRepository->findIdsByNameWithoutMbid($name, $full_name) as $matched_id) {
+                        $artistRepository->setField($matched_id, ArtistFieldEnum::MBID, $mbid);
+                    }
                 }
+            } else {
+                // look for artists with no mbid (if they exist) and then match on mbid artists last
+                $artist_id = $artistRepository->findIdByName($name, $full_name, false)
+                    ?? $artistRepository->findIdByName($name, $full_name, true)
+                    ?? 0;
             }
-        } else {
-            // look for artists with no mbid (if they exist) and then match on mbid artists last
-            $artist_id = $artistRepository->findIdByName($name, $full_name, false)
-                ?? $artistRepository->findIdByName($name, $full_name, true)
-                ?? 0;
-        }
+
+            return $artist_id;
+        };
+
+        $artist_id = $lookup();
 
         // cache and return the result
         if ($artist_id > 0) {
@@ -237,6 +244,20 @@ class Artist extends database_object implements
 
         if ($readonly) {
             return null;
+        }
+
+        // lock, then look again: a parallel request may just have created it
+        $lock = 'artist_check|' . ($prefix ?? '') . '|' . $name;
+        if (!DbLock::acquire($lock)) {
+            debug_event(self::class, 'check artist: could not lock {' . $name . '}, inserting unguarded', 3);
+        } else {
+            $artist_id = $lookup();
+            if ($artist_id > 0) {
+                DbLock::release($lock);
+                self::$_mapcache[$name][$prefix ?? ''][$mbid ?? ''] = $artist_id;
+
+                return $artist_id;
+            }
         }
 
         // prefer the name of the artist as provided by MusicBrainz
@@ -259,6 +280,7 @@ class Artist extends database_object implements
             : $mbid;
 
         $artist_id = $artistRepository->create($name, $prefix, $mbid, $user);
+        DbLock::release($lock);
         if ($artist_id === null) {
             return null;
         }


### PR DESCRIPTION
Fixes #4441
 
`Artist::check` and `Album::check` looked up then inserted with no serialization: two concurrent requests (parallel uploads) both missed the lookup and both inserted. `artist` and `album` carry no UNIQUE constraint to catch it (multiple NULL mbids are allowed).
 
- New `DbLock`: named MySQL lock (`GET_LOCK`/`RELEASE_LOCK`), key prefixed with the database name, 10s timeout.
- `Artist::check` / `Album::check`: fast lookup unchanged; on miss, acquire the lock, look up again (finds the row a parallel request just created), insert otherwise, release. Readonly path never locks. If the lock cannot be acquired, insert anyway and log.
- The re-lookup also resolves the artist through the mbid back-filled by the first pass.

Tested: two parallel uploads of a new artist created 2 rows before, 1 row after (same instance). Other creators on the upload path (`album_disk`, `tag`) are already covered by UNIQUE constraints.