### PR TITLE
Answer a status when a download cannot be opened

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,6 +46,7 @@ Name and Year are recorded but all other dropped columns are not kept. Year will
 * A playlist's total duration only summed its songs, leaving videos and podcast episodes uncounted
 * Uploading new art didn't update the image already on the page: its cache-busting id was looked up per-size, which is empty right after an upload, so the browser kept its cached copy
 * Missing close box on a few template phtml files
+* Downloading a file the server could not open answered with an empty file and a success status rather than an error
 
 ## Ampache 8.0.1
 

--- a/src/Module/Application/Playback/PlayAction.php
+++ b/src/Module/Application/Playback/PlayAction.php
@@ -896,6 +896,10 @@ final readonly class PlayAction implements ApplicationActionInterface
                     [LegacyLogger::CONTEXT_TYPE => self::class]
                 );
 
+                if (!headers_sent()) {
+                    header('HTTP/1.1 500 Failed to open file');
+                }
+
                 return null;
             }
 


### PR DESCRIPTION
The streaming branch of `play/index.php` sets `500 Failed to open stream` when it cannot open the file (#4427); the download branch 300 lines above it still returns without a status, so the request answers 200 with an empty body and the client saves an empty file as a success. This adds the same guard there.

Verified against a local instance: the download went from `200` with `Content-Length: 0` to `500 Failed to open file`, and a normal download still returns the whole file.