### PR TITLE
Replace fopen/fread/fwrite loops that read or write an entire file at once

### DIFF
--- a/src/Module/Art/Art.php
+++ b/src/Module/Art/Art.php
@@ -663,15 +663,12 @@ class Art extends database_object
 
         // Check to see if it's a FILE
         if (isset($data['file'])) {
-            $handle = fopen($data['file'], 'rb');
-            $size   = Core::get_filesize($data['file']);
-            if (
-                $handle
-                && $size > 0
-            ) {
-                $image_data = (string) fread($handle, $size);
-                fclose($handle);
-
+            $image_data = (Core::is_readable($data['file']))
+                ? file_get_contents($data['file'])
+                : false;
+            if ($image_data === false || $image_data === '') {
+                debug_event(self::class, 'Cannot read art file ' . $data['file'], 2);
+            } else {
                 return $image_data;
             }
         }
@@ -1077,7 +1074,7 @@ class Art extends database_object
             return false;
         }
 
-        if (!Core::is_readable($path)) {
+        if (!is_dir($path)) {
             debug_event(self::class, 'Local image art directory ' . $path . ' does not exist.', 1);
 
             return false;
@@ -1099,10 +1096,11 @@ class Art extends database_object
             unlink($path);
         }
 
-        $filepath = fopen($path, "wb");
-        if ($filepath) {
-            fwrite($filepath, $source);
-            fclose($filepath);
+        // insert() drops the blob from the database when this returns true, so a failed write must say so
+        if (file_put_contents($path, $source) === false) {
+            debug_event(self::class, 'Local image art ' . $path . ' cannot be written.', 1);
+
+            return false;
         }
 
         return true;

--- a/src/Module/System/InstallationHelper.php
+++ b/src/Module/System/InstallationHelper.php
@@ -65,7 +65,7 @@ final readonly class InstallationHelper implements InstallationHelperInterface
     {
         // Start building the new config file
         $distfile = __DIR__ . '/../../../config/ampache.cfg.php.dist';
-        $dist = (Core::is_readable($distfile))
+        $dist     = (Core::is_readable($distfile))
             ? file_get_contents($distfile)
             : false;
         if ($dist === false || $dist === '') {

--- a/src/Module/System/InstallationHelper.php
+++ b/src/Module/System/InstallationHelper.php
@@ -65,16 +65,14 @@ final readonly class InstallationHelper implements InstallationHelperInterface
     {
         // Start building the new config file
         $distfile = __DIR__ . '/../../../config/ampache.cfg.php.dist';
-        $handle   = fopen($distfile, 'r');
-        $length   = Core::get_filesize($distfile);
-        if (!$handle || $length <= 0) {
+        $dist = (Core::is_readable($distfile))
+            ? file_get_contents($distfile)
+            : false;
+        if ($dist === false || $dist === '') {
             return '';
         }
 
-        $dist = fread($handle, $length);
-        fclose($handle);
-
-        $data  = explode("\n", (string) $dist);
+        $data  = explode("\n", $dist);
         $final = "";
         foreach ($data as $line) {
             if (
@@ -592,17 +590,11 @@ final readonly class InstallationHelper implements InstallationHelperInterface
         }
 
         if ($create_tables) {
-            $sql_file   = __DIR__ . '/../../../resources/sql/ampache.sql';
-            $sql_handle = fopen($sql_file, 'r');
-            $length     = Core::get_filesize($sql_file);
-            if (!$sql_handle || $length <= 0) {
-                AmpError::add('general', T_('Unable to open ampache.sql'));
-
-                return false;
-            }
-
-            $query = fread($sql_handle, $length);
-            if (!$query) {
+            $sql_file = __DIR__ . '/../../../resources/sql/ampache.sql';
+            $query    = (Core::is_readable($sql_file))
+                ? file_get_contents($sql_file)
+                : false;
+            if ($query === false || $query === '') {
                 AmpError::add('general', T_('Unable to open ampache.sql'));
 
                 return false;
@@ -696,21 +688,12 @@ final readonly class InstallationHelper implements InstallationHelperInterface
 
         $new_data = $this->generate_config(parse_ini_file($current_file_path) ?: []);
 
-        // Start writing into the current config file
-        $handle = fopen($current_file_path, 'w+');
-        $length = strlen($new_data);
-        if (
-            $new_data === '' || $new_data === '0'
-            || !$handle
-            || $length <= 0
-        ) {
+        if ($new_data === '' || $new_data === '0') {
             return false;
         }
 
-        fwrite($handle, $new_data, $length);
-        fclose($handle);
-
-        return true;
+        // Start writing into the current config file
+        return file_put_contents($current_file_path, $new_data) !== false;
     }
 
     /**


### PR DESCRIPTION
- Art::_write_to_dir() checked the target directory with is_readable(); use is_dir(), which is what the log message already claimed.
- Art::_write_to_dir() returned true even when the write failed. insert() reads that return value to null the image column, so a failed disk write could drop the blob from both disk and database. It now returns false and logs.
- InstallationHelper::write_config() returned true unconditionally; it now returns the write result.
- Log unreadable art files instead of falling through silently.

Streaming reads (playback, WebDAV, uploads, WAV headers, 32-bit filesize fallback) are left alone.