### PR TITLE
Art: don't read file if you don't need to

### DIFF
--- a/src/Module/Art/Art.php
+++ b/src/Module/Art/Art.php
@@ -1481,8 +1481,16 @@ class Art extends database_object
      */
     public function has_db_meta(): bool
     {
-        $row = self::getImageRepository()->getOriginalRow($this->object_type, $this->object_id, $this->kind);
-        if ($row === []) {
+        $index = 'art_meta_' . $this->object_type . '_' . $this->kind;
+        if (database_object::is_cached($index, $this->object_id)) {
+            $row = database_object::get_from_cache($index, $this->object_id);
+        } else {
+            $row = self::getImageRepository()->getOriginalRow($this->object_type, $this->object_id, $this->kind);
+            // [0] marks "no art": add_to_cache() drops empty arrays, so a miss would re-query every time
+            database_object::add_to_cache($index, $this->object_id, ($row === []) ? [0] : $row);
+        }
+
+        if ($row === [] || $row === [0]) {
             return false;
         }
 

--- a/src/Module/Art/Art.php
+++ b/src/Module/Art/Art.php
@@ -233,7 +233,7 @@ class Art extends database_object
         }
 
         $art    = new Art($object_id, $object_type, $kind);
-        $has_db = $art->has_db_info();
+        $has_db = $art->has_db_meta();
         // Don't show any image if not available
         if (!$show_default && !$has_db) {
             return false;
@@ -303,8 +303,9 @@ class Art extends database_object
             }
 
             // This to keep browser cache feature but force a refresh in case image just changed
-            if ($art->has_db_info($out_size)) {
-                $imgurl .= '&id=' . $art->id;
+            $thumbRow = self::getImageRepository()->findThumbnail($object_type, $object_id, $out_size, $kind, 0, 0);
+            if ($thumbRow !== []) {
+                $imgurl .= '&id=' . (int) $thumbRow['id'];
             }
         } else {
             // one shared url for every item with no art, so the browser fetches and caches the placeholder once
@@ -1479,6 +1480,24 @@ class Art extends database_object
         }
 
         return false;
+    }
+
+    /**
+     * Fills id/width/height from the database without reading the file off disk.
+     */
+    public function has_db_meta(): bool
+    {
+        $row = self::getImageRepository()->getOriginalRow($this->object_type, $this->object_id, $this->kind);
+        if ($row === []) {
+            return false;
+        }
+
+        $this->id       = (int) $row['id'];
+        $this->width    = (int) $row['width'];
+        $this->height   = (int) $row['height'];
+        $this->raw_mime = (string) ($row['mime'] ?? '');
+
+        return true;
     }
 
     /**

--- a/src/Module/Art/Art.php
+++ b/src/Module/Art/Art.php
@@ -1009,17 +1009,11 @@ class Art extends database_object
             return null;
         }
 
-        $image    = '';
-        $filepath = fopen($path, "rb");
-        if ($filepath) {
-            do {
-                $image .= fread($filepath, 2048);
-            } while (!feof($filepath));
+        $image = file_get_contents($path);
 
-            fclose($filepath);
-        }
-
-        return $image;
+        return ($image === false)
+            ? null
+            : $image;
     }
 
     /**
@@ -1848,17 +1842,11 @@ class Art extends database_object
             return '';
         }
 
-        $image    = '';
-        $filepath = fopen($path, "rb");
-        if ($filepath) {
-            do {
-                $image .= fread($filepath, 2048);
-            } while (!feof($filepath));
+        $image = file_get_contents($path);
 
-            fclose($filepath);
-        }
-
-        return $image;
+        return ($image === false)
+            ? ''
+            : $image;
     }
 
     /**


### PR DESCRIPTION
https://play.dogmazic.net/server/ajax.server.php?page=index&action=random_albums was slow

has_db_info read file even if it don't need it.

Before this patch, sometimes fast, sometimes slow:
```
$ for i in $(seq 20); do   curl -so /dev/null -w "%{time_total}\n" "https://play.dogmazic.net/server/ajax.server.php?page=index&action=random_albums"; done | sort -n | awk '{a[NR]=$1} END{print "min",a[1],"med",a[int(NR/2)],"max",a[NR]}'
min 0.150701 med 0.227246 max 1.415745
$ for i in $(seq 20); do   curl -so /dev/null -w "%{time_total}\n" "https://play.dogmazic.net/server/ajax.server.php?page=index&action=random_albums"; done | sort -n | awk '{a[NR]=$1} END{print "min",a[1],"med",a[int(NR/2)],"max",a[NR]}'
min 0.144027 med 0.191481 max 0.529760
$ for i in $(seq 20); do   curl -so /dev/null -w "%{time_total}\n" "https://play.dogmazic.net/server/ajax.server.php?page=index&action=random_albums"; done | sort -n | awk '{a[NR]=$1} END{print "min",a[1],"med",a[int(NR/2)],"max",a[NR]}'
min 0.131845 med 0.235472 max 0.668494
```


After, always fast: 
```
$ for i in $(seq 20); do   curl -so /dev/null -w "%{time_total}\n" "https://play.dogmazic.net/server/ajax.server.php?page=index&action=random_albums"; done | sort -n | awk '{a[NR]=$1} END{print "min",a[1],"med",a[int(NR/2)],"max",a[NR]}'
min 0.129378 med 0.140646 max 0.221572
$ for i in $(seq 20); do   curl -so /dev/null -w "%{time_total}\n" "https://play.dogmazic.net/server/ajax.server.php?page=index&action=random_albums"; done | sort -n | awk '{a[NR]=$1} END{print "min",a[1],"med",a[int(NR/2)],"max",a[NR]}'
min 0.122797 med 0.138099 max 0.167029
$ for i in $(seq 20); do   curl -so /dev/null -w "%{time_total}\n" "https://play.dogmazic.net/server/ajax.server.php?page=index&action=random_albums"; done | sort -n | awk '{a[NR]=$1} END{print "min",a[1],"med",a[int(NR/2)],"max",a[NR]}'
min 0.102935 med 0.121475 max 0.142592
```

Cold cache file reading was the issue.