### PR TITLE
Stats

### DIFF
--- a/src/Module/Application/Stats/HighestAlbumAction.php
+++ b/src/Module/Application/Stats/HighestAlbumAction.php
@@ -50,7 +50,6 @@ final readonly class HighestAlbumAction implements ApplicationActionInterface
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createHighest($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/HighestAlbumArtistAction.php
+++ b/src/Module/Application/Stats/HighestAlbumArtistAction.php
@@ -50,7 +50,6 @@ final readonly class HighestAlbumArtistAction implements ApplicationActionInterf
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createHighest($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/HighestAlbumDiskAction.php
+++ b/src/Module/Application/Stats/HighestAlbumDiskAction.php
@@ -50,7 +50,6 @@ final readonly class HighestAlbumDiskAction implements ApplicationActionInterfac
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createHighest($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/HighestArtistAction.php
+++ b/src/Module/Application/Stats/HighestArtistAction.php
@@ -50,7 +50,6 @@ final readonly class HighestArtistAction implements ApplicationActionInterface
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createHighest($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/HighestPlaylistAction.php
+++ b/src/Module/Application/Stats/HighestPlaylistAction.php
@@ -50,7 +50,6 @@ final readonly class HighestPlaylistAction implements ApplicationActionInterface
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createHighest($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/HighestPodcastEpisodeAction.php
+++ b/src/Module/Application/Stats/HighestPodcastEpisodeAction.php
@@ -53,7 +53,6 @@ final readonly class HighestPodcastEpisodeAction implements ApplicationActionInt
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createHighest($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/HighestSongAction.php
+++ b/src/Module/Application/Stats/HighestSongAction.php
@@ -50,7 +50,6 @@ final readonly class HighestSongAction implements ApplicationActionInterface
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createHighest($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/HighestVideoAction.php
+++ b/src/Module/Application/Stats/HighestVideoAction.php
@@ -55,7 +55,6 @@ final readonly class HighestVideoAction implements ApplicationActionInterface
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createHighest($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/PopularAlbumAction.php
+++ b/src/Module/Application/Stats/PopularAlbumAction.php
@@ -62,7 +62,7 @@ final readonly class PopularAlbumAction implements ApplicationActionInterface
         // Temporary workaround to avoid sorting on custom base requests
         define('NO_BROWSE_SORTING', true);
 
-        $objects = Stats::get_top('album', -1, $thresh_value, 0, $gatekeeper->getUser(), false, 0, 0, $by_user);
+        $objects = Stats::get_top('album', -1, $thresh_value, 0, ($by_user) ? $gatekeeper->getUser() : null, false, 0, 0, $by_user);
         $browse  = $this->browseFactory->create();
         $browse->set_use_filters(false);
         $browse->set_type('album');

--- a/src/Module/Application/Stats/PopularAlbumAction.php
+++ b/src/Module/Application/Stats/PopularAlbumAction.php
@@ -55,7 +55,6 @@ final readonly class PopularAlbumAction implements ApplicationActionInterface
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createPopular($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/PopularAlbumArtistAction.php
+++ b/src/Module/Application/Stats/PopularAlbumArtistAction.php
@@ -62,7 +62,7 @@ final readonly class PopularAlbumArtistAction implements ApplicationActionInterf
         // Temporary workaround to avoid sorting on custom base requests
         define('NO_BROWSE_SORTING', true);
 
-        $objects = Stats::get_top('album_artist', -1, $thresh_value, 0, $gatekeeper->getUser(), false, 0, 0, $by_user);
+        $objects = Stats::get_top('album_artist', -1, $thresh_value, 0, ($by_user) ? $gatekeeper->getUser() : null, false, 0, 0, $by_user);
         $browse  = $this->browseFactory->create();
         $browse->set_use_filters(false);
         $browse->set_type('album_artist');

--- a/src/Module/Application/Stats/PopularAlbumArtistAction.php
+++ b/src/Module/Application/Stats/PopularAlbumArtistAction.php
@@ -55,7 +55,6 @@ final readonly class PopularAlbumArtistAction implements ApplicationActionInterf
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createPopular($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/PopularAlbumDiskAction.php
+++ b/src/Module/Application/Stats/PopularAlbumDiskAction.php
@@ -62,7 +62,7 @@ final readonly class PopularAlbumDiskAction implements ApplicationActionInterfac
         // Temporary workaround to avoid sorting on custom base requests
         define('NO_BROWSE_SORTING', true);
 
-        $objects = Stats::get_top('album_disk', -1, $thresh_value, 0, $gatekeeper->getUser(), false, 0, 0, $by_user);
+        $objects = Stats::get_top('album_disk', -1, $thresh_value, 0, ($by_user) ? $gatekeeper->getUser() : null, false, 0, 0, $by_user);
         $browse  = $this->browseFactory->create();
         $browse->set_use_filters(false);
         $browse->set_type('album_disk');

--- a/src/Module/Application/Stats/PopularAlbumDiskAction.php
+++ b/src/Module/Application/Stats/PopularAlbumDiskAction.php
@@ -55,7 +55,6 @@ final readonly class PopularAlbumDiskAction implements ApplicationActionInterfac
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createPopular($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/PopularArtistAction.php
+++ b/src/Module/Application/Stats/PopularArtistAction.php
@@ -55,7 +55,6 @@ final readonly class PopularArtistAction implements ApplicationActionInterface
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createPopular($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/PopularArtistAction.php
+++ b/src/Module/Application/Stats/PopularArtistAction.php
@@ -62,7 +62,7 @@ final readonly class PopularArtistAction implements ApplicationActionInterface
         // Temporary workaround to avoid sorting on custom base requests
         define('NO_BROWSE_SORTING', true);
 
-        $objects = Stats::get_top('artist', -1, $thresh_value, 0, $gatekeeper->getUser(), false, 0, 0, $by_user);
+        $objects = Stats::get_top('artist', -1, $thresh_value, 0, ($by_user) ? $gatekeeper->getUser() : null, false, 0, 0, $by_user);
         $browse  = $this->browseFactory->create();
         $browse->set_use_filters(false);
         $browse->set_type('artist');

--- a/src/Module/Application/Stats/PopularPlaylistAction.php
+++ b/src/Module/Application/Stats/PopularPlaylistAction.php
@@ -62,7 +62,7 @@ final readonly class PopularPlaylistAction implements ApplicationActionInterface
         // Temporary workaround to avoid sorting on custom base requests
         define('NO_BROWSE_SORTING', true);
 
-        $objects = Stats::get_top('playlist', -1, $thresh_value, 0, $gatekeeper->getUser(), false, 0, 0, $by_user);
+        $objects = Stats::get_top('playlist', -1, $thresh_value, 0, ($by_user) ? $gatekeeper->getUser() : null, false, 0, 0, $by_user);
         $browse  = $this->browseFactory->create();
         $browse->set_use_filters(false);
         $browse->set_type('playlist');

--- a/src/Module/Application/Stats/PopularPlaylistAction.php
+++ b/src/Module/Application/Stats/PopularPlaylistAction.php
@@ -55,7 +55,6 @@ final readonly class PopularPlaylistAction implements ApplicationActionInterface
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createPopular($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/PopularPodcastEpisodeAction.php
+++ b/src/Module/Application/Stats/PopularPodcastEpisodeAction.php
@@ -62,7 +62,7 @@ final readonly class PopularPodcastEpisodeAction implements ApplicationActionInt
         // Temporary workaround to avoid sorting on custom base requests
         define('NO_BROWSE_SORTING', true);
 
-        $objects = Stats::get_top('podcast_episode', -1, $thresh_value, 0, $gatekeeper->getUser(), false, 0, 0, $by_user);
+        $objects = Stats::get_top('podcast_episode', -1, $thresh_value, 0, ($by_user) ? $gatekeeper->getUser() : null, false, 0, 0, $by_user);
         $browse  = $this->browseFactory->create();
         $browse->set_use_filters(false);
         $browse->set_type('podcast_episode');

--- a/src/Module/Application/Stats/PopularPodcastEpisodeAction.php
+++ b/src/Module/Application/Stats/PopularPodcastEpisodeAction.php
@@ -55,7 +55,6 @@ final readonly class PopularPodcastEpisodeAction implements ApplicationActionInt
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createPopular($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/PopularSongAction.php
+++ b/src/Module/Application/Stats/PopularSongAction.php
@@ -62,7 +62,7 @@ final readonly class PopularSongAction implements ApplicationActionInterface
         // Temporary workaround to avoid sorting on custom base requests
         define('NO_BROWSE_SORTING', true);
 
-        $objects = Stats::get_top('song', -1, $thresh_value, 0, $gatekeeper->getUser(), false, 0, 0, $by_user);
+        $objects = Stats::get_top('song', -1, $thresh_value, 0, ($by_user) ? $gatekeeper->getUser() : null, false, 0, 0, $by_user);
         $browse  = $this->browseFactory->create();
         $browse->set_use_filters(false);
         $browse->set_type('song');

--- a/src/Module/Application/Stats/PopularSongAction.php
+++ b/src/Module/Application/Stats/PopularSongAction.php
@@ -55,7 +55,6 @@ final readonly class PopularSongAction implements ApplicationActionInterface
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createPopular($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/PopularVideoAction.php
+++ b/src/Module/Application/Stats/PopularVideoAction.php
@@ -57,7 +57,6 @@ final readonly class PopularVideoAction implements ApplicationActionInterface
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createPopular($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/PopularVideoAction.php
+++ b/src/Module/Application/Stats/PopularVideoAction.php
@@ -68,7 +68,7 @@ final readonly class PopularVideoAction implements ApplicationActionInterface
             $this->configContainer->isFeatureEnabled(ConfigurationKeyEnum::ALLOW_VIDEO)
             && $this->videoRepository->getItemCount()
         ) {
-            $objects = Stats::get_top('video', -1, $thresh_value, 0, $gatekeeper->getUser(), false, 0, 0, $by_user);
+            $objects = Stats::get_top('video', -1, $thresh_value, 0, ($by_user) ? $gatekeeper->getUser() : null, false, 0, 0, $by_user);
             $browse  = $this->browseFactory->create();
             $browse->set_threshold((string) $thresh_value);
             $browse->set_type('video');

--- a/src/Module/Application/Stats/UserflagAlbumAction.php
+++ b/src/Module/Application/Stats/UserflagAlbumAction.php
@@ -55,7 +55,6 @@ final readonly class UserflagAlbumAction implements ApplicationActionInterface
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createUserflag($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/UserflagAlbumArtistAction.php
+++ b/src/Module/Application/Stats/UserflagAlbumArtistAction.php
@@ -55,7 +55,6 @@ final readonly class UserflagAlbumArtistAction implements ApplicationActionInter
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createUserflag($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/UserflagAlbumDiskAction.php
+++ b/src/Module/Application/Stats/UserflagAlbumDiskAction.php
@@ -55,7 +55,6 @@ final readonly class UserflagAlbumDiskAction implements ApplicationActionInterfa
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createUserflag($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/UserflagArtistAction.php
+++ b/src/Module/Application/Stats/UserflagArtistAction.php
@@ -55,7 +55,6 @@ final readonly class UserflagArtistAction implements ApplicationActionInterface
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createUserflag($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/UserflagPlaylistAction.php
+++ b/src/Module/Application/Stats/UserflagPlaylistAction.php
@@ -55,7 +55,6 @@ final readonly class UserflagPlaylistAction implements ApplicationActionInterfac
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createUserflag($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/UserflagPodcastEpisodeAction.php
+++ b/src/Module/Application/Stats/UserflagPodcastEpisodeAction.php
@@ -55,7 +55,6 @@ final readonly class UserflagPodcastEpisodeAction implements ApplicationActionIn
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createUserflag($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/UserflagSongAction.php
+++ b/src/Module/Application/Stats/UserflagSongAction.php
@@ -55,7 +55,6 @@ final readonly class UserflagSongAction implements ApplicationActionInterface
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createUserflag($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Module/Application/Stats/UserflagVideoAction.php
+++ b/src/Module/Application/Stats/UserflagVideoAction.php
@@ -57,7 +57,6 @@ final readonly class UserflagVideoAction implements ApplicationActionInterface
 
         $this->ui->showHeader();
         echo $this->statsFormViewFactory->createUserflag($by_user)->render();
-        $this->ui->showHeader();
 
         define('TABLE_RENDERED', 1);
 

--- a/src/Repository/Model/Album.php
+++ b/src/Repository/Model/Album.php
@@ -208,6 +208,8 @@ class Album extends database_object implements
         }
 
         // warm grouped caches the row render would otherwise hit per album
+        // (an album_disk row asks for its parent album's genres, so this covers both)
+        Tag::build_object_tag_cache('album', array_map(intval(...), $ids));
         Art::build_cache($ids, 'album');
         if ($artist_ids !== []) {
             Artist::build_cache(array_values($artist_ids));

--- a/src/Repository/Model/Album.php
+++ b/src/Repository/Model/Album.php
@@ -197,6 +197,16 @@ class Album extends database_object implements
             }
         }
 
+        // one album_map read for the page instead of one per album; the mapped
+        // artists join the primary ones so the row render finds them cached too
+        global $dic;
+        foreach ($dic->get(SongRepositoryInterface::class)->getParentIdsBulk($ids, true) as $albumId => $parentIds) {
+            parent::add_to_cache('album_artists', $albumId, $parentIds);
+            foreach ($parentIds as $parentId) {
+                $artist_ids[$parentId] = $parentId;
+            }
+        }
+
         // warm grouped caches the row render would otherwise hit per album
         Art::build_cache($ids, 'album');
         if ($artist_ids !== []) {
@@ -352,7 +362,9 @@ class Album extends database_object implements
      */
     public static function get_parent_array(int $album_id, ?int $primary_id = null, string $object_type = 'album'): array
     {
-        $results = self::getAlbumRepository()->getMappedObjectIds($album_id, $object_type);
+        $results = ($object_type === 'album' && parent::is_cached('album_artists', $album_id))
+            ? parent::get_from_cache('album_artists', $album_id)
+            : self::getAlbumRepository()->getMappedObjectIds($album_id, $object_type);
         $primary = ((int) $primary_id > 0)
             ? [(int) $primary_id]
             : [];

--- a/src/Repository/Model/Tag.php
+++ b/src/Repository/Model/Tag.php
@@ -140,6 +140,32 @@ class Tag extends database_object implements library_item, displayable_item, con
     }
 
     /**
+     * get_top_tags
+     * This gets the top tags for the specified object using limit
+     *
+     * `user` is the owner of the map: 0 for a genre read out of the file tags, otherwise whoever set it by hand.
+     *
+     * @return array<int, array{id: int, name: string, is_hidden: int, user: int, count: int}>
+     */
+    /**
+     * Warm get_top_tags() for a whole page with one read
+     *
+     * @param list<int> $object_ids
+     */
+    public static function build_object_tag_cache(string $type, array $object_ids): bool
+    {
+        if ($object_ids === [] || !database_object::isCacheEnabled()) {
+            return false;
+        }
+
+        foreach (self::getTagRepository()->getTopTagsBulk($type, $object_ids) as $object_id => $tags) {
+            parent::add_to_cache('object_tags_' . $type, (int) $object_id, $tags);
+        }
+
+        return true;
+    }
+
+    /**
      * clean_to_existing
      * Clean tag list to existing tag list only
      * @param string[]|string $tags
@@ -293,18 +319,18 @@ class Tag extends database_object implements library_item, displayable_item, con
         return $results;
     }
 
-    /**
-     * get_top_tags
-     * This gets the top tags for the specified object using limit
-     *
-     * `user` is the owner of the map: 0 for a genre read out of the file tags, otherwise whoever set it by hand.
-     *
-     * @return array<int, array{id: int, name: string, is_hidden: int, user: int, count: int}>
-     */
     public static function get_top_tags(string $type, int $object_id, ?int $limit = 10): array
     {
         if (!InterfaceImplementationChecker::is_library_item($type)) {
             return [];
+        }
+
+        // build_cache() fills this for a whole page; the limit is applied here
+        $key = 'object_tags_' . $type;
+        if (parent::is_cached($key, $object_id)) {
+            $cached = parent::get_from_cache($key, $object_id);
+
+            return ((int) $limit > 0) ? array_slice($cached, 0, (int) $limit) : $cached;
         }
 
         return self::getTagRepository()->getTopTags($type, $object_id, (int) $limit);

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -378,6 +378,47 @@ final readonly class TagRepository implements TagRepositoryInterface
         return $tags;
     }
 
+    /**
+     * The same rows getTopTags() returns, for a whole page of objects at once.
+     *
+     * @param list<int> $objectIds
+     * @return array<int, list<array{id: int, name: string, is_hidden: int, user: int, count: int}>>
+     */
+    public function getTopTagsBulk(string $objectType, array $objectIds): array
+    {
+        if ($objectIds === []) {
+            return [];
+        }
+
+        $countType = TagCountTypeEnum::tryFrom($objectType);
+        $count     = ($countType instanceof TagCountTypeEnum)
+            ? sprintf('`tag`.`%s`', $countType->value)
+            : '(`tag`.`artist`+`tag`.`album`+`tag`.`song`)';
+        $holders = implode(',', array_fill(0, count($objectIds), '?'));
+
+        $sql = sprintf(
+            'SELECT `tag_map`.`object_id` AS `owner_id`, `tag`.`id`, `tag`.`name`, `tag`.`is_hidden`, MAX(`tag_map`.`user`) AS `user`, %s AS `count` FROM `tag` LEFT JOIN `tag_map` ON `tag_map`.`tag_id`=`tag`.`id` WHERE `tag`.`is_hidden` = false AND `tag_map`.`object_type` = ? AND `tag_map`.`object_id` IN (%s) GROUP BY `tag_map`.`object_id`, `tag`.`id`, `tag`.`name`, `tag`.`is_hidden`, %s ORDER BY `count` DESC, `tag`.`id`',
+            $count,
+            $holders,
+            $count
+        );
+
+        $result = $this->connection->query($sql, array_merge([$objectType], $objectIds));
+
+        $tags = array_fill_keys($objectIds, []);
+        while ($row = $result->fetch(PDO::FETCH_ASSOC)) {
+            $tags[(int) $row['owner_id']][] = [
+                'id' => (int) $row['id'],
+                'name' => (string) $row['name'],
+                'is_hidden' => (int) $row['is_hidden'],
+                'user' => (int) $row['user'],
+                'count' => (int) $row['count'],
+            ];
+        }
+
+        return $tags;
+    }
+
     public function incrementCount(int $tagId, TagCountTypeEnum $type): void
     {
         $this->connection->query(

--- a/src/Repository/TagRepositoryInterface.php
+++ b/src/Repository/TagRepositoryInterface.php
@@ -128,6 +128,8 @@ interface TagRepositoryInterface
      */
     public function getTags(?string $type, int $limit, string $order): array;
 
+    public function getTopTags(string $objectType, int $objectId, int $limit): array;
+
     /**
      * Reads the highest-weighted tags applied to a single object
      *
@@ -135,7 +137,13 @@ interface TagRepositoryInterface
      *
      * @return list<array{id: int, name: string, is_hidden: int, user: int, count: int}>
      */
-    public function getTopTags(string $objectType, int $objectId, int $limit): array;
+    /**
+     * The same rows getTopTags() returns, for a whole page of objects at once.
+     *
+     * @param list<int> $objectIds
+     * @return array<int, list<array{id: int, name: string, is_hidden: int, user: int, count: int}>>
+     */
+    public function getTopTagsBulk(string $objectType, array $objectIds): array;
 
     /**
      * Steps a counter column up


### PR DESCRIPTION
First add some cache. Went from 219 to 122 query.

Then, a more fun patch.

```
Every Popular*Action passed $gatekeeper->getUser() to Stats::get_top().
A non-null $user makes get_top_sql() add `object_count`.`user` = X to the
aggregate, so the charts were always the caller's own plays, and the
by_user flag only appended the same predicate twice.

It also killed the cache: the cache_object_count fast path requires
$user === null, so the aggregate was computed live. For album_disk that
is a three table join through `song` with a temporary table and a
filesort: 685ms of a 746ms page, against 4.7ms from the cache.

Pass the user only when by_user is set, which is what the flag is for.
```

Before:
```bash
$ time curl -s "https://play.dogmazic.net/stats.php?action=popular_album_disk" > /dev/null 
real	0m0,979s
user	0m0,055s
sys		0m0,028s
```

After:
```bash
$ time curl -s "https://play.dogmazic.net/stats.php?action=popular_album_disk" > /dev/null 
real	0m0,295s
user	0m0,042s
sys		0m0,023s
```
