### PR TITLE
Podcast here we go

### DIFF
--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -983,6 +983,16 @@ show_footer_statistics = "true"
 ; DEFAULT: "false"
 ;use_rss = "true"
 
+; Set the itunes:explicit flag sent in rss feeds. Podcast directories
+; require the tag, Ampache has no per-item rating to fill it from.
+; DEFAULT: "false"
+;rss_explicit = "true"
+
+; Apple sub-category advertised by podcast feeds, on top of the "Music"
+; category. Valid values: Music Commentary, Music History, Music Interviews
+; DEFAULT: ""
+;rss_subcategory = "Music Commentary"
+
 ; This setting allows themes to overwrite PHP template files. This can be really
 ; dangerous. Do this only if you trust every theme in your themes/ directory.
 ; DEFAULT: "false"

--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -988,6 +988,12 @@ show_footer_statistics = "true"
 ; DEFAULT: "false"
 ;rss_explicit = "true"
 
+; Serve rss feeds under /rss/{object_type}/{object_id}/{slug} instead of a
+; query string. Requires the rewrite rules shipped in public/rss/.htaccess.dist
+; (apache) or docs/examples/nginx-site.conf (nginx).
+; DEFAULT: "false"
+;rss_beautiful_url = "true"
+
 ; Apple sub-category advertised by podcast feeds, on top of the "Music"
 ; category. Valid values: Music Commentary, Music History, Music Interviews
 ; DEFAULT: ""

--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -6,7 +6,7 @@
 ; This value is used to detect if this config file is up to date
 ; this is compared against a constant called CONFIG_VERSION
 ; that is located in src/Config/Init/InitializationHandlerConfig.php
-config_version = 95
+config_version = 96
 
 ; Defines the default timezone used by the date functions
 ; Uses the same strings as the default date.timezone (https://php.net/date.timezone)

--- a/config/ampache.cfg.php.dist
+++ b/config/ampache.cfg.php.dist
@@ -994,6 +994,12 @@ show_footer_statistics = "true"
 ; DEFAULT: "false"
 ;rss_beautiful_url = "true"
 
+; Send X-Robots-Tag: noindex with rss feeds. Feeds are meant to be found, and
+; podcast directories skip a feed marked noindex, so this is off by default.
+; Note that the shipped web server configs send X-Robots-Tag: none site wide.
+; DEFAULT: "false"
+;rss_noindex = "true"
+
 ; Apple sub-category advertised by podcast feeds, on top of the "Music"
 ; category. Valid values: Music Commentary, Music History, Music Interviews
 ; DEFAULT: ""

--- a/docs/examples/nginx-site.conf
+++ b/docs/examples/nginx-site.conf
@@ -55,6 +55,16 @@ server {
     # Somebody said this helps, in my setup it doesn't prevent temporary saving in files
     proxy_max_temp_file_size 0;
 
+    # Rewrite rules for the rss feeds, enabled with rss_beautiful_url.
+    # These mirror public/rss/.htaccess.dist; keep the two in sync when adding a route.
+    # The trailing slug is decorative, a feed resolves without it.
+    if ( !-e $request_filename ) {
+        # /rss/{object_type}/{object_id}[/{slug}]
+        rewrite ^/rss/(album|album-disk|artist|podcast|song)/([0-9]+)(/[^/]*)?/?$ /rss.php?type=library_item&object_type=$1&object_id=$2 last;
+        # /rss/{feed}
+        rewrite ^/rss/(latest-album|latest-artist|latest-shout|latest-song|now-playing|recently-played)/?$ /rss.php?type=$1 last;
+    }
+
     # Rewrite rules for the Ampache REST API and the Subsonic backend.
     # These mirror public/rest/.htaccess.dist; keep the two in sync when adding a route.
     # Order matters: the versioned REST routes must be matched before the Subsonic catch-alls.

--- a/public/rss/.htaccess.dist
+++ b/public/rss/.htaccess.dist
@@ -1,0 +1,14 @@
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+
+    # These mirror docs/examples/nginx-site.conf; keep the two in sync when adding a route.
+    # The trailing slug is decorative, a feed resolves without it.
+
+    # /rss/{object_type}/{object_id}[/{slug}] | `rss.php?type=library_item&object_type={object_type}&object_id={object_id}`
+    RewriteRule ^(album|album-disk|artist|podcast|song)/([0-9]+)(/[^/]*)?/?$ /rss.php?type=library_item&object_type=$1&object_id=$2 [L,QSA]
+
+    # /rss/{feed} | `rss.php?type={feed}`
+    RewriteRule ^(latest-album|latest-artist|latest-shout|latest-song|now-playing|recently-played)/?$ /rss.php?type=$1 [L,QSA]
+</IfModule>

--- a/resources/templates/album/album.phtml
+++ b/resources/templates/album/album.phtml
@@ -82,7 +82,7 @@ Ui::show_box_top($this->getTitle(), 'info-box'); ?>
         </li>
         <?php } ?>
         <?php if ($this->showRss()) { ?>
-        <li><?php echo $this->raw(Ui::getRssLink(RssFeedTypeEnum::LIBRARY_ITEM, $this->getUser(), T_('RSS Feed'), ['object_type' => $type, 'object_id' => (string) $albumId])); ?></li>
+        <li><?php echo $this->raw(Ui::getRssLink(RssFeedTypeEnum::LIBRARY_ITEM, $this->getUser(), T_('RSS Feed'), ['object_type' => $type, 'object_id' => (string) $albumId], $this->getTitle())); ?></li>
         <?php } ?>
         <?php if ($this->showShout()) { ?>
         <li>

--- a/resources/templates/artist/artist.phtml
+++ b/resources/templates/artist/artist.phtml
@@ -117,7 +117,7 @@ Ui::show_box_top($this->e($this->getFullname()), 'info-box'); ?>
         <?php } ?>
         <?php } ?>
         <?php if ($this->showRss()) { ?>
-        <li><?php echo $this->raw(Ui::getRssLink(RssFeedTypeEnum::LIBRARY_ITEM, $this->getUser(), T_('RSS Feed'), ['object_type' => 'artist', 'object_id' => (string) $artistId])); ?></li>
+        <li><?php echo $this->raw(Ui::getRssLink(RssFeedTypeEnum::LIBRARY_ITEM, $this->getUser(), T_('RSS Feed'), ['object_type' => 'artist', 'object_id' => (string) $artistId], $this->getFullname())); ?></li>
         <?php } ?>
         <?php if ($this->showShout()) { ?>
         <li>

--- a/resources/templates/podcast.phtml
+++ b/resources/templates/podcast.phtml
@@ -99,7 +99,8 @@ if ($this->areRatingsShown()) { ?>
                 RssFeedTypeEnum::LIBRARY_ITEM,
                 $this->getCurrentUser(),
                 T_('RSS Feed'),
-                ['object_type' => 'podcast', 'object_id' => (string) $podcastId]
+                ['object_type' => 'podcast', 'object_id' => (string) $podcastId],
+                $this->getName()
             )); ?>
         </li>
     <?php }

