### PR TITLE
Keep the SSE catalog lock name inside MySQL's limit

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,7 @@ Name and Year are recorded but all other dropped columns are not kept. Year will
 * A playlist's total duration only summed its songs, leaving videos and podcast episodes uncounted
 * Uploading new art didn't update the image already on the page: its cache-busting id was looked up per-size, which is empty right after an upload, so the browser kept its cached copy
 * Missing close box on a few template phtml files
+* Catalog actions started from the web interface (scan, clean, gather art) stopped with a connection error on MySQL, which rejects a user-level lock name longer than 64 characters
 
 ## Ampache 8.0.1
 

--- a/src/Module/Api/SseApiApplication.php
+++ b/src/Module/Api/SseApiApplication.php
@@ -133,7 +133,7 @@ final class SseApiApplication implements ApiApplicationInterface
     {
         $catalogPart = ($catalogIds === null) ? 'null' : implode(',', $catalogIds);
 
-        return hash('sha256', $action . '|' . $catalogPart);
+        return $action . '|' . $catalogPart;
     }
 
     /**

--- a/src/Repository/CatalogRepository.php
+++ b/src/Repository/CatalogRepository.php
@@ -312,13 +312,13 @@ final readonly class CatalogRepository implements CatalogRepositoryInterface
     {
         return $this->connection->fetchOne(
             'SELECT IS_USED_LOCK(?)',
-            ['ampache_sse_action_' . $lockKey]
+            [$this->actionLockName($lockKey)]
         ) !== null;
     }
 
     public function releaseActionLock(string $lockKey): void
     {
-        $this->connection->query('SELECT RELEASE_LOCK(?)', ['ampache_sse_action_' . $lockKey]);
+        $this->connection->query('SELECT RELEASE_LOCK(?)', [$this->actionLockName($lockKey)]);
     }
 
     public function releaseProcessingLock(int $catalogId): void
@@ -370,7 +370,7 @@ final readonly class CatalogRepository implements CatalogRepositoryInterface
     {
         return (int) $this->connection->fetchOne(
             'SELECT GET_LOCK(?, 0)',
-            ['ampache_sse_action_' . $lockKey]
+            [$this->actionLockName($lockKey)]
         ) === 1;
     }
 
@@ -404,5 +404,15 @@ final readonly class CatalogRepository implements CatalogRepositoryInterface
             sprintf('UPDATE `%s` SET `path` = ? WHERE `catalog_id` = ?', $type->tableName()),
             [$path, $catalogId]
         );
+    }
+
+    /**
+     * Names the lock for one SSE action call
+     *
+     * MySQL rejects a user-level lock name longer than 64 characters, so the key is hashed instead of pasted in.
+     */
+    private function actionLockName(string $lockKey): string
+    {
+        return 'ampache_sse_action_' . md5($lockKey);
     }
 }

--- a/tests/Repository/CatalogRepositoryTest.php
+++ b/tests/Repository/CatalogRepositoryTest.php
@@ -42,6 +42,23 @@ class CatalogRepositoryTest extends TestCase
     private DatabaseConnectionInterface&MockObject $connection;
     private CatalogRepository $subject;
 
+    public function testActionLockNameStaysWithinTheLimitMysqlEnforces(): void
+    {
+        $lockName = null;
+
+        $this->connection->expects(static::once())
+            ->method('fetchOne')
+            ->willReturnCallback(function (string $sql, array $params) use (&$lockName): string {
+                $lockName = $params[0];
+
+                return '1';
+            });
+
+        $this->subject->tryAcquireActionLock(str_repeat('a', 200));
+
+        static::assertLessThanOrEqual(64, strlen((string) $lockName));
+    }
+
     public function testCreateSubTypeTableRefusesAColumnNoBackendDeclares(): void
     {
         $this->configContainer->method('get')->willReturn('utf8mb4');
@@ -277,7 +294,7 @@ class CatalogRepositoryTest extends TestCase
     {
         $this->connection->expects(static::exactly(2))
             ->method('fetchOne')
-            ->with('SELECT IS_USED_LOCK(?)', ['ampache_sse_action_some-key'])
+            ->with('SELECT IS_USED_LOCK(?)', ['ampache_sse_action_' . md5('some-key')])
             ->willReturn('42', null);
 
         self::assertTrue($this->subject->isActionProcessing('some-key'));
@@ -288,7 +305,7 @@ class CatalogRepositoryTest extends TestCase
     {
         $this->connection->expects(static::once())
             ->method('query')
-            ->with('SELECT RELEASE_LOCK(?)', ['ampache_sse_action_some-key']);
+            ->with('SELECT RELEASE_LOCK(?)', ['ampache_sse_action_' . md5('some-key')]);
 
         $this->subject->releaseActionLock('some-key');
     }
@@ -336,7 +353,7 @@ class CatalogRepositoryTest extends TestCase
     {
         $this->connection->expects(static::exactly(2))
             ->method('fetchOne')
-            ->with('SELECT GET_LOCK(?, 0)', ['ampache_sse_action_some-key'])
+            ->with('SELECT GET_LOCK(?, 0)', ['ampache_sse_action_' . md5('some-key')])
             ->willReturn('1', '0');
 
         self::assertTrue($this->subject->tryAcquireActionLock('some-key'));


### PR DESCRIPTION
Fixes #4476.

The SSE action lock key was a sha256, so the lock name came to 83 characters and MySQL — which caps a user-level lock name at 64 — refused it with error 4163, ending every catalog action started from the web interface. MariaDB allows 192, which is why this only shows on MySQL. The repository now hashes the key it is given, so the name is 51 characters whatever a caller passes; reproduced against mysql:8.4.11 and covered by a test that fails without the change.