### PR TITLE
Declare explicit permissions for the CodeQL job

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,10 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      security-events: write
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The CodeQL workflow declares no `permissions:`, so `GITHUB_TOKEN` falls back to the repository default. Where that default is read-only, the SARIF upload is refused and the whole job fails as a configuration error:

```
Uploading code scanning results
CodeQL job status was configuration error.
##[warning]This run of the CodeQL Action does not have permission to access the CodeQL Action API endpoints.
   Details: Resource not accessible by integration
```

The analysis itself runs fine; only the upload is rejected. This doesn't affect ampache/ampache today, but it fails on every fork left at GitHub's recommended read-only default — so contributors get a red CodeQL on each push to their own `develop`.

Declaring the two permissions the job actually uses fixes that and makes it least-privilege rather than inherited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)