--- a/resources/templates/rss/generic_rss_feed.phtml
+++ b/resources/templates/rss/generic_rss_feed.phtml
@@ -36,6 +36,7 @@ echo '<?xml version="1.0"?>', "\n"; ?>
         <description><?php echo $this->e($this->getTitle()); ?></description>
         <language><?php echo $this->e($this->getLanguage()); ?></language>
         <itunes:category text="Music"/>
+        <itunes:explicit><?php echo $this->e($this->getExplicit()); ?></itunes:explicit>
 <?php if ($this->getPubDate() !== null) { ?>
         <pubDate><?php echo $this->e($this->getPubDate()); ?></pubDate>
 <?php }

--- a/resources/templates/rss/podcast.phtml
+++ b/resources/templates/rss/podcast.phtml
@@ -30,13 +30,14 @@ declare(strict_types=1);
 $item = $this->getItem();
 
 echo '<?xml version="1.0" encoding="utf-8"?>', "\n"; ?>
-<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
     <channel>
         <title><?php echo $this->e($item->getTitle()); ?></title>
         <link><?php echo $this->e($item->getLink()); ?></link>
         <atom:link href="<?php echo $this->e($item->getRssLink()); ?>" rel="self" type="application/rss+xml"/>
         <itunes:image href="<?php echo $this->e($item->getImageUrl()); ?>"/>
         <description><![CDATA[<?php echo nl2br(str_replace(']]>', ']]]]><![CDATA[>', $item->getSummary())); ?>]]></description>
+        <content:encoded><![CDATA[<?php echo nl2br(str_replace(']]>', ']]]]><![CDATA[>', $item->getSummary())); ?>]]></content:encoded>
         <itunes:summary><?php echo $this->e($item->getSummary()); ?></itunes:summary>
         <language><?php echo $this->e($item->getLanguage()); ?></language>
         <generator>ampache</generator>
