### PR TITLE
mood: skip the recount when no map was removed, fold case like the db

### DIFF
--- a/src/Repository/Model/Mood.php
+++ b/src/Repository/Model/Mood.php
@@ -311,7 +311,8 @@ class Mood extends database_object implements GarbageCollectibleInterface
 
             $found = false;
             foreach ($editedMoods as $key => $mood_name) {
-                if (strtolower((string) $cmv['name']) === strtolower($mood_name)) {
+                // `name` is a _ci column, fold the same way
+                if (mb_strtolower((string) $cmv['name']) === mb_strtolower($mood_name)) {
                     $found = true;
                     unset($editedMoods[$key]);
                     break;
@@ -456,7 +457,10 @@ class Mood extends database_object implements GarbageCollectibleInterface
         }
 
         $moodRepository = self::getMoodRepository();
-        $moodRepository->removeAllMaps($object_type, $object_id, $user_id);
+        // nothing was mapped, nothing to recount
+        if ($moodRepository->removeAllMaps($object_type, $object_id, $user_id) === 0) {
+            return true;
+        }
 
         $countType = MoodCountTypeEnum::tryFrom($object_type);
         if ($countType instanceof MoodCountTypeEnum) {

--- a/src/Repository/MoodRepository.php
+++ b/src/Repository/MoodRepository.php
@@ -342,22 +342,20 @@ final readonly class MoodRepository implements MoodRepositoryInterface
         );
     }
 
-    public function removeAllMaps(string $objectType, int $objectId, ?int $userId = null): void
+    public function removeAllMaps(string $objectType, int $objectId, ?int $userId = null): int
     {
         // a null user clears the lot, which is what deleting the object wants; an id keeps everybody else's, so a scan cannot drop a hand-set mood
         if ($userId === null) {
-            $this->connection->query(
+            return $this->connection->query(
                 'DELETE FROM `mood_map` WHERE `object_type` = ? AND `object_id` = ?',
                 [$objectType, $objectId]
-            );
-
-            return;
+            )->rowCount();
         }
 
-        $this->connection->query(
+        return $this->connection->query(
             'DELETE FROM `mood_map` WHERE `object_type` = ? AND `object_id` = ? AND `user` = ?',
             [$objectType, $objectId, $userId]
-        );
+        )->rowCount();
     }
 
     public function removeMap(int $moodId, string $objectType, int $objectId, ?int $userId = null): void

--- a/src/Repository/MoodRepositoryInterface.php
+++ b/src/Repository/MoodRepositoryInterface.php
@@ -140,9 +140,9 @@ interface MoodRepositoryInterface
     public function recountType(MoodCountTypeEnum $type): void;
 
     /**
-     * Drops every mood mapped onto an object
+     * Drops every mood mapped onto an object and returns how many went
      */
-    public function removeAllMaps(string $objectType, int $objectId, ?int $userId = null): void;
+    public function removeAllMaps(string $objectType, int $objectId, ?int $userId = null): int;
 
     /**
      * Drops one mood from one object


### PR DESCRIPTION
update_mood_list with an empty list always triggered a full recount of mood_map, so a scan hit it once per song, album and artist even when the object had no mood (25ms each on an empty table, 320ms on 200k maps). removeAllMaps now returns the rows it dropped and the recount only runs when that is non-zero.

mood.name is a _ci column but the name comparison used strtolower, which only folds ASCII, so a file tagged café plus a user typing CAFÉ got a second map. mb_strtolower matches the collation.