@@ -77,6 +78,12 @@ foreach ($item->getMedias() as $media) { ?>
 <?php   }
     if (!empty($media['episode'])) { ?>
             <podcast:episode><?php echo $this->e($media['episode']); ?></podcast:episode>
+<?php   }
+    if (!empty($media['image'])) { ?>
+            <itunes:image href="<?php echo $this->e($media['image']); ?>"/>
+<?php   }
+    if (!empty($media['explicit'])) { ?>
+            <itunes:explicit><?php echo $this->e($media['explicit']); ?></itunes:explicit>
 <?php   }
     if (!empty($media['url'])) { ?>
             <enclosure type="<?php echo $this->e($media['type']); ?>" length="<?php echo $this->e($media['size']); ?>" url="<?php echo $this->e($media['url']); ?>"/>

--- a/resources/templates/rss/podcast.phtml
+++ b/resources/templates/rss/podcast.phtml
@@ -35,17 +35,21 @@ echo '<?xml version="1.0" encoding="utf-8"?>', "\n"; ?>
         <title><?php echo $this->e($item->getTitle()); ?></title>
         <link><?php echo $this->e($item->getLink()); ?></link>
         <atom:link href="<?php echo $this->e($item->getRssLink()); ?>" rel="self" type="application/rss+xml"/>
-<?php if ($item->hasImage()) { ?>
         <itunes:image href="<?php echo $this->e($item->getImageUrl()); ?>"/>
-<?php }
-if ($item->hasSummary()) { ?>
         <description><![CDATA[<?php echo nl2br(str_replace(']]>', ']]]]><![CDATA[>', $item->getSummary())); ?>]]></description>
         <itunes:summary><?php echo $this->e($item->getSummary()); ?></itunes:summary>
-<?php } ?>
         <language><?php echo $this->e($item->getLanguage()); ?></language>
         <generator>ampache</generator>
         <podcast:guid><?php echo $this->e($item->getPodcastGuid()); ?></podcast:guid>
+        <itunes:author><?php echo $this->e($item->getAuthor()); ?></itunes:author>
+        <itunes:explicit><?php echo $this->e($item->getExplicit()); ?></itunes:explicit>
+<?php if ($item->getSubCategory() !== '') { ?>
+        <itunes:category text="<?php echo $this->e($item->getCategory()); ?>">
+            <itunes:category text="<?php echo $this->e($item->getSubCategory()); ?>"/>
+        </itunes:category>
+<?php } else { ?>
         <itunes:category text="<?php echo $this->e($item->getCategory()); ?>"/>
+<?php } ?>
 <?php if ($item->hasOwner()) { ?>
         <itunes:owner>
             <itunes:name><?php echo $this->e($item->getOwnerName()); ?></itunes:name>

--- a/src/Config/ConfigurationKeyEnum.php
+++ b/src/Config/ConfigurationKeyEnum.php
@@ -201,6 +201,7 @@ final class ConfigurationKeyEnum
     public const string RESIZE_IMAGES                         = 'resize_images';
     public const string RSS_BEAUTIFUL_URL                     = 'rss_beautiful_url';
     public const string RSS_EXPLICIT                          = 'rss_explicit';
+    public const string RSS_NOINDEX                           = 'rss_noindex';
     public const string RSS_SUBCATEGORY                       = 'rss_subcategory';
     public const string SECRET_KEY                            = 'secret_key';
     public const string SESSION_NAME                          = 'session_name';

--- a/src/Config/ConfigurationKeyEnum.php
+++ b/src/Config/ConfigurationKeyEnum.php
@@ -199,6 +199,7 @@ final class ConfigurationKeyEnum
     public const string REGISTRATION_MANDATORY_FIELDS         = 'registration_mandatory_fields';
     public const string REQUIRE_SESSION                       = 'require_session';
     public const string RESIZE_IMAGES                         = 'resize_images';
+    public const string RSS_BEAUTIFUL_URL                     = 'rss_beautiful_url';
     public const string RSS_EXPLICIT                          = 'rss_explicit';
     public const string RSS_SUBCATEGORY                       = 'rss_subcategory';
     public const string SECRET_KEY                            = 'secret_key';

--- a/src/Config/ConfigurationKeyEnum.php
+++ b/src/Config/ConfigurationKeyEnum.php
@@ -199,6 +199,8 @@ final class ConfigurationKeyEnum
     public const string REGISTRATION_MANDATORY_FIELDS         = 'registration_mandatory_fields';
     public const string REQUIRE_SESSION                       = 'require_session';
     public const string RESIZE_IMAGES                         = 'resize_images';
+    public const string RSS_EXPLICIT                          = 'rss_explicit';
+    public const string RSS_SUBCATEGORY                       = 'rss_subcategory';
     public const string SECRET_KEY                            = 'secret_key';
     public const string SESSION_NAME                          = 'session_name';
     public const string SHARE                                 = 'share';

--- a/src/Config/Init/InitializationHandlerConfig.php
+++ b/src/Config/Init/InitializationHandlerConfig.php
@@ -36,7 +36,7 @@ final readonly class InitializationHandlerConfig implements InitializationHandle
 {
     public const string CONFIG_FILE_PATH = __DIR__ . '/../../../config/ampache.cfg.php';
 
-    private const string CONFIG_VERSION = '95';
+    private const string CONFIG_VERSION = '96'; // AMPACHE_CONFIG_VERSION
 
     private const string STRUCTURE = 'public';
 

--- a/src/Module/Application/Playback/PlayAction.php
+++ b/src/Module/Application/Playback/PlayAction.php
@@ -135,7 +135,8 @@ final readonly class PlayAction implements ApplicationActionInterface
 
             $_REQUEST     = $new_request;
             $action       = $new_request['action'] ?? '';
-            $stream_name  = $new_request['name'] ?? '';
+            // the path segments came straight off the raw query string, so 'name' is still percent-encoded
+            $stream_name  = rawurldecode($new_request['name'] ?? '');
             $object_id    = (int) scrub_in((string) ($new_request['oid'] ?? 0));
             $user_id      = (int) scrub_in((string) ($new_request['uid'] ?? 0));
             $session_id   = (string) scrub_in($new_request['ssid'] ?? '');
@@ -844,7 +845,7 @@ final readonly class PlayAction implements ApplicationActionInterface
         // Format the media name
         $media_name = ($stream_name === '' || $stream_name === '0')
             ? $media->get_stream_name() . "." . $streamConfiguration['file_type']
-            : rawurldecode($stream_name);
+            : $stream_name;
         $transcode_to = ($transcode_cfg == 'never' || $cache_file || ($is_download && !$transcode_to))
             ? null
             : Stream::get_transcode_format($streamConfiguration['file_type'], $transcode_to, $player, $type);

--- a/src/Module/Application/Playback/PlayAction.php
+++ b/src/Module/Application/Playback/PlayAction.php
@@ -844,7 +844,7 @@ final readonly class PlayAction implements ApplicationActionInterface
         // Format the media name
         $media_name = ($stream_name === '' || $stream_name === '0')
             ? $media->get_stream_name() . "." . $streamConfiguration['file_type']
-            : $stream_name;
+            : rawurldecode($stream_name);
         $transcode_to = ($transcode_cfg == 'never' || $cache_file || ($is_download && !$transcode_to))
             ? null
             : Stream::get_transcode_format($streamConfiguration['file_type'], $transcode_to, $player, $type);

--- a/src/Module/Application/Playback/PlayAction.php
+++ b/src/Module/Application/Playback/PlayAction.php
@@ -897,10 +897,16 @@ final readonly class PlayAction implements ApplicationActionInterface
             $end          = 0;
             $range_values = sscanf(Core::get_server('HTTP_RANGE'), "bytes=%d-%d", $start, $end);
             $stream_size  = $file_size;
-            if ($range_values > 0 && ($start > 0 || $end > 0)) {
-                $end = ($range_values >= 2)
-                    ? (int) min($end, $file_size - 1)
-                    : $file_size - 1;
+            if ($range_values > 0) {
+                if ($start < 0) {
+                    // a suffix range asks for the last bytes of the file
+                    $start = max(0, $file_size + $start);
+                    $end   = $file_size - 1;
+                } else {
+                    $end = ($range_values >= 2)
+                        ? (int) min($end, $file_size - 1)
+                        : $file_size - 1;
+                }
 
                 $stream_size = ($end - (int) $start) + 1;
                 if ($stream_size <= 0 || $start > $file_size - 1) {
@@ -1207,9 +1213,13 @@ final readonly class PlayAction implements ApplicationActionInterface
         $end          = 0;
         $range_values = sscanf(Core::get_server('HTTP_RANGE'), "bytes=%d-%d", $start, $end);
 
-        if (!$transcode && $range_values > 0 && ($start > 0 || $end > 0)) {
+        if (!$transcode && $range_values > 0) {
             // Calculate stream size from byte range
-            if ($range_values >= 2) {
+            if ($start < 0) {
+                // a suffix range asks for the last bytes of the file
+                $start = max(0, $streamConfiguration['file_size'] + $start);
+                $end   = $streamConfiguration['file_size'] - 1;
+            } elseif ($range_values >= 2) {
                 $end = (int) min($end, $streamConfiguration['file_size'] - 1);
             } else {
                 $end = $streamConfiguration['file_size'] - 1;
@@ -1326,7 +1336,8 @@ final readonly class PlayAction implements ApplicationActionInterface
         // Warning: Do not change any session variable after this call
         session_write_close();
 
-        $headers = $this->browser->getDownloadHeaders($media_name, $mime, false, (string) $stream_size);
+        // a stream plays in place, only an explicit download is an attachment
+        $headers = $this->browser->getDownloadHeaders($media_name, $mime, !$is_download, (string) $stream_size);
 
         foreach ($headers as $headerName => $value) {
             header(sprintf('%s: %s', $headerName, $value));

--- a/src/Module/Application/Rss/ShowAction.php
+++ b/src/Module/Application/Rss/ShowAction.php
@@ -96,17 +96,35 @@ final readonly class ShowAction implements ApplicationActionInterface
             };
         }
 
+        $body = $handler->createView()->render();
+        $etag = '"' . md5($body) . '"';
+
         $response = $this->responseFactory->createResponse()
-            ->withHeader('X-Robots-Tag', 'noindex')
             ->withHeader(
                 'Content-Type',
                 sprintf(
                     'application/xml; charset=%s',
                     $this->configContainer->get(ConfigurationKeyEnum::SITE_CHARSET)
                 )
-            );
+            )
+            // bots and podcast apps poll feeds hard: let them cache, and answer 304 when nothing moved
+            ->withHeader('ETag', $etag)
+            ->withHeader('Cache-Control', 'public, max-age=' . self::CACHE_SECONDS);
 
-        $response->getBody()->write($handler->createView()->render());
+        if ($this->configContainer->isFeatureEnabled(ConfigurationKeyEnum::RSS_NOINDEX)) {
+            $response = $response->withHeader('X-Robots-Tag', 'noindex');
+        }
+
+        // If-None-Match uses weak comparison, so a W/ prefix still matches
+        $known = array_map(
+            static fn(string $value): string => ltrim(trim($value), 'W/'),
+            explode(',', $request->getHeaderLine('If-None-Match'))
+        );
+        if (in_array($etag, $known, true)) {
+            return $response->withStatus(self::NOT_MODIFIED);
+        }
+
+        $response->getBody()->write($body);
 
         return $response;
     }

--- a/src/Module/Application/Rss/ShowAction.php
+++ b/src/Module/Application/Rss/ShowAction.php
@@ -67,14 +67,15 @@ final readonly class ShowAction implements ApplicationActionInterface
 
         $queryParams = $request->getQueryParams();
 
-        $type     = RssFeedTypeEnum::tryFrom($queryParams['type'] ?? '') ?? RssFeedTypeEnum::NOW_PLAYING;
+        // a beautiful url spells the types with dashes
+        $type     = RssFeedTypeEnum::tryFrom(str_replace('-', '_', (string) ($queryParams['type'] ?? ''))) ?? RssFeedTypeEnum::NOW_PLAYING;
         $rssToken = $queryParams['rsstoken'] ?? '';
 
         $user = $this->userRepository->getByRssToken($rssToken);
 
         if ($type === RssFeedTypeEnum::LIBRARY_ITEM) {
             $item = $this->libraryItemLoader->load(
-                LibraryItemEnum::tryFrom($queryParams['object_type'] ?? '') ?? LibraryItemEnum::SONG,
+                LibraryItemEnum::tryFrom(str_replace('-', '_', (string) ($queryParams['object_type'] ?? ''))) ?? LibraryItemEnum::SONG,
                 (int) ($queryParams['object_id'] ?? 0),
                 [Album::class, AlbumDisk::class, Artist::class, Podcast::class, Song::class]
             );

--- a/src/Module/Art/Art.php
+++ b/src/Module/Art/Art.php
@@ -534,7 +534,9 @@ class Art extends database_object
             }
         }
 
-        return AmpConfig::get_web_path() . '/images/' . $name . '_' . self::_fallback_size($size) . '.png';
+        $suffix = self::_fallback_size($size);
+
+        return AmpConfig::get_web_path() . '/images/' . $name . $suffix . '.png';
     }
 
     /**
@@ -711,6 +713,11 @@ class Art extends database_object
                 // large 174x174
                 $size['height'] = 174;
                 $size['width']  = 174;
+                break;
+            case 700:
+                // podcast/rss cover art: doubled to 1400x1400, the minimum size directories accept
+                $size['height'] = 700;
+                $size['width']  = 700;
                 break;
             case 300:
                 // extralarge, mega 300x300
@@ -955,15 +962,18 @@ class Art extends database_object
             $wanted = max((int) $matches[1], (int) $matches[2]);
         }
 
+        // the full size image, for 'original' and anything bigger than the largest thumbnail
+        if ($size === 'original') {
+            return '';
+        }
+
         foreach (self::FALLBACK_SIZES as $available) {
             if ($wanted <= $available) {
-                return $available . 'x' . $available;
+                return '_' . $available . 'x' . $available;
             }
         }
 
-        $largest = self::FALLBACK_SIZES[count(self::FALLBACK_SIZES) - 1];
-
-        return $largest . 'x' . $largest;
+        return '';
     }
 
     private static function _hasGD(): bool

--- a/src/Module/Util/Rss/RssUrl.php
+++ b/src/Module/Util/Rss/RssUrl.php
@@ -44,6 +44,32 @@ final class RssUrl
     }
 
     /**
+     * The current request's own query params, normalized back to underscores so a feed built from them
+     * identifies the same way whether this request arrived beautiful or not
+     *
+     * @return array<string, string>
+     */
+    public static function currentQueryParams(): array
+    {
+        parse_str((string) ($_SERVER['QUERY_STRING'] ?? ''), $parsed);
+
+        $params = [];
+        foreach ($parsed as $key => $value) {
+            if (is_scalar($value)) {
+                $params[(string) $key] = (string) $value;
+            }
+        }
+
+        foreach (['type', 'object_type'] as $key) {
+            if (isset($params[$key])) {
+                $params[$key] = str_replace('-', '_', $params[$key]);
+            }
+        }
+
+        return $params;
+    }
+
+    /**
      * The url a feed is published under, a path when rss_beautiful_url is on
      *
      * @param array<string, string> $params
@@ -72,32 +98,6 @@ final class RssUrl
         return AmpConfig::get_web_path() . '/rss/' . $path . (($token !== '')
             ? '?rsstoken=' . rawurlencode($token)
             : '');
-    }
-
-    /**
-     * The current request's own query params, normalized back to underscores so a feed built from them
-     * identifies the same way whether this request arrived beautiful or not
-     *
-     * @return array<string, string>
-     */
-    public static function currentQueryParams(): array
-    {
-        parse_str((string) ($_SERVER['QUERY_STRING'] ?? ''), $parsed);
-
-        $params = [];
-        foreach ($parsed as $key => $value) {
-            if (is_scalar($value)) {
-                $params[(string) $key] = (string) $value;
-            }
-        }
-
-        foreach (['type', 'object_type'] as $key) {
-            if (isset($params[$key])) {
-                $params[$key] = str_replace('-', '_', $params[$key]);
-            }
-        }
-
-        return $params;
     }
 
     /**

--- a/src/Module/Util/Rss/RssUrl.php
+++ b/src/Module/Util/Rss/RssUrl.php
@@ -75,6 +75,32 @@ final class RssUrl
     }
 
     /**
+     * The current request's own query params, normalized back to underscores so a feed built from them
+     * identifies the same way whether this request arrived beautiful or not
+     *
+     * @return array<string, string>
+     */
+    public static function currentQueryParams(): array
+    {
+        parse_str((string) ($_SERVER['QUERY_STRING'] ?? ''), $parsed);
+
+        $params = [];
+        foreach ($parsed as $key => $value) {
+            if (is_scalar($value)) {
+                $params[(string) $key] = (string) $value;
+            }
+        }
+
+        foreach (['type', 'object_type'] as $key) {
+            if (isset($params[$key])) {
+                $params[$key] = str_replace('-', '_', $params[$key]);
+            }
+        }
+
+        return $params;
+    }
+
+    /**
      * A readable, ascii only path segment. Purely decorative, feeds resolve without it
      */
     public static function slug(string $text): string

--- a/src/Module/Util/Rss/RssUrl.php
+++ b/src/Module/Util/Rss/RssUrl.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Module\Util\Rss;
+
+use Ampache\Config\AmpConfig;
+
+/**
+ * Feed urls, in the query form every install understands and in the path form
+ * enabled by rss_beautiful_url (see public/rss/.htaccess.dist)
+ */
+final class RssUrl
+{
+    /**
+     * The url a feed is identified by: the query form, whatever shape it is served under
+     *
+     * @param array<string, string> $params
+     */
+    public static function canonical(array $params): string
+    {
+        return AmpConfig::get_web_path() . '/rss.php?' . http_build_query($params);
+    }
+
+    /**
+     * The url a feed is published under, a path when rss_beautiful_url is on
+     *
+     * @param array<string, string> $params
+     */
+    public static function published(array $params, string $title = ''): string
+    {
+        if (!AmpConfig::get('rss_beautiful_url')) {
+            return self::canonical($params);
+        }
+
+        $type  = str_replace('_', '-', (string) ($params['type'] ?? ''));
+        $token = (string) ($params['rsstoken'] ?? '');
+
+        $path = ($type === 'library-item')
+            ? str_replace('_', '-', (string) ($params['object_type'] ?? '')) . '/' . (string) ($params['object_id'] ?? '')
+            : $type;
+        if ($path === '' || str_ends_with($path, '/')) {
+            return self::canonical($params);
+        }
+
+        $slug = self::slug($title);
+        if ($slug !== '' && isset($params['object_id'])) {
+            $path .= '/' . $slug;
+        }
+
+        return AmpConfig::get_web_path() . '/rss/' . $path . (($token !== '')
+            ? '?rsstoken=' . rawurlencode($token)
+            : '');
+    }
+
+    /**
+     * A readable, ascii only path segment. Purely decorative, feeds resolve without it
+     */
+    public static function slug(string $text): string
+    {
+        $slug = (string) iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $text);
+        $slug = strtolower((string) preg_replace('/[^a-zA-Z0-9]+/', '-', $slug));
+
+        return trim($slug, '-');
+    }
+}

--- a/src/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapter.php
+++ b/src/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapter.php
@@ -101,11 +101,12 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
     }
 
     /**
-     * RSS channel language, two-letter code taken from the installation locale
+     * RSS channel language, a lowercase ISO 639 code with an optional region modifier (e.g. "en-us")
+     * https://help.apple.com/itc/podcasts_connect/#/itcb54353390
      */
     public function getLanguage(): string
     {
-        return strtolower(substr((string) AmpConfig::get('lang', 'en_US'), 0, 2));
+        return strtolower(str_replace('_', '-', (string) AmpConfig::get('lang', 'en_US')));
     }
 
     /**
@@ -219,7 +220,7 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
     public function getPodcastGuid(): string
     {
         // the query form identifies a feed whatever url shape it is served under
-        $params = $this->getQueryParams();
+        $params = RssUrl::currentQueryParams();
         unset($params['rsstoken']);
 
         return PodcastGuid::fromFeedUrl(RssUrl::canonical($params));
@@ -230,7 +231,7 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
      */
     public function getRssLink(): string
     {
-        return RssUrl::published($this->getQueryParams(), $this->getTitle());
+        return RssUrl::published(RssUrl::currentQueryParams(), $this->getTitle());
     }
 
     /**
@@ -262,27 +263,11 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
     }
 
     /**
-     * Returns `true` if the item provides an image
-     */
-    public function hasImage(): bool
-    {
-        return $this->playable->has_art();
-    }
-
-    /**
      * Returns `true` if an item-owner is set
      */
     public function hasOwner(): bool
     {
         return ($this->playable->get_user_owner() ?? 0) > 0;
-    }
-
-    /**
-     * Returns `true` if the item provides a summary/description text
-     */
-    public function hasSummary(): bool
-    {
-        return $this->playable->get_description() !== '';
     }
 
     /**
@@ -295,15 +280,5 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
         return ($media->has_art())
             ? (Art::url($media->getId(), $type, null, 700) ?? $this->getImageUrl())
             : $this->getImageUrl();
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function getQueryParams(): array
-    {
-        parse_str((string) ($_SERVER['QUERY_STRING'] ?? ''), $params);
-
-        return array_map('strval', $params);
     }
 }

--- a/src/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapter.php
+++ b/src/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapter.php
@@ -132,7 +132,9 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
      *     url: null|string,
      *     season: null|string,
      *     season_name: null|string,
-     *     episode: null|string
+     *     episode: null|string,
+     *     image: string,
+     *     explicit: string
      * }>
      */
     public function getMedias(): Generator
@@ -165,6 +167,8 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
                     : $media->get_description(),
                 'length' => $media->get_f_time(),
                 'author' => $media->get_parent_fullname(),
+                'image' => $this->getMediaImageUrl($media),
+                'explicit' => $this->getExplicit(),
                 'pubDate' => null,
                 'type' => null,
                 'size' => null,
@@ -274,5 +278,17 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
     public function hasSummary(): bool
     {
         return $this->playable->get_description() !== '';
+    }
+
+    /**
+     * Art of a single episode, its own if it has any, the feed art otherwise
+     */
+    private function getMediaImageUrl(Song|Podcast_Episode $media): string
+    {
+        $type = $media->getMediaType()->value;
+
+        return ($media->has_art())
+            ? (Art::url($media->getId(), $type, null, 700) ?? $this->getImageUrl())
+            : $this->getImageUrl();
     }
 }

--- a/src/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapter.php
+++ b/src/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapter.php
@@ -51,6 +51,20 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
     ) {}
 
     /**
+     * Returns the itunes author of the item
+     */
+    public function getAuthor(): string
+    {
+        $author = ($this->playable instanceof container_item)
+            ? $this->playable->get_parent_fullname()
+            : '';
+
+        return ($author !== '')
+            ? $author
+            : $this->getTitle();
+    }
+
+    /**
      * Returns the itunes category of the item
      * https://www.rssboard.org/rss-validator/docs/error/InvalidItunesCategory.html
      */
@@ -60,19 +74,37 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
     }
 
     /**
-     * Returns the items image-url
+     * itunes:explicit, required by directories. Ampache has no per-item rating so it comes from the config
      */
-    public function getImageUrl(): string
+    public function getExplicit(): string
     {
-        return (string) Art::url($this->playable->getId(), 'album');
+        return (AmpConfig::get('rss_explicit', false))
+            ? 'true'
+            : 'false';
     }
 
     /**
-     * RSS channel language (RFC 5646), from the installation locale
+     * Returns the items image-url; Art falls back to the placeholder when the item has no art
+     */
+    public function getImageUrl(): string
+    {
+        $type = $this->playable->getMediaType()->value;
+
+        // directories require 1400px artwork, so ask for the thumbnail that size unless upscaling is disabled
+        $thumb = (AmpConfig::get('upscale_images', true))
+            ? 700
+            : null;
+
+        return Art::url($this->playable->getId(), $type, null, $thumb)
+            ?? Art::get_fallback_url($type, 'original');
+    }
+
+    /**
+     * RSS channel language, two-letter code taken from the installation locale
      */
     public function getLanguage(): string
     {
-        return str_replace('_', '-', (string) AmpConfig::get('lang', 'en_US'));
+        return strtolower(substr((string) AmpConfig::get('lang', 'en_US'), 0, 2));
     }
 
     /**
@@ -193,11 +225,23 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
     }
 
     /**
+     * Apple sub-category, empty unless the admin picked one (Music Commentary, Music History, Music Interviews)
+     */
+    public function getSubCategory(): string
+    {
+        return (string) AmpConfig::get('rss_subcategory', '');
+    }
+
+    /**
      * Returns the items summary/description text
      */
     public function getSummary(): string
     {
-        return $this->playable->get_description();
+        $summary = $this->playable->get_description();
+
+        return ($summary !== '')
+            ? $summary
+            : sprintf(T_('%1$s on %2$s'), $this->getTitle(), (string) AmpConfig::get('site_title'));
     }
 
     /**

--- a/src/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapter.php
+++ b/src/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapter.php
@@ -29,6 +29,7 @@ use Ampache\Config\AmpConfig;
 use Ampache\Module\Art\Art;
 use Ampache\Module\Util\Rss\EnclosureResolver;
 use Ampache\Module\Util\Rss\PodcastGuid;
+use Ampache\Module\Util\Rss\RssUrl;
 use Ampache\Repository\Model\container_item;
 use Ampache\Repository\Model\library_item;
 use Ampache\Repository\Model\LibraryItemLoaderInterface;
@@ -217,7 +218,11 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
      */
     public function getPodcastGuid(): string
     {
-        return PodcastGuid::fromFeedUrl((string) preg_replace('/&?rsstoken=[^&]*/', '', $this->getRssLink()));
+        // the query form identifies a feed whatever url shape it is served under
+        $params = $this->getQueryParams();
+        unset($params['rsstoken']);
+
+        return PodcastGuid::fromFeedUrl(RssUrl::canonical($params));
     }
 
     /**
@@ -225,7 +230,7 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
      */
     public function getRssLink(): string
     {
-        return AmpConfig::get_web_path() . '/rss.php?' . ($_SERVER['QUERY_STRING'] ?? '');
+        return RssUrl::published($this->getQueryParams(), $this->getTitle());
     }
 
     /**
@@ -290,5 +295,15 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
         return ($media->has_art())
             ? (Art::url($media->getId(), $type, null, 700) ?? $this->getImageUrl())
             : $this->getImageUrl();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getQueryParams(): array
+    {
+        parse_str((string) ($_SERVER['QUERY_STRING'] ?? ''), $params);
+
+        return array_map('strval', $params);
     }
 }

--- a/src/Module/Util/Rss/Surrogate/RssItemInterface.php
+++ b/src/Module/Util/Rss/Surrogate/RssItemInterface.php
@@ -32,7 +32,17 @@ interface RssItemInterface
     /**
      * Returns the itunes category of the item
      */
+    /**
+     * Returns the itunes author of the item
+     */
+    public function getAuthor(): string;
+
     public function getCategory(): string;
+
+    /**
+     * itunes:explicit value ('true' or 'false')
+     */
+    public function getExplicit(): string;
 
     /**
      * Returns the items image-url
@@ -85,6 +95,11 @@ interface RssItemInterface
      * Returns a link to the feed url
      */
     public function getRssLink(): string;
+
+    /**
+     * Apple sub-category, empty when unset
+     */
+    public function getSubCategory(): string;
 
     /**
      * Returns the items summary/description text

--- a/src/Module/Util/Rss/Surrogate/RssItemInterface.php
+++ b/src/Module/Util/Rss/Surrogate/RssItemInterface.php
@@ -30,13 +30,13 @@ use Traversable;
 interface RssItemInterface
 {
     /**
-     * Returns the itunes category of the item
-     */
-    /**
      * Returns the itunes author of the item
      */
     public function getAuthor(): string;
 
+    /**
+     * Returns the itunes category of the item
+     */
     public function getCategory(): string;
 
     /**
@@ -50,7 +50,8 @@ interface RssItemInterface
     public function getImageUrl(): string;
 
     /**
-     * RSS channel language (RFC 5646), from the installation locale
+     * RSS channel language, a lowercase ISO 639 code with an optional region modifier (e.g. "en-us")
+     * https://help.apple.com/itc/podcasts_connect/#/itcb54353390
      */
     public function getLanguage(): string;
 
@@ -112,17 +113,7 @@ interface RssItemInterface
     public function getTitle(): string;
 
     /**
-     * Returns `true` if the item provides an image
-     */
-    public function hasImage(): bool;
-
-    /**
      * Returns `true` if an item-owner is set
      */
     public function hasOwner(): bool;
-
-    /**
-     * Returns `true` if the item provides a summary/description text
-     */
-    public function hasSummary(): bool;
 }

--- a/src/Module/Util/Rss/Type/AbstractGenericRssFeed.php
+++ b/src/Module/Util/Rss/Type/AbstractGenericRssFeed.php
@@ -38,29 +38,20 @@ use Traversable;
  */
 abstract readonly class AbstractGenericRssFeed implements FeedTypeInterface
 {
-    /**
-     * @return array<string, string>
-     */
-    private static function queryParams(): array
-    {
-        parse_str((string) ($_SERVER['QUERY_STRING'] ?? ''), $params);
-
-        return array_map('strval', $params);
-    }
-
     #[Override]
     public function createView(): TemplateInterface
     {
         return new GenericRssFeedView(
             AmpConfig::get('site_title') . ' - ' . $this->getTitle(),
             AmpConfig::get_web_path(),
-            RssUrl::published(self::queryParams()),
+            RssUrl::published(RssUrl::currentQueryParams()),
             ($this->getPubDate()) ? date('r', (int) $this->getPubDate()) : null,
             $this->getImage(),
             $this->getItems(),
             $this->getMedium(),
             $this->getRemoteItems(),
-            strtolower(substr((string) AmpConfig::get('lang', 'en_US'), 0, 2)),
+            // lowercase ISO 639 + region (e.g. "en-us"); see https://help.apple.com/itc/podcasts_connect/#/itcb54353390
+            strtolower(str_replace('_', '-', (string) AmpConfig::get('lang', 'en_US'))),
             (AmpConfig::get('rss_explicit', false)) ? 'true' : 'false'
         );
     }

--- a/src/Module/Util/Rss/Type/AbstractGenericRssFeed.php
+++ b/src/Module/Util/Rss/Type/AbstractGenericRssFeed.php
@@ -49,7 +49,8 @@ abstract readonly class AbstractGenericRssFeed implements FeedTypeInterface
             $this->getItems(),
             $this->getMedium(),
             $this->getRemoteItems(),
-            str_replace('_', '-', (string) AmpConfig::get('lang', 'en_US'))
+            strtolower(substr((string) AmpConfig::get('lang', 'en_US'), 0, 2)),
+            (AmpConfig::get('rss_explicit', false)) ? 'true' : 'false'
         );
     }
 

--- a/src/Module/Util/Rss/Type/AbstractGenericRssFeed.php
+++ b/src/Module/Util/Rss/Type/AbstractGenericRssFeed.php
@@ -27,6 +27,7 @@ namespace Ampache\Module\Util\Rss\Type;
 
 use Ampache\Config\AmpConfig;
 use Ampache\Gui\View\TemplateInterface;
+use Ampache\Module\Util\Rss\RssUrl;
 use Ampache\Module\Util\Rss\View\GenericRssFeedView;
 use Generator;
 use Override;
@@ -37,13 +38,23 @@ use Traversable;
  */
 abstract readonly class AbstractGenericRssFeed implements FeedTypeInterface
 {
+    /**
+     * @return array<string, string>
+     */
+    private static function queryParams(): array
+    {
+        parse_str((string) ($_SERVER['QUERY_STRING'] ?? ''), $params);
+
+        return array_map('strval', $params);
+    }
+
     #[Override]
     public function createView(): TemplateInterface
     {
         return new GenericRssFeedView(
             AmpConfig::get('site_title') . ' - ' . $this->getTitle(),
             AmpConfig::get_web_path(),
-            AmpConfig::get_web_path() . '/rss.php?' . ($_SERVER['QUERY_STRING'] ?? ''),
+            RssUrl::published(self::queryParams()),
             ($this->getPubDate()) ? date('r', (int) $this->getPubDate()) : null,
             $this->getImage(),
             $this->getItems(),

--- a/src/Module/Util/Rss/View/GenericRssFeedView.php
+++ b/src/Module/Util/Rss/View/GenericRssFeedView.php
@@ -65,7 +65,7 @@ final class GenericRssFeedView extends AbstractView
         private readonly Traversable $items,
         private readonly ?string $medium = null,
         private readonly array $remoteItems = [],
-        private readonly string $language = 'en',
+        private readonly string $language = 'en-us',
         private readonly string $explicit = 'false',
     ) {}
 

--- a/src/Module/Util/Rss/View/GenericRssFeedView.php
+++ b/src/Module/Util/Rss/View/GenericRssFeedView.php
@@ -65,8 +65,14 @@ final class GenericRssFeedView extends AbstractView
         private readonly Traversable $items,
         private readonly ?string $medium = null,
         private readonly array $remoteItems = [],
-        private readonly string $language = 'en-US',
+        private readonly string $language = 'en',
+        private readonly string $explicit = 'false',
     ) {}
+
+    public function getExplicit(): string
+    {
+        return $this->explicit;
+    }
 
     public function getImage(): ?string
     {

--- a/src/Module/Util/Ui.php
+++ b/src/Module/Util/Ui.php
@@ -55,6 +55,7 @@ use Ampache\Module\System\Dba;
 use Ampache\Module\System\Plugin\Plugin;
 use Ampache\Module\System\Plugin\PluginTypeEnum;
 use Ampache\Module\System\Preference;
+use Ampache\Module\Util\Rss\RssUrl;
 use Ampache\Module\Util\Rss\Type\RssFeedTypeEnum;
 use Ampache\Plugin\AmpacheLastfm;
 use Ampache\Plugin\Ampachelibrefm;
@@ -476,25 +477,24 @@ class Ui implements UiInterface
         ?User $user = null,
         string $title = '',
         ?array $params = null,
+        string $slug = '',
     ): string {
-        $strparams = "";
-        if (is_array($params)) {
-            foreach ($params as $key => $value) {
-                $strparams .= "&" . scrub_out($key) . "=" . scrub_out($value);
-            }
-        }
-
-        $rsstoken = '';
+        $query = ['type' => $type->value];
         if ($user !== null && AmpConfig::get('use_auth')) {
             // On an open instance (use_auth false) every visitor shares the same default user,
             // so a token adds nothing and would leak into publicly served pages
-            $rsstoken = "&rsstoken=" . $user->getRssToken();
+            $query['rsstoken'] = $user->getRssToken();
+        }
+
+        if (is_array($params)) {
+            foreach ($params as $key => $value) {
+                $query[$key] = $value;
+            }
         }
 
         $string = (
-            '<a class="nohtml" href="' . AmpConfig::get_web_path()
-            . '/rss.php?type=' . $type->value
-            . $rsstoken . $strparams . '" target="_blank">'
+            '<a class="nohtml" href="' . scrub_out(RssUrl::published($query, $slug))
+            . '" target="_blank">'
             . self::get_material_symbol(
                 'rss_feed',
                 T_('RSS Feed')

--- a/src/Module/Util/Ui.php
+++ b/src/Module/Util/Ui.php
@@ -494,7 +494,7 @@ class Ui implements UiInterface
 
         $string = (
             '<a class="nohtml" href="' . scrub_out(RssUrl::published($query, $slug))
-            . '" target="_blank">'
+            . '" target="_blank" rel="nofollow noopener">'
             . self::get_material_symbol(
                 'rss_feed',
                 T_('RSS Feed')

--- a/src/Repository/Model/Podcast_Episode.php
+++ b/src/Repository/Model/Podcast_Episode.php
@@ -538,9 +538,8 @@ class Podcast_Episode extends database_object implements
 
         $media_name = $this->get_stream_name() . "." . $this->type;
         $media_name = preg_replace("/[^a-zA-Z0-9\. ]+/", "-", $media_name);
-        $media_name = (AmpConfig::get('stream_beautiful_url'))
-            ? urlencode((string) $media_name)
-            : rawurlencode((string) $media_name);
+        // rawurlencode: a beautiful url puts the name in a path segment, where a '+' is a literal plus
+        $media_name = rawurlencode((string) $media_name);
 
         $url = Stream::get_base_url($local, $streamToken) . "type=podcast_episode&oid=" . $this->id . "&uid=" . $uid . '&format=raw' . $additional_params;
         if ($player !== '') {

--- a/src/Repository/Model/Song.php
+++ b/src/Repository/Model/Song.php
@@ -2196,9 +2196,8 @@ class Song extends database_object implements
 
         $media_name = $this->get_stream_name() . "." . Stream::get_base_format($this->type);
         $media_name = (string) preg_replace("/[^a-zA-Z0-9\. ]+/", "-", $media_name);
-        $media_name = (AmpConfig::get('stream_beautiful_url'))
-            ? urlencode($media_name)
-            : rawurlencode($media_name);
+        // rawurlencode: a beautiful url puts the name in a path segment, where a '+' is a literal plus
+        $media_name = rawurlencode($media_name);
 
         $url = Stream::get_base_url($local, $streamToken) . "type=song&oid=" . $this->id . "&uid=" . $uid . $additional_params;
         if ($player !== '') {

--- a/src/Repository/Model/Video.php
+++ b/src/Repository/Model/Video.php
@@ -829,9 +829,8 @@ class Video extends database_object implements
 
         $media_name = $this->get_stream_name() . "." . $this->type;
         $media_name = (string) preg_replace("/[^a-zA-Z0-9\. ]+/", "-", $media_name);
-        $media_name = (AmpConfig::get('stream_beautiful_url'))
-            ? urlencode($media_name)
-            : rawurlencode($media_name);
+        // rawurlencode: a beautiful url puts the name in a path segment, where a '+' is a literal plus
+        $media_name = rawurlencode($media_name);
 
         $url = Stream::get_base_url($local, $streamToken) . "type=video&oid=" . $this->id . "&uid=" . $uid . $additional_params;
         if ($player !== '') {

--- a/tests/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapterTest.php
+++ b/tests/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapterTest.php
@@ -94,28 +94,6 @@ class PlayableItemRssItemAdapterTest extends TestCase
         );
     }
 
-    public function testHasImageReturnsFalseIfNotAvailable(): void
-    {
-        $this->playable->expects(static::once())
-            ->method('has_art')
-            ->willReturn(false);
-
-        self::assertFalse(
-            $this->subject->hasImage()
-        );
-    }
-
-    public function testHasImageReturnsTrueIfAvailable(): void
-    {
-        $this->playable->expects(static::once())
-            ->method('has_art')
-            ->willReturn(true);
-
-        self::assertTrue(
-            $this->subject->hasImage()
-        );
-    }
-
     public function testHasOwnerReturnsFalseIfNotAvailable(): void
     {
         $this->playable->expects(static::once())
@@ -135,28 +113,6 @@ class PlayableItemRssItemAdapterTest extends TestCase
 
         self::assertTrue(
             $this->subject->hasOwner()
-        );
-    }
-
-    public function testHasSummaryReturnsFalseIfNotAvailable(): void
-    {
-        $this->playable->expects(static::once())
-            ->method('get_description')
-            ->willReturn('');
-
-        self::assertFalse(
-            $this->subject->hasSummary()
-        );
-    }
-
-    public function testHasSummaryReturnsTrueIfAvailable(): void
-    {
-        $this->playable->expects(static::once())
-            ->method('get_description')
-            ->willReturn('snafu');
-
-        self::assertTrue(
-            $this->subject->hasSummary()
         );
     }
 


### PR DESCRIPTION
Podcast :
- `itunes:image` always emitted, 1400x1400 (`upscale_images` gated), falls back to the placeholder
- Art fallback urls serve the full size image instead of a 128px one
- Cover art uses the item's own type (was hardcoded to `album`)
- `description` / `itunes:summary` always emitted, generated when the item has none
- `itunes:author` added
- `itunes:explicit` added, set with `rss_explicit`
- `language` uses the two-letter code (`fr`, not `fr-FR`)
- Optional Apple sub-category, set with `rss_subcategory`

Fix suffix range and attachements for streams 
- `bytes=0-` and `bytes=0-0` answer 206 instead of 200
- Suffix ranges (`bytes=-500`) resolved against the file size
- Streams sent as `inline`, only explicit downloads stay attachments
- Play counts, transcoding and 416 handling unchanged