### PR TITLE
Random fix + SEO

### DIFF
--- a/docs/CHANGELOG-API.md
+++ b/docs/CHANGELOG-API.md
@@ -25,6 +25,8 @@
   * `playlist`, `playlist_songs`: A private playlist or smartlist you neither own nor collaborate on was readable by anyone who guessed its id
 * API5
   * `ping`: `server_details` returned server-wide catalog counts scoped to user id `0` when the auth token didn't resolve to a real user, instead of being rejected like API8 already was
+* `playlist_add` (API6, API8)
+  * A private playlist or smartlist named as the source object was expanded into the caller's own playlist, leaking its songs; a non-public source you neither own nor collaborate on is now refused
 * `playlist_folder_items` (API8)
   * A private playlist or smartlist filed into a folder leaked its metadata through the folder listing, which gated only on existence; a non-public list you neither own nor collaborate on is now hidden from the output
 

--- a/docs/CHANGELOG-API.md
+++ b/docs/CHANGELOG-API.md
@@ -25,6 +25,8 @@
   * `playlist`, `playlist_songs`: A private playlist or smartlist you neither own nor collaborate on was readable by anyone who guessed its id
 * API5
   * `ping`: `server_details` returned server-wide catalog counts scoped to user id `0` when the auth token didn't resolve to a real user, instead of being rejected like API8 already was
+* `playlist_folder_items` (API8)
+  * A private playlist or smartlist filed into a folder leaked its metadata through the folder listing, which gated only on existence; a non-public list you neither own nor collaborate on is now hidden from the output
 
 ## API 8.0.1
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -88,6 +88,7 @@ Name and Year are recorded but all other dropped columns are not kept. Year will
 * A client could send any play date, so one wrong clock pinned itself to the top of every recently played list until real time caught up. The play row, `last_played` on album disks and the `savePlayQueue` shift are all clamped. Devices whose clock is not exact get one minute of slack. 
 * A username was used raw as an upload folder name, so ../.. escaped the catalog. Path segments are no longer allowed in username
 * Hardened the upload file browser sandbox (prefix containment is anchored on a separator, better check of the ownership)
+* The web "add to playlist" action expanded a source playlist or smartlist checking only that it existed, so a user could copy another user's private list into their own; a non-public source you neither own nor collaborate on is now skipped
 * The web folder browse listed a folder's contents without a catalog-access check and with the per-user catalog filter disabled, so a catalog-filtered user could enumerate folders in a catalog they're excluded from; it now checks catalog access
 * localplay access was never actually checked (any user passed) and Subsonic jukeboxControl checked nothing. Now they are gated on the user's access level
 * Private playlists and searches leaked through several endpoints: web smartlist, Subsonic getPlaylist/getPlaylists

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -88,6 +88,7 @@ Name and Year are recorded but all other dropped columns are not kept. Year will
 * A client could send any play date, so one wrong clock pinned itself to the top of every recently played list until real time caught up. The play row, `last_played` on album disks and the `savePlayQueue` shift are all clamped. Devices whose clock is not exact get one minute of slack. 
 * A username was used raw as an upload folder name, so ../.. escaped the catalog. Path segments are no longer allowed in username
 * Hardened the upload file browser sandbox (prefix containment is anchored on a separator, better check of the ownership)
+* The web folder browse listed a folder's contents without a catalog-access check and with the per-user catalog filter disabled, so a catalog-filtered user could enumerate folders in a catalog they're excluded from; it now checks catalog access
 * localplay access was never actually checked (any user passed) and Subsonic jukeboxControl checked nothing. Now they are gated on the user's access level
 * Private playlists and searches leaked through several endpoints: web smartlist, Subsonic getPlaylist/getPlaylists
 * Deleting a play queue track checked only the row id, so any user could empty another user's queue. Playlist's id is now added to prevent that.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@ Name and Year are recorded but all other dropped columns are not kept. Year will
 * A `branding` section under the server settings gathering the favicon, logos, login artwork and the two new icons in one place, plus a site description for link previews
 * An `Uploaded` column on the upload browses, sortable
 * A browser-measured HTTP compression check on the test page
+* Folder and collection pages describe themselves in a shared link, like the other object pages do
 
 ### Changed (8.1.0)
 
@@ -118,6 +119,10 @@ Name and Year are recorded but all other dropped columns are not kept. Year will
 * `admin/catalog.php?action=clear_stats`, `system.php?action=reset_db_charset`, `action=clear_cache` and `action=clear_now_playing` didn't check the CSRF confirmation token either
 * The `set_rating`/`set_userflag` ajax actions had no CSRF check at all
 * Disabling a user, or changing their password, didn't revoke their `session_remember` cookie, so the old session could keep authenticating with it
+* Link previews described the site instead of the page: the metadata each object page already built was never emitted, so a shared album or artist showed the generic card
+* A share link announced every object as a song, so an album, artist or playlist preview claimed to be one
+* A folder was served no cover at all: the image action asked for a placeholder file that was never shipped
+* A shared link showed no image for an item without a cover while generated art was on: the drawn tile is an svg, which no preview scraper renders
 
 ## Ampache 8.0.1
 

--- a/resources/templates/share/share.phtml
+++ b/resources/templates/share/share.phtml
@@ -35,19 +35,8 @@ use Ampache\Module\Util\Ui;
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title><?php echo $this->e($this->getShareTitle() . ' - ' . $this->getSiteTitle()); ?></title>
-<?php if (!$this->isEmbed()) { ?>
-<meta property="og:type" content="music.song" />
-<meta property="og:title" content="<?php echo $this->e($this->getShareTitle()); ?>" />
-<meta property="og:image" content="<?php echo $this->e($this->getArtUrl()); ?>" />
-<meta property="og:description" content="<?php echo $this->e($this->getSharedByText()); ?>" />
-<meta property="og:url" content="<?php echo $this->e($this->getPublicUrl()); ?>" />
-<meta property="og:site_name" content="<?php echo $this->e($this->getSiteTitle()); ?>" />
-<meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:title" content="<?php echo $this->e($this->getShareTitle()); ?>" />
-<meta name="twitter:description" content="<?php echo $this->e($this->getSharedByText()); ?>" />
-<meta name="twitter:image" content="<?php echo $this->e($this->getArtUrl()); ?>" />
-<?php }
-// Load the player CSS/JS into the head; the player itself is rendered as a fragment below.
+<?php
+// the head's CSS/JS and its branding and link-preview tags; the player itself is a fragment below
 echo $this->raw($this->renderPlayerHeaders()); ?>
 <style>
     body {

--- a/src/Gui/Partial/HeaderView.php
+++ b/src/Gui/Partial/HeaderView.php
@@ -28,6 +28,7 @@ namespace Ampache\Gui\Partial;
 use Ampache\Config\AmpConfig;
 use Ampache\Gui\Sidebar\SidebarViewFactoryInterface;
 use Ampache\Gui\View\AbstractView;
+use Ampache\Module\Database\Query\Search;
 use Ampache\Module\Playlist\PlaylistLoaderInterface;
 use Ampache\Module\System\AutoUpdate;
 use Ampache\Module\System\Plugin\Plugin;
@@ -41,6 +42,7 @@ use Ampache\Module\Util\ZipHandlerInterface;
 use Ampache\Repository\CollectionRepositoryInterface;
 use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\LibraryItemLoaderInterface;
+use Ampache\Repository\Model\Playlist;
 use Ampache\Repository\Model\User;
 use Ampache\Repository\PrivateMessageRepositoryInterface;
 use Override;
@@ -371,6 +373,15 @@ final class HeaderView extends AbstractView
                 }
 
                 $item = $this->libraryItemLoader->load(LibraryItemEnum::from($type), $object_id);
+                // a private list you cannot see must not name itself in the tab title either
+                if (
+                    ($item instanceof Playlist || $item instanceof Search)
+                    && $item->type !== 'public'
+                    && !$item->has_collaborate($this->currentUser)
+                ) {
+                    continue;
+                }
+
                 $name = $item?->get_fullname();
                 if ($name !== null && $name !== '') {
                     return $this->withIcon(self::TYPE_ICONS[$type], $name);

--- a/src/Gui/Partial/HeaderView.php
+++ b/src/Gui/Partial/HeaderView.php
@@ -373,11 +373,10 @@ final class HeaderView extends AbstractView
                 }
 
                 $item = $this->libraryItemLoader->load(LibraryItemEnum::from($type), $object_id);
-                // a private list you cannot see must not name itself in the tab title either
+                // a private list you cannot see must not name itself in the tab title either, only the site
                 if (
                     ($item instanceof Playlist || $item instanceof Search)
-                    && $item->type !== 'public'
-                    && !$item->has_collaborate($this->currentUser)
+                    && !$item->isVisible($this->currentUser)
                 ) {
                     continue;
                 }

--- a/src/Gui/Partial/PageMeta.php
+++ b/src/Gui/Partial/PageMeta.php
@@ -85,7 +85,10 @@ final class PageMeta
         }
 
         if ($meta->image !== '') {
-            $out[] = '<meta property="og:image" content="' . $e($meta->image) . '">';
+            // whoever draws the preview renders no svg, so art is told to hand over a raster
+            $image = (str_contains($meta->image, 'image.php?')) ? $meta->image . '&nosvg=1' : $meta->image;
+
+            $out[] = '<meta property="og:image" content="' . $e($image) . '">';
             $out[] = '<meta name="twitter:card" content="summary">';
         }
 

--- a/src/Gui/Partial/PageMeta.php
+++ b/src/Gui/Partial/PageMeta.php
@@ -25,6 +25,8 @@ declare(strict_types=1);
 
 namespace Ampache\Gui\Partial;
 
+use Ampache\Config\AmpConfig;
+
 /**
  * What the page's <head> says about the object it shows: description, Open Graph and schema.org.
  * An action sets it before the header renders; pages that set nothing emit nothing.
@@ -73,9 +75,11 @@ final class PageMeta
 
         $e   = static fn(string $value): string => htmlspecialchars($value, ENT_QUOTES);
         $out = [];
-        if ($meta->description !== '') {
-            $out[] = '<meta name="description" content="' . $e($meta->description) . '">';
-            $out[] = '<meta property="og:description" content="' . $e($meta->description) . '">';
+        // An object with nothing of its own to say still gets a description, falling back to the site-wide one
+        $description = ($meta->description !== '') ? $meta->description : trim((string) AmpConfig::get('site_description', ''));
+        if ($description !== '') {
+            $out[] = '<meta name="description" content="' . $e($description) . '">';
+            $out[] = '<meta property="og:description" content="' . $e($description) . '">';
         }
 
         $out[] = '<meta property="og:type" content="' . $e($meta->ogType) . '">';
@@ -85,8 +89,11 @@ final class PageMeta
         }
 
         if ($meta->image !== '') {
-            // whoever draws the preview renders no svg, so art is told to hand over a raster
-            $image = (str_contains($meta->image, 'image.php?')) ? $meta->image . '&nosvg=1' : $meta->image;
+            // Both the direct route and its beautified `stream_beautiful_url` rewrite reach the same art
+            // handler, and only that handler can generate an svg placeholder a scraper cannot render.
+            $imagePath   = (string) parse_url($meta->image, PHP_URL_PATH);
+            $servedByArt = str_ends_with($imagePath, '/image.php') || str_contains($imagePath, '/play/art/');
+            $image       = ($servedByArt) ? $meta->image . '&nosvg=1' : $meta->image;
 
             $out[] = '<meta property="og:image" content="' . $e($image) . '">';
             $out[] = '<meta name="twitter:card" content="summary">';

--- a/src/Gui/Share/ShareView.php
+++ b/src/Gui/Share/ShareView.php
@@ -91,6 +91,21 @@ final class ShareView extends AbstractView
         return $this->share->getObjectUrl();
     }
 
+    /**
+     * The Open Graph type of the shared object, so a preview is not announced as a song whatever it holds.
+     */
+    public function getOgType(): string
+    {
+        return match ((string) $this->share->object_type) {
+            'album', 'album_disk' => 'music.album',
+            'artist' => 'profile',
+            'playlist', 'search' => 'music.playlist',
+            'song' => 'music.song',
+            'video' => 'video.other',
+            default => 'website',
+        };
+    }
+
     public function getPublicUrl(): string
     {
         return (string) $this->share->public_url;

--- a/src/Module/Api/Ajax/Handler/DefaultAjaxHandler.php
+++ b/src/Module/Api/Ajax/Handler/DefaultAjaxHandler.php
@@ -95,7 +95,7 @@ final readonly class DefaultAjaxHandler implements AjaxHandlerInterface
                         array_map('intval', explode(',', $request_ids)),
                         static fn(int $object_id): bool => $object_id > 0
                     );
-                    $itemType = LibraryItemEnum::tryFrom($object_type);
+                    $itemType = LibraryItemEnum::fromObjectType($object_type);
                     if ($object_ids !== [] && $itemType instanceof LibraryItemEnum) {
                         $medias = [];
                         foreach ($object_ids as $object_id) {
@@ -104,11 +104,10 @@ final readonly class DefaultAjaxHandler implements AjaxHandlerInterface
                                 continue;
                             }
 
-                            // a private list you cannot see is not yours to expand into a playlist
+                            // a private list you cannot see is not yours to expand into the queue here
                             if (
                                 ($object instanceof Playlist || $object instanceof Search)
-                                && $object->type !== 'public'
-                                && !$object->has_collaborate($user)
+                                && !$object->isVisible($user)
                             ) {
                                 continue;
                             }

--- a/src/Module/Api/Ajax/Handler/DefaultAjaxHandler.php
+++ b/src/Module/Api/Ajax/Handler/DefaultAjaxHandler.php
@@ -27,11 +27,11 @@ namespace Ampache\Module\Api\Ajax\Handler;
 
 use Ampache\Config\AmpConfig;
 use Ampache\Module\Database\Query\BrowseFactoryInterface;
+use Ampache\Module\Database\Query\Search;
 use Ampache\Module\Statistics\Rating;
 use Ampache\Module\Statistics\Userflag;
 use Ampache\Module\System\Core;
 use Ampache\Module\Util\InterfaceImplementationChecker;
-use Ampache\Module\Util\ObjectTypeToClassNameMapper;
 use Ampache\Module\Util\RequestParserInterface;
 use Ampache\Module\Util\UiInterface;
 use Ampache\Repository\AlbumRepositoryInterface;
@@ -39,6 +39,7 @@ use Ampache\Repository\Model\Artist;
 use Ampache\Repository\Model\container_item;
 use Ampache\Repository\Model\Folder;
 use Ampache\Repository\Model\LibraryItemEnum;
+use Ampache\Repository\Model\LibraryItemLoaderInterface;
 use Ampache\Repository\Model\Playlist;
 use Ampache\Repository\Model\Tag;
 use Ampache\Repository\Model\User;
@@ -52,6 +53,7 @@ final readonly class DefaultAjaxHandler implements AjaxHandlerInterface
         private SongRepositoryInterface $songRepository,
         private UiInterface $ui,
         private BrowseFactoryInterface $browseFactory,
+        private LibraryItemLoaderInterface $libraryItemLoader,
     ) {}
 
     public function handle(User $user): void
@@ -93,12 +95,24 @@ final readonly class DefaultAjaxHandler implements AjaxHandlerInterface
                         array_map('intval', explode(',', $request_ids)),
                         static fn(int $object_id): bool => $object_id > 0
                     );
-                    if ($object_ids !== []) {
-                        $className = ObjectTypeToClassNameMapper::map($object_type);
-                        $medias    = [];
+                    $itemType = LibraryItemEnum::tryFrom($object_type);
+                    if ($object_ids !== [] && $itemType instanceof LibraryItemEnum) {
+                        $medias = [];
                         foreach ($object_ids as $object_id) {
-                            /** @var container_item $object */
-                            $object = new $className($object_id);
+                            $object = $this->libraryItemLoader->load($itemType, $object_id);
+                            if (!$object instanceof container_item) {
+                                continue;
+                            }
+
+                            // a private list you cannot see is not yours to expand into a playlist
+                            if (
+                                ($object instanceof Playlist || $object instanceof Search)
+                                && $object->type !== 'public'
+                                && !$object->has_collaborate($user)
+                            ) {
+                                continue;
+                            }
+
                             $medias = array_merge($medias, $object->get_medias());
                         }
 

--- a/src/Module/Api/Ajax/Handler/PlaylistAjaxHandler.php
+++ b/src/Module/Api/Ajax/Handler/PlaylistAjaxHandler.php
@@ -32,9 +32,10 @@ use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Database\Query\BrowseFactoryInterface;
 use Ampache\Module\Database\Query\Search;
 use Ampache\Module\Util\InterfaceImplementationChecker;
-use Ampache\Module\Util\ObjectTypeToClassNameMapper;
 use Ampache\Module\Util\RequestParserInterface;
 use Ampache\Repository\Model\container_item;
+use Ampache\Repository\Model\LibraryItemEnum;
+use Ampache\Repository\Model\LibraryItemLoaderInterface;
 use Ampache\Repository\Model\Playlist;
 use Ampache\Repository\Model\User;
 
@@ -43,6 +44,7 @@ final readonly class PlaylistAjaxHandler implements AjaxHandlerInterface
     public function __construct(
         private RequestParserInterface $requestParser,
         private BrowseFactoryInterface $browseFactory,
+        private LibraryItemLoaderInterface $libraryItemLoader,
     ) {}
 
     public function handle(User $user): void
@@ -106,12 +108,12 @@ final readonly class PlaylistAjaxHandler implements AjaxHandlerInterface
                         break;
                     }
 
-                    $playlist = new Playlist($playlist_id);
+                    $playlist = $this->libraryItemLoader->load(LibraryItemEnum::PLAYLIST, $playlist_id);
                 } else {
-                    $playlist = new Playlist((int) $_REQUEST['playlist_id']);
+                    $playlist = $this->libraryItemLoader->load(LibraryItemEnum::PLAYLIST, (int) $_REQUEST['playlist_id']);
                 }
 
-                if (!$playlist->has_collaborate()) {
+                if (!$playlist instanceof Playlist || !$playlist->has_collaborate()) {
                     break;
                 }
 
@@ -124,11 +126,12 @@ final readonly class PlaylistAjaxHandler implements AjaxHandlerInterface
                 if (!empty($item_type) && InterfaceImplementationChecker::is_library_item($item_type)) {
                     debug_event('playlist.ajax', 'Adding all medias of ' . $item_type . '(s) {' . $item_id . '}...', 5);
                     $item_ids = explode(',', (string) $item_id);
+                    $itemType = LibraryItemEnum::tryFrom($item_type);
                     foreach ($item_ids as $iid) {
-                        $className = ObjectTypeToClassNameMapper::map($item_type);
-                        /** @var container_item $libitem */
-                        $libitem = new $className((int) $iid);
-                        if ($libitem->isNew()) {
+                        $libitem = ($itemType instanceof LibraryItemEnum)
+                            ? $this->libraryItemLoader->load($itemType, (int) $iid)
+                            : null;
+                        if (!$libitem instanceof container_item) {
                             continue;
                         }
                         // a private list you cannot see is not yours to expand into a playlist

--- a/src/Module/Api/Ajax/Handler/PlaylistAjaxHandler.php
+++ b/src/Module/Api/Ajax/Handler/PlaylistAjaxHandler.php
@@ -126,7 +126,7 @@ final readonly class PlaylistAjaxHandler implements AjaxHandlerInterface
                 if (!empty($item_type) && InterfaceImplementationChecker::is_library_item($item_type)) {
                     debug_event('playlist.ajax', 'Adding all medias of ' . $item_type . '(s) {' . $item_id . '}...', 5);
                     $item_ids = explode(',', (string) $item_id);
-                    $itemType = LibraryItemEnum::tryFrom($item_type);
+                    $itemType = LibraryItemEnum::fromObjectType($item_type);
                     foreach ($item_ids as $iid) {
                         $libitem = ($itemType instanceof LibraryItemEnum)
                             ? $this->libraryItemLoader->load($itemType, (int) $iid)
@@ -134,11 +134,10 @@ final readonly class PlaylistAjaxHandler implements AjaxHandlerInterface
                         if (!$libitem instanceof container_item) {
                             continue;
                         }
-                        // a private list you cannot see is not yours to expand into a playlist
+                        // a private list you cannot see is not yours to expand into a playlist you can edit
                         if (
                             ($libitem instanceof Playlist || $libitem instanceof Search)
-                            && $libitem->type !== 'public'
-                            && !$libitem->has_collaborate($user)
+                            && !$libitem->isVisible($user)
                         ) {
                             continue;
                         }

--- a/src/Module/Api/Ajax/Handler/PlaylistAjaxHandler.php
+++ b/src/Module/Api/Ajax/Handler/PlaylistAjaxHandler.php
@@ -30,6 +30,7 @@ use Ampache\Module\Authorization\Access;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Database\Query\BrowseFactoryInterface;
+use Ampache\Module\Database\Query\Search;
 use Ampache\Module\Util\InterfaceImplementationChecker;
 use Ampache\Module\Util\ObjectTypeToClassNameMapper;
 use Ampache\Module\Util\RequestParserInterface;
@@ -127,9 +128,18 @@ final readonly class PlaylistAjaxHandler implements AjaxHandlerInterface
                         $className = ObjectTypeToClassNameMapper::map($item_type);
                         /** @var container_item $libitem */
                         $libitem = new $className((int) $iid);
-                        if ($libitem->isNew() === false) {
-                            $medias = array_merge($medias, $libitem->get_medias());
+                        if ($libitem->isNew()) {
+                            continue;
                         }
+                        // a private list you cannot see is not yours to expand into a playlist
+                        if (
+                            ($libitem instanceof Playlist || $libitem instanceof Search)
+                            && $libitem->type !== 'public'
+                            && !$libitem->has_collaborate($user)
+                        ) {
+                            continue;
+                        }
+                        $medias = array_merge($medias, $libitem->get_medias());
                     }
                 } else {
                     debug_event('playlist.ajax', 'Adding all medias of current playlist...', 5);

--- a/src/Module/Api/Json8_Data.php
+++ b/src/Module/Api/Json8_Data.php
@@ -2478,14 +2478,15 @@ final class Json8_Data
              */
             if ((int) $playlist_id === 0) {
                 $playlist = new Search((int) str_replace('smart_', '', (string) $playlist_id), 'song', $user);
-                if ($playlist->isNew()) {
+                // a private list is only exposed to its owner or a collaborator, whatever route reached it
+                if ($playlist->isNew() || ($playlist->type !== 'public' && !$playlist->has_collaborate($user))) {
                     continue;
                 }
                 $object_type    = 'search';
                 $playitem_total = $playlist->last_count;
             } else {
                 $playlist = new Playlist((int) $playlist_id);
-                if ($playlist->isNew()) {
+                if ($playlist->isNew() || ($playlist->type !== 'public' && !$playlist->has_collaborate($user))) {
                     continue;
                 }
                 $object_type    = 'playlist';

--- a/src/Module/Api/Json8_Data.php
+++ b/src/Module/Api/Json8_Data.php
@@ -2479,14 +2479,14 @@ final class Json8_Data
             if ((int) $playlist_id === 0) {
                 $playlist = new Search((int) str_replace('smart_', '', (string) $playlist_id), 'song', $user);
                 // a private list is only exposed to its owner or a collaborator, whatever route reached it
-                if ($playlist->isNew() || ($playlist->type !== 'public' && !$playlist->has_collaborate($user))) {
+                if ($playlist->isNew() || !$playlist->isVisible($user)) {
                     continue;
                 }
                 $object_type    = 'search';
                 $playitem_total = $playlist->last_count;
             } else {
                 $playlist = new Playlist((int) $playlist_id);
-                if ($playlist->isNew() || ($playlist->type !== 'public' && !$playlist->has_collaborate($user))) {
+                if ($playlist->isNew() || !$playlist->isVisible($user)) {
                     continue;
                 }
                 $object_type    = 'playlist';

--- a/src/Module/Api/Method/AbstractPlaylistAddMethod.php
+++ b/src/Module/Api/Method/AbstractPlaylistAddMethod.php
@@ -33,7 +33,6 @@ use Ampache\Module\Api\Method\Exception\ResultEmptyException;
 use Ampache\Module\Api\Output\ApiOutputInterface;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Database\Query\Search;
-use Ampache\Module\Util\ObjectTypeToClassNameMapper;
 use Ampache\Repository\Model\Album;
 use Ampache\Repository\Model\Artist;
 use Ampache\Repository\Model\ModelFactoryInterface;
@@ -150,11 +149,26 @@ abstract class AbstractPlaylistAddMethod implements MethodInterface
             $objectType = 'search';
         }
 
-        $className = ObjectTypeToClassNameMapper::map($objectType);
-
-        /** @var Album|Artist|Playlist|Search|Song $item */
-        $item = new $className((int) $objectId);
+        $item = match ($objectType) {
+            'album' => $this->modelFactory->createAlbum((int) $objectId),
+            'artist' => $this->modelFactory->createArtist((int) $objectId),
+            'playlist' => $this->modelFactory->createPlaylist((int) $objectId),
+            'search' => $this->modelFactory->createSearch((int) $objectId),
+            default => $this->modelFactory->createSong((int) $objectId),
+        };
         if ($item->isNew()) {
+            throw new ResultEmptyException(
+                (string) $objectId,
+                'id'
+            );
+        }
+
+        // a private list you cannot see is not yours to expand into a playlist
+        if (
+            ($item instanceof Playlist || $item instanceof Search)
+            && $item->type !== 'public'
+            && !$item->has_collaborate($user)
+        ) {
             throw new ResultEmptyException(
                 (string) $objectId,
                 'id'

--- a/src/Module/Api/Method/AbstractPlaylistAddMethod.php
+++ b/src/Module/Api/Method/AbstractPlaylistAddMethod.php
@@ -163,11 +163,10 @@ abstract class AbstractPlaylistAddMethod implements MethodInterface
             );
         }
 
-        // a private list you cannot see is not yours to expand into a playlist
+        // a private list you cannot see is not yours to expand into a playlist, whatever route reached it
         if (
             ($item instanceof Playlist || $item instanceof Search)
-            && $item->type !== 'public'
-            && !$item->has_collaborate($user)
+            && !$item->isVisible($user)
         ) {
             throw new ResultEmptyException(
                 (string) $objectId,

--- a/src/Module/Api/Method/Api5/PlaylistEdit5Method.php
+++ b/src/Module/Api/Method/Api5/PlaylistEdit5Method.php
@@ -32,6 +32,9 @@ use Ampache\Module\Api\Method\Exception\RequestParamMissingException;
 use Ampache\Module\Api\Method\Exception\ResultEmptyException;
 use Ampache\Module\Api\Method\MethodInterface;
 use Ampache\Module\Api\Output\ApiOutputInterface;
+use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\AccessTypeEnum;
+use Ampache\Module\Authorization\Check\PrivilegeCheckerInterface;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\Model\User;
 use Psr\Http\Message\ResponseInterface;
@@ -49,6 +52,7 @@ final class PlaylistEdit5Method implements MethodInterface
 
     public function __construct(
         private ModelFactoryInterface $modelFactory,
+        private PrivilegeCheckerInterface $privilegeChecker,
         private StreamFactoryInterface $streamFactory,
     ) {}
 
@@ -128,6 +132,16 @@ final class PlaylistEdit5Method implements MethodInterface
         if ((int) $owner === 0) {
             $lookup = User::get_from_username((string) $owner);
             $owner  = $lookup->id ?? $playlist->user;
+        }
+
+        // handing a list to somebody else is an admin's call, the way setting a play for them is
+        if (
+            (int) $owner !== (int) $playlist->user
+            && !$this->privilegeChecker->check(AccessTypeEnum::INTERFACE, AccessLevelEnum::ADMIN, $user->getId())
+        ) {
+            throw new AccessFailedException(
+                'Require: 100'
+            );
         }
 
         // update name/type

--- a/src/Module/Api/Method/Api5/PlaylistEdit5Method.php
+++ b/src/Module/Api/Method/Api5/PlaylistEdit5Method.php
@@ -134,7 +134,7 @@ final class PlaylistEdit5Method implements MethodInterface
             $owner  = $lookup->id ?? $playlist->user;
         }
 
-        // handing a list to somebody else is an admin's call, the way setting a play for them is
+        // handing a list's ownership to somebody else is an admin's call, not the current owner's to make
         if (
             (int) $owner !== (int) $playlist->user
             && !$this->privilegeChecker->check(AccessTypeEnum::INTERFACE, AccessLevelEnum::ADMIN, $user->getId())

--- a/src/Module/Api/Method/Api8/CollectionEdit8Method.php
+++ b/src/Module/Api/Method/Api8/CollectionEdit8Method.php
@@ -104,6 +104,17 @@ final class CollectionEdit8Method implements MethodInterface
         $hasAccess  = $collection->has_access($user);
         $changeMade = false;
 
+        // has_collaborate allows reordering, but only an owner or admin may edit the metadata below; refused
+        // up front, before any reorder is applied, so a request either applies whole or not at all
+        if (
+            !$hasAccess
+            && (isset($input['name']) || isset($input['type']) || isset($input['object_type']) || isset($input['collaborate']))
+        ) {
+            throw new AccessFailedException(
+                sprintf('Require: %s', AccessLevelEnum::ADMIN->value)
+            );
+        }
+
         $objectType = (isset($input['object_type'])) ? (string) $input['object_type'] : null;
         if ($objectType !== null && $objectType !== '' && !Collection::isValidType($objectType)) {
             throw new RequestParamMissingException(
@@ -170,7 +181,8 @@ final class CollectionEdit8Method implements MethodInterface
             $collection->regenerate_track_numbers();
         }
 
-        // has_collaborate allows reordering, but only an owner or admin may edit the metadata below
+        // No metadata field reached this point, per the guard above, so a collaborator with no reorder
+        // either has nothing to do or sent a malformed request
         if (!$hasAccess) {
             if ($changeMade) {
                 $response->getBody()->write(

--- a/src/Module/Api/Method/Api8/CollectionEdit8Method.php
+++ b/src/Module/Api/Method/Api8/CollectionEdit8Method.php
@@ -28,10 +28,12 @@ namespace Ampache\Module\Api\Method\Api8;
 use Ampache\Module\Api\Authentication\GatekeeperInterface;
 use Ampache\Module\Api\Exception\ErrorCodeEnum;
 use Ampache\Module\Api\Method\Exception\AccessDeniedException;
+use Ampache\Module\Api\Method\Exception\AccessFailedException;
 use Ampache\Module\Api\Method\Exception\RequestParamMissingException;
 use Ampache\Module\Api\Method\Exception\ResultEmptyException;
 use Ampache\Module\Api\Method\MethodInterface;
 use Ampache\Module\Api\Output\ApiOutputInterface;
+use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Repository\CollectionRepositoryInterface;
 use Ampache\Repository\Model\Collection;
 use Ampache\Repository\Model\User;
@@ -99,6 +101,8 @@ final class CollectionEdit8Method implements MethodInterface
         int $apiVersion,
     ): ResponseInterface {
         $collection = $this->loadEditableCollection($input, $user);
+        $hasAccess  = $collection->has_access($user);
+        $changeMade = false;
 
         $objectType = (isset($input['object_type'])) ? (string) $input['object_type'] : null;
         if ($objectType !== null && $objectType !== '' && !Collection::isValidType($objectType)) {
@@ -160,9 +164,25 @@ final class CollectionEdit8Method implements MethodInterface
                 }
 
                 $collection->set_by_track_number($memberId, $memberType, $track);
+                $changeMade = true;
             }
 
             $collection->regenerate_track_numbers();
+        }
+
+        // has_collaborate allows reordering, but only an owner or admin may edit the metadata below
+        if (!$hasAccess) {
+            if ($changeMade) {
+                $response->getBody()->write(
+                    $output->success($apiVersion, 'collection track changes saved')
+                );
+
+                return $response;
+            }
+
+            throw new AccessFailedException(
+                sprintf('Require: %s', AccessLevelEnum::ADMIN->value)
+            );
         }
 
         $type = (isset($input['type']))

--- a/src/Module/Api/Method/PlaylistEditMethod.php
+++ b/src/Module/Api/Method/PlaylistEditMethod.php
@@ -32,6 +32,8 @@ use Ampache\Module\Api\Method\Exception\RequestParamMissingException;
 use Ampache\Module\Api\Method\Exception\ResultEmptyException;
 use Ampache\Module\Api\Output\ApiOutputInterface;
 use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\AccessTypeEnum;
+use Ampache\Module\Authorization\Check\PrivilegeCheckerInterface;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\Model\User;
 use Psr\Http\Message\ResponseInterface;
@@ -46,11 +48,14 @@ final class PlaylistEditMethod implements MethodInterface
     public const string REST_ACTION = 'playlists_edit';
 
     private ModelFactoryInterface $modelFactory;
+    private PrivilegeCheckerInterface $privilegeChecker;
 
     public function __construct(
         ModelFactoryInterface $modelFactory,
+        PrivilegeCheckerInterface $privilegeChecker,
     ) {
-        $this->modelFactory = $modelFactory;
+        $this->modelFactory     = $modelFactory;
+        $this->privilegeChecker = $privilegeChecker;
     }
 
     /**
@@ -153,6 +158,16 @@ final class PlaylistEditMethod implements MethodInterface
         if ((int) $owner === 0) {
             $lookup = User::get_from_username((string) $owner);
             $owner  = $lookup->id ?? $playlist->user;
+        }
+
+        // handing a list to somebody else is an admin's call, the way setting a play for them is
+        if (
+            (int) $owner !== (int) $playlist->user
+            && !$this->privilegeChecker->check(AccessTypeEnum::INTERFACE, AccessLevelEnum::ADMIN, $user->getId())
+        ) {
+            throw new AccessFailedException(
+                sprintf('Require: %s', AccessLevelEnum::ADMIN->value)
+            );
         }
 
         // update name/type

--- a/src/Module/Api/Method/PlaylistEditMethod.php
+++ b/src/Module/Api/Method/PlaylistEditMethod.php
@@ -122,6 +122,15 @@ final class PlaylistEditMethod implements MethodInterface
         $hasAccess = $playlist->has_access($user);
         $hasCollab = $playlist->has_collaborate($user);
 
+        if (
+            !$hasAccess
+            && (isset($input['name']) || isset($input['type']) || isset($input['owner']) || isset($input['sort']))
+        ) {
+            throw new AccessFailedException(
+                sprintf('Require: %s', AccessLevelEnum::ADMIN->value)
+            );
+        }
+
         $changeMade = false;
         if (
             $hasCollab
@@ -135,10 +144,10 @@ final class PlaylistEditMethod implements MethodInterface
             }
         }
 
-        // don't continue if you don't actually have the access level to edit
+        // No metadata field reached this point, per the guard above, so a collaborator with no reorder either
+        // has nothing to do or sent a malformed request
         if (!$hasAccess) {
             if ($changeMade) {
-                // has_collaborate allows playlist track editing
                 $response->getBody()->write(
                     $output->success($apiVersion, 'playlist track changes saved')
                 );

--- a/src/Module/Api/Method/PlaylistEditMethod.php
+++ b/src/Module/Api/Method/PlaylistEditMethod.php
@@ -122,6 +122,7 @@ final class PlaylistEditMethod implements MethodInterface
         $hasAccess = $playlist->has_access($user);
         $hasCollab = $playlist->has_collaborate($user);
 
+        // has_collaborate allows reordering, but only an owner or admin may edit the metadata below; refuse before any reorder is applied
         if (
             !$hasAccess
             && (isset($input['name']) || isset($input['type']) || isset($input['owner']) || isset($input['sort']))
@@ -144,8 +145,7 @@ final class PlaylistEditMethod implements MethodInterface
             }
         }
 
-        // No metadata field reached this point, per the guard above, so a collaborator with no reorder either
-        // has nothing to do or sent a malformed request
+        // No metadata field reached this point, per the guard above, so a collaborator with no reorder either has nothing to do or sent a malformed request
         if (!$hasAccess) {
             if ($changeMade) {
                 $response->getBody()->write(

--- a/src/Module/Api/Method/PlaylistEditMethod.php
+++ b/src/Module/Api/Method/PlaylistEditMethod.php
@@ -160,7 +160,7 @@ final class PlaylistEditMethod implements MethodInterface
             $owner  = $lookup->id ?? $playlist->user;
         }
 
-        // handing a list to somebody else is an admin's call, the way setting a play for them is
+        // handing a list's ownership to somebody else is an admin's call, not the current owner's to make
         if (
             (int) $owner !== (int) $playlist->user
             && !$this->privilegeChecker->check(AccessTypeEnum::INTERFACE, AccessLevelEnum::ADMIN, $user->getId())

--- a/src/Module/Api/Xml8_Data.php
+++ b/src/Module/Api/Xml8_Data.php
@@ -1448,14 +1448,15 @@ final class Xml8_Data
              */
             if ((int) $playlist_id === 0) {
                 $playlist = new Search((int) str_replace('smart_', '', (string) $playlist_id), 'song', $user);
-                if ($playlist->isNew()) {
+                // a private list is only exposed to its owner or a collaborator, whatever route reached it
+                if ($playlist->isNew() || ($playlist->type !== 'public' && !$playlist->has_collaborate($user))) {
                     continue;
                 }
                 $object_type    = 'search';
                 $playitem_total = (int) $playlist->last_count;
             } else {
                 $playlist = new Playlist((int) $playlist_id);
-                if ($playlist->isNew()) {
+                if ($playlist->isNew() || ($playlist->type !== 'public' && !$playlist->has_collaborate($user))) {
                     continue;
                 }
                 $object_type    = 'playlist';

--- a/src/Module/Api/Xml8_Data.php
+++ b/src/Module/Api/Xml8_Data.php
@@ -1449,14 +1449,14 @@ final class Xml8_Data
             if ((int) $playlist_id === 0) {
                 $playlist = new Search((int) str_replace('smart_', '', (string) $playlist_id), 'song', $user);
                 // a private list is only exposed to its owner or a collaborator, whatever route reached it
-                if ($playlist->isNew() || ($playlist->type !== 'public' && !$playlist->has_collaborate($user))) {
+                if ($playlist->isNew() || !$playlist->isVisible($user)) {
                     continue;
                 }
                 $object_type    = 'search';
                 $playitem_total = (int) $playlist->last_count;
             } else {
                 $playlist = new Playlist((int) $playlist_id);
-                if ($playlist->isNew() || ($playlist->type !== 'public' && !$playlist->has_collaborate($user))) {
+                if ($playlist->isNew() || !$playlist->isVisible($user)) {
                     continue;
                 }
                 $object_type    = 'playlist';

--- a/src/Module/Application/Collection/ShowAction.php
+++ b/src/Module/Application/Collection/ShowAction.php
@@ -25,7 +25,9 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Application\Collection;
 
+use Ampache\Config\AmpConfig;
 use Ampache\Gui\GuiFactoryInterface;
+use Ampache\Gui\Partial\PageMeta;
 use Ampache\Module\Application\ApplicationActionInterface;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
 use Ampache\Module\Database\Query\BrowseFactoryInterface;
@@ -56,8 +58,6 @@ final readonly class ShowAction implements ApplicationActionInterface
             (int) ($request->getQueryParams()['collection'] ?? 0)
         );
 
-        $this->ui->showHeader();
-
         $globalUser = Core::get_global('user');
         $user       = $globalUser instanceof User ? $globalUser : null;
         // A collection the user may not see reports as missing rather than forbidden, matching the API: telling
@@ -70,8 +70,20 @@ final readonly class ShowAction implements ApplicationActionInterface
                 'Requested a collection that does not exist',
                 [LegacyLogger::CONTEXT_TYPE => self::class]
             );
+            $this->ui->showHeader();
             echo T_('You have requested an object that does not exist');
         } else {
+            // the header renders the meta, so the collection has to describe itself before it
+            $webPath = AmpConfig::get_web_path();
+            PageMeta::set(
+                [],
+                'music.playlist',
+                (string) $collection->get_fullname(),
+                $webPath . '/collection.php?action=show&collection=' . $collection->getId(),
+                $webPath . '/image.php?object_id=' . $collection->getId() . '&object_type=collection&size=600x600'
+            );
+
+            $this->ui->showHeader();
             // `get_items()` is the shape every other ordered browse is fed, so `show_objects()` needs no
             // special case; the view decides how to lay the members out
             echo $this->guiFactory->createCollectionViewAdapter(

--- a/src/Module/Application/Collection/ShowAction.php
+++ b/src/Module/Application/Collection/ShowAction.php
@@ -73,7 +73,7 @@ final readonly class ShowAction implements ApplicationActionInterface
             $this->ui->showHeader();
             echo T_('You have requested an object that does not exist');
         } else {
-            // the header renders the meta, so the collection has to describe itself before it
+            // the header renders the meta, so the collection has to describe itself before it is shown
             $webPath = AmpConfig::get_web_path();
             PageMeta::set(
                 [],

--- a/src/Module/Application/Folder/ShowAction.php
+++ b/src/Module/Application/Folder/ShowAction.php
@@ -30,6 +30,7 @@ use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
 use Ampache\Gui\Folder\FolderView;
 use Ampache\Gui\Form\StatsFormViewFactoryInterface;
+use Ampache\Gui\Partial\PageMeta;
 use Ampache\Module\Application\ApplicationActionInterface;
 use Ampache\Module\Application\Exception\AccessDeniedException;
 use Ampache\Module\Authorization\AccessLevelEnum;
@@ -67,8 +68,6 @@ final readonly class ShowAction implements ApplicationActionInterface
             throw new AccessDeniedException('Access Denied: folder features are not enabled.');
         }
 
-        $this->ui->showHeader();
-
         $input = $request->getQueryParams();
 
         // lookup by ID
@@ -77,6 +76,25 @@ final readonly class ShowAction implements ApplicationActionInterface
         $folder    = ($folder_id > 0)
             ? $this->folderRepository->findById($folder_id)
             : new Folder(-1);
+
+        // a folder in a catalog you are filtered from is not yours to browse, and the check has to
+        // come before the header so nothing about it reaches the page
+        if ($folder instanceof Folder && $folder->id > 0) {
+            if (!Catalog::has_access($folder->getCatalogId(), $user->getId())) {
+                throw new AccessDeniedException('Access Denied: catalog filter');
+            }
+
+            $webPath = AmpConfig::get_web_path();
+            PageMeta::set(
+                [],
+                'website',
+                (string) $folder->get_fullname(),
+                $webPath . '/folders.php?action=show&folder=' . $folder->getId(),
+                $webPath . '/image.php?object_id=' . $folder->getId() . '&object_type=folder&size=600x600'
+            );
+        }
+
+        $this->ui->showHeader();
 
         if (!$folder_id && $folder === null) {
             $this->logger->warning(
@@ -88,11 +106,6 @@ final readonly class ShowAction implements ApplicationActionInterface
 
             return null;
         } elseif ($folder instanceof Folder) {
-            // a folder in a catalog you are filtered from is not yours to browse
-            if ($folder->id > 0 && !Catalog::has_access($folder->getCatalogId(), $user->getId())) {
-                throw new AccessDeniedException('Access Denied: catalog filter');
-            }
-
             $browse = $this->browseFactory->create();
             $browse->set_type('folder');
             $browse->set_use_pages(true);

--- a/src/Module/Application/Folder/ShowAction.php
+++ b/src/Module/Application/Folder/ShowAction.php
@@ -35,6 +35,7 @@ use Ampache\Module\Application\Exception\AccessDeniedException;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Authorization\GuiGatekeeperInterface;
+use Ampache\Module\Catalog\Catalog;
 use Ampache\Module\Database\Query\BrowseFactoryInterface;
 use Ampache\Module\Playback\Stream_Playlist;
 use Ampache\Module\System\LegacyLogger;
@@ -71,7 +72,7 @@ final readonly class ShowAction implements ApplicationActionInterface
         $input = $request->getQueryParams();
 
         // lookup by ID
-        $gatekeeper->getUser() ?? $this->modelFactory->createUser(-1);
+        $user      = $gatekeeper->getUser() ?? $this->modelFactory->createUser(-1);
         $folder_id = (isset($input['folder'])) ? (int) $input['folder'] : -1;
         $folder    = ($folder_id > 0)
             ? $this->folderRepository->findById($folder_id)
@@ -87,6 +88,11 @@ final readonly class ShowAction implements ApplicationActionInterface
 
             return null;
         } elseif ($folder instanceof Folder) {
+            // a folder in a catalog you are filtered from is not yours to browse
+            if ($folder->id > 0 && !Catalog::has_access($folder->getCatalogId(), $user->getId())) {
+                throw new AccessDeniedException('Access Denied: catalog filter');
+            }
+
             $browse = $this->browseFactory->create();
             $browse->set_type('folder');
             $browse->set_use_pages(true);

--- a/src/Module/Application/Folder/ShowAction.php
+++ b/src/Module/Application/Folder/ShowAction.php
@@ -77,8 +77,8 @@ final readonly class ShowAction implements ApplicationActionInterface
             ? $this->folderRepository->findById($folder_id)
             : new Folder(-1);
 
-        // a folder in a catalog you are filtered from is not yours to browse, and the check has to
-        // come before the header so nothing about it reaches the page
+        // a folder in a catalog you are filtered from is not yours to browse, and the check has to come
+        // before the header so nothing about it reaches the page
         if ($folder instanceof Folder && $folder->id > 0) {
             if (!Catalog::has_access($folder->getCatalogId(), $user->getId())) {
                 throw new AccessDeniedException('Access Denied: catalog filter');

--- a/src/Module/Application/Image/AbstractShowAction.php
+++ b/src/Module/Application/Image/AbstractShowAction.php
@@ -119,9 +119,11 @@ abstract readonly class AbstractShowAction implements ApplicationActionInterface
         // Naming them in the url gives one link that draws the same tile for everyone who opens it,
         // whatever their own settings are, and makes a tile reproducible while debugging.
         $forceGenerated = (filter_input(INPUT_GET, 'generate', FILTER_SANITIZE_NUMBER_INT) === '1');
-        $previewMotif   = filter_input(INPUT_GET, 'preview', FILTER_SANITIZE_SPECIAL_CHARS, FILTER_NULL_ON_FAILURE);
-        $wantedTemplate = filter_input(INPUT_GET, 'template', FILTER_SANITIZE_SPECIAL_CHARS, FILTER_NULL_ON_FAILURE);
-        $wantedTemplate = is_string($wantedTemplate) ? $wantedTemplate : null;
+        // a caller that renders no svg says so, and a link preview scraper never renders one
+        $noSvg           = (filter_input(INPUT_GET, 'nosvg', FILTER_SANITIZE_NUMBER_INT) === '1');
+        $previewMotif    = filter_input(INPUT_GET, 'preview', FILTER_SANITIZE_SPECIAL_CHARS, FILTER_NULL_ON_FAILURE);
+        $wantedTemplate  = filter_input(INPUT_GET, 'template', FILTER_SANITIZE_SPECIAL_CHARS, FILTER_NULL_ON_FAILURE);
+        $wantedTemplate  = is_string($wantedTemplate) ? $wantedTemplate : null;
 
         // the preferences page shows one of these beside every template, so a listener can see a design
         // before picking it rather than choosing a name out of a list
@@ -196,7 +198,8 @@ abstract readonly class AbstractShowAction implements ApplicationActionInterface
                 // A drawn tile at least says which item is missing its cover, where one shared placeholder
                 // turns a whole grid into the same picture. Nothing is stored: the svg is rebuilt per request.
                 $generated = (
-                    ($forceGenerated || $this->generatedArt->isEnabled())
+                    !$noSvg
+                    && ($forceGenerated || $this->generatedArt->isEnabled())
                     && (empty($defaultimg) || $forceGenerated)
                 )
                     ? $this->generatedArt->render(
@@ -228,7 +231,7 @@ abstract readonly class AbstractShowAction implements ApplicationActionInterface
 
                 // the closest pre-rendered file, so a 200x200 slot is not handed the 1400x1400 original
                 $suffix     = ($has_size) ? Art::fallback_size($size) : '';
-                $filename   = ($type === 'folder') ? 'folder' : 'blankalbum';
+                $filename   = Art::fallback_image_name($type);
                 $defaultimg = $rootimg . $filename . $suffix . ".png";
                 $etag       = "EmptyMediaAlbum" . $suffix;
                 $image      = file_get_contents($defaultimg);

--- a/src/Module/Application/Image/AbstractShowAction.php
+++ b/src/Module/Application/Image/AbstractShowAction.php
@@ -119,7 +119,7 @@ abstract readonly class AbstractShowAction implements ApplicationActionInterface
         // Naming them in the url gives one link that draws the same tile for everyone who opens it,
         // whatever their own settings are, and makes a tile reproducible while debugging.
         $forceGenerated = (filter_input(INPUT_GET, 'generate', FILTER_SANITIZE_NUMBER_INT) === '1');
-        // a caller that renders no svg says so, and a link preview scraper never renders one
+        // a caller that renders no svg says so, and a link preview scraper never renders one on its own
         $noSvg           = (filter_input(INPUT_GET, 'nosvg', FILTER_SANITIZE_NUMBER_INT) === '1');
         $previewMotif    = filter_input(INPUT_GET, 'preview', FILTER_SANITIZE_SPECIAL_CHARS, FILTER_NULL_ON_FAILURE);
         $wantedTemplate  = filter_input(INPUT_GET, 'template', FILTER_SANITIZE_SPECIAL_CHARS, FILTER_NULL_ON_FAILURE);

--- a/src/Module/Application/Share/ConsumeAction.php
+++ b/src/Module/Application/Share/ConsumeAction.php
@@ -28,6 +28,7 @@ namespace Ampache\Module\Application\Share;
 use Ampache\Config\AmpConfig;
 use Ampache\Config\ConfigContainerInterface;
 use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Gui\Partial\PageMeta;
 use Ampache\Gui\Share\ShareView;
 use Ampache\Module\Application\ApplicationActionInterface;
 use Ampache\Module\Application\Batch\DefaultAction;
@@ -122,11 +123,24 @@ final readonly class ConsumeAction implements ApplicationActionInterface
 
             return $this->dic->get(DefaultAction::class)->run($request, $gatekeeper);
         } elseif ($action === 'stream') {
-            echo new ShareView(
+            $view = new ShareView(
                 AmpConfig::get_web_path(),
                 $this->ajaxUriRetriever,
                 $share
-            )->render();
+            );
+
+            // the page head is rendered from inside the view, so the meta has to be set before it
+            if (!$view->isEmbed()) {
+                PageMeta::set(
+                    [$view->getSharedByText()],
+                    $view->getOgType(),
+                    $view->getShareTitle(),
+                    $view->getPublicUrl(),
+                    $view->getArtUrl()
+                );
+            }
+
+            echo $view->render();
         } else {
             throw new AccessDeniedException('Access Denied: unknown action.');
         }

--- a/src/Module/Application/Share/ConsumeAction.php
+++ b/src/Module/Application/Share/ConsumeAction.php
@@ -129,7 +129,7 @@ final readonly class ConsumeAction implements ApplicationActionInterface
                 $share
             );
 
-            // the page head is rendered from inside the view, so the meta has to be set before it
+            // the page head is rendered from inside the view, so the meta has to be set before it runs
             if (!$view->isEmbed()) {
                 PageMeta::set(
                     [$view->getSharedByText()],

--- a/src/Module/Art/Art.php
+++ b/src/Module/Art/Art.php
@@ -531,6 +531,16 @@ class Art extends database_object
     }
 
     /**
+     * fallback_image_name
+     *
+     * The placeholder file a type falls back to, so a caller cannot name one that was never shipped.
+     */
+    public static function fallback_image_name(string $type): string
+    {
+        return self::FALLBACK_IMAGES[$type] ?? self::FALLBACK_IMAGE;
+    }
+
+    /**
      * fallback_size
      *
      * Snaps a requested size onto a shipped placeholder. Anything else fell through to the full size image,
@@ -665,7 +675,7 @@ class Art extends database_object
      */
     public static function get_fallback_url(string $type, ?string $size = null): string
     {
-        $name = self::FALLBACK_IMAGES[$type] ?? self::FALLBACK_IMAGE;
+        $name = self::fallback_image_name($type);
 
         // a custom blank album is already a url of its own, and a type with its own placeholder keeps it
         if ($name === self::FALLBACK_IMAGE) {

--- a/src/Module/Share/ShareCreator.php
+++ b/src/Module/Share/ShareCreator.php
@@ -32,6 +32,7 @@ use Ampache\Plugin\PluginShortenerInterface;
 use Ampache\Repository\Model\Album;
 use Ampache\Repository\Model\AlbumDisk;
 use Ampache\Repository\Model\LibraryItemEnum;
+use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\Model\Playlist;
 use Ampache\Repository\Model\Share;
 use Ampache\Repository\Model\Song;
@@ -47,6 +48,7 @@ final readonly class ShareCreator implements ShareCreatorInterface
     public function __construct(
         private PluginRetrieverInterface $pluginRetriever,
         private LoggerInterface $logger,
+        private ModelFactoryInterface $modelFactory,
     ) {}
 
     public function create(
@@ -79,6 +81,21 @@ final readonly class ShareCreator implements ShareCreatorInterface
             );
 
             return null;
+        }
+
+        // a private list the sharer cannot see is not theirs to publish
+        if ($object_type === LibraryItemEnum::PLAYLIST || $object_type === LibraryItemEnum::SEARCH) {
+            $list = ($object_type === LibraryItemEnum::SEARCH)
+                ? $this->modelFactory->createSearch($object_id)
+                : $this->modelFactory->createPlaylist($object_id);
+            if ($list->type !== 'public' && !$list->has_collaborate($user)) {
+                $this->logger->error(
+                    'create_share: not allowed to share a private list you do not own',
+                    [LegacyLogger::CONTEXT_TYPE => self::class]
+                );
+
+                return null;
+            }
         }
 
         if ($description === '') {

--- a/src/Module/Share/ShareCreator.php
+++ b/src/Module/Share/ShareCreator.php
@@ -83,12 +83,12 @@ final readonly class ShareCreator implements ShareCreatorInterface
             return null;
         }
 
-        // a private list the sharer cannot see is not theirs to publish
+        // a private list the sharer neither owns nor collaborates on is not theirs to publish via a share
         if ($object_type === LibraryItemEnum::PLAYLIST || $object_type === LibraryItemEnum::SEARCH) {
             $list = ($object_type === LibraryItemEnum::SEARCH)
-                ? $this->modelFactory->createSearch($object_id)
+                ? $this->modelFactory->createSmartlist($object_id)
                 : $this->modelFactory->createPlaylist($object_id);
-            if ($list->type !== 'public' && !$list->has_collaborate($user)) {
+            if (!$list->isVisible($user)) {
                 $this->logger->error(
                     'create_share: not allowed to share a private list you do not own',
                     [LegacyLogger::CONTEXT_TYPE => self::class]

--- a/src/Module/Util/Ui.php
+++ b/src/Module/Util/Ui.php
@@ -964,7 +964,7 @@ class Ui implements UiInterface
             $share    = $supplied ?: (($square) ? $custom : $webPath . '/ampache-card.png');
 
             $tags[] = '<meta property="og:image" content="' . self::esc(self::absolute($share)) . '">';
-            // a favicon standing in for the wide artwork would be cropped by the banner card
+            // a favicon standing in for the wide artwork would be cropped by the banner card format
             $tags[] = '<meta name="twitter:card" content="' . (($square) ? 'summary' : 'summary_large_image') . '">';
         }
 

--- a/src/Module/Util/Ui.php
+++ b/src/Module/Util/Ui.php
@@ -34,6 +34,7 @@ use Ampache\Gui\Partial\BoxBottomView;
 use Ampache\Gui\Partial\BoxTopView;
 use Ampache\Gui\Partial\FooterView;
 use Ampache\Gui\Partial\HeaderView;
+use Ampache\Gui\Partial\PageMeta;
 use Ampache\Gui\Partial\RightbarView;
 use Ampache\Gui\Preferences\PreferenceBoxView;
 use Ampache\Gui\Sidebar\SidebarViewFactoryInterface;
@@ -654,7 +655,9 @@ class Ui implements UiInterface
             echo "<style>#loginPage #headerlogo, #registerPage #logo { background-image: url('" . AmpConfig::get('custom_login_logo') . "') !important; }</style>";
         }
 
-        echo self::branding_tags();
+        $pageMeta = PageMeta::render();
+        echo self::branding_tags($pageMeta === '');
+        echo $pageMeta;
     }
 
     /**
@@ -925,8 +928,10 @@ class Ui implements UiInterface
      * Ampache's own next to it. A vector answers every size at once, so it is preferred where it
      * works; where a raster is required and only a vector was given, the tag is left out rather
      * than filled with somebody else's logo.
+     *
+     * @param bool $withSocialCard false when the page already described its own object through PageMeta
      */
-    private static function branding_tags(): string
+    private static function branding_tags(bool $withSocialCard): string
     {
         $webPath = AmpConfig::get_web_path();
         $custom  = trim((string) AmpConfig::get('custom_favicon', ''));
@@ -953,26 +958,30 @@ class Ui implements UiInterface
 
         // a shared link always shows something: the shipped card stands in when nothing usable was
         // supplied, since Ampache's artwork beats the stray page image a scraper settles on
-        $supplied = trim((string) AmpConfig::get('custom_share_image', ''));
-        $square   = ($supplied === '' && $custom !== '' && !$vector);
-        $share    = $supplied ?: (($square) ? $custom : $webPath . '/ampache-card.png');
+        if ($withSocialCard) {
+            $supplied = trim((string) AmpConfig::get('custom_share_image', ''));
+            $square   = ($supplied === '' && $custom !== '' && !$vector);
+            $share    = $supplied ?: (($square) ? $custom : $webPath . '/ampache-card.png');
 
-        $tags[] = '<meta property="og:image" content="' . self::esc(self::absolute($share)) . '">';
-        // a favicon standing in for the wide artwork would be cropped by the banner card
-        $tags[] = '<meta name="twitter:card" content="' . (($square) ? 'summary' : 'summary_large_image') . '">';
+            $tags[] = '<meta property="og:image" content="' . self::esc(self::absolute($share)) . '">';
+            // a favicon standing in for the wide artwork would be cropped by the banner card
+            $tags[] = '<meta name="twitter:card" content="' . (($square) ? 'summary' : 'summary_large_image') . '">';
+        }
 
         $title = trim((string) AmpConfig::get('site_title', ''));
         if ($title !== '') {
             $tags[] = '<meta property="og:site_name" content="' . self::esc($title) . '">';
         }
 
-        $description = trim((string) AmpConfig::get('site_description', ''));
-        if ($description !== '') {
-            $tags[] = '<meta name="description" content="' . self::esc($description) . '">';
-            $tags[] = '<meta property="og:description" content="' . self::esc($description) . '">';
-        }
+        if ($withSocialCard) {
+            $description = trim((string) AmpConfig::get('site_description', ''));
+            if ($description !== '') {
+                $tags[] = '<meta name="description" content="' . self::esc($description) . '">';
+                $tags[] = '<meta property="og:description" content="' . self::esc($description) . '">';
+            }
 
-        $tags[] = '<meta property="og:type" content="website">';
+            $tags[] = '<meta property="og:type" content="website">';
+        }
 
         return implode("\n", $tags) . "\n";
     }

--- a/src/Repository/Model/Collection.php
+++ b/src/Repository/Model/Collection.php
@@ -386,14 +386,6 @@ class Collection extends playlist_object
     }
 
     /**
-     * Whether the user may see this collection at all; a collaborator counts, they are invited to curate it.
-     */
-    public function isVisible(?User $user = null): bool
-    {
-        return ($this->type === 'public' || $this->has_collaborate($user));
-    }
-
-    /**
      * Renumber the members from 1 so the positions stay dense
      */
     public function regenerate_track_numbers(): void

--- a/src/Repository/Model/LibraryItemEnum.php
+++ b/src/Repository/Model/LibraryItemEnum.php
@@ -46,4 +46,18 @@ enum LibraryItemEnum: string
     case TAG             = 'tag';
     case TAG_HIDDEN      = 'tag_hidden';
     case VIDEO           = 'video';
+
+    /**
+     * Resolves an `ObjectTypeEnum` alias (`album_artist`, `song_artist`, `genre`, `smartlist`) onto the
+     * loadable case it is a role or alternate spelling of, in addition to a direct case match.
+     */
+    public static function fromObjectType(string $objectType): ?self
+    {
+        return self::tryFrom(match ($objectType) {
+            'album_artist', 'song_artist' => 'artist',
+            'genre' => 'tag',
+            'smartlist' => 'search',
+            default => $objectType,
+        });
+    }
 }

--- a/src/Repository/Model/playlist_object.php
+++ b/src/Repository/Model/playlist_object.php
@@ -374,6 +374,14 @@ abstract class playlist_object extends database_object implements
     }
 
     /**
+     * Whether the user may see this list at all; a collaborator counts, they are invited to curate it.
+     */
+    public function isVisible(?User $user = null): bool
+    {
+        return ($this->type === 'public' || $this->has_collaborate($user));
+    }
+
+    /**
      * set_last
      * Stores one of the cached totals.
      */

--- a/tests/Gui/Partial/HeaderViewTest.php
+++ b/tests/Gui/Partial/HeaderViewTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Gui\Partial;
+
+use Ampache\Config\AmpConfig;
+use Ampache\Gui\Sidebar\SidebarViewFactoryInterface;
+use Ampache\Module\Database\Query\Search;
+use Ampache\Module\Playlist\PlaylistLoaderInterface;
+use Ampache\Module\Util\AjaxUriRetrieverInterface;
+use Ampache\Module\Util\EnvironmentInterface;
+use Ampache\Module\Util\ZipHandlerInterface;
+use Ampache\Repository\CollectionRepositoryInterface;
+use Ampache\Repository\Model\LibraryItemLoaderInterface;
+use Ampache\Repository\Model\Playlist;
+use Ampache\Repository\Model\User;
+use Ampache\Repository\PrivateMessageRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The tab title names the object the page shows. A list the viewer may not see must not name itself
+ * there either, or the title says what the page itself refuses to.
+ */
+class HeaderViewTest extends TestCase
+{
+    private LibraryItemLoaderInterface&MockObject $libraryItemLoader;
+    private ?string $script    = null;
+    private ?string $siteTitle = null;
+
+    public function testAPrivateListTheViewerCannotSeeStaysAnonymous(): void
+    {
+        $playlist = $this->list(Playlist::class, 'private', false);
+        // the tell that the guard fired: the name is never even read
+        $playlist->expects(static::never())
+            ->method('get_fullname');
+
+        self::assertSame('Some site', $this->title('playlist', 'playlist_id'));
+    }
+
+    public function testAPrivateListTheViewerCollaboratesOnNamesItself(): void
+    {
+        $playlist = $this->list(Playlist::class, 'private', true);
+        $playlist->method('get_fullname')
+            ->willReturn('Shared list');
+
+        self::assertSame('Shared list - Some site', $this->title('playlist', 'playlist_id'));
+    }
+
+    public function testAPrivateSearchTheViewerCannotSeeStaysAnonymous(): void
+    {
+        $search = $this->list(Search::class, 'private', false);
+        $search->expects(static::never())
+            ->method('get_fullname');
+
+        self::assertSame('Some site', $this->title('smartplaylist', 'playlist_id'));
+    }
+
+    public function testAPublicListNamesItself(): void
+    {
+        $playlist = $this->list(Playlist::class, 'public', false);
+        $playlist->method('get_fullname')
+            ->willReturn('Electro cool');
+
+        self::assertSame('Electro cool - Some site', $this->title('playlist', 'playlist_id'));
+    }
+
+    public function testAVisitorWithNoAccountSeesNoPrivateName(): void
+    {
+        $playlist = $this->list(Playlist::class, 'private', false);
+        $playlist->expects(static::never())
+            ->method('get_fullname');
+
+        self::assertSame('Some site', $this->title('playlist', 'playlist_id', null));
+    }
+
+    protected function setUp(): void
+    {
+        $this->libraryItemLoader = $this->createMock(LibraryItemLoaderInterface::class);
+        $this->script            = $_SERVER['SCRIPT_NAME'] ?? null;
+        $this->siteTitle         = (string) AmpConfig::get('site_title');
+        AmpConfig::set('site_title', 'Some site', true);
+        AmpConfig::set('page_title_icons', '0', true);
+    }
+
+    protected function tearDown(): void
+    {
+        AmpConfig::set('site_title', $this->siteTitle, true);
+        unset($_GET['playlist_id']);
+        if ($this->script === null) {
+            unset($_SERVER['SCRIPT_NAME']);
+        } else {
+            $_SERVER['SCRIPT_NAME'] = $this->script;
+        }
+    }
+
+    /**
+     * @param class-string $className
+     */
+    private function list(string $className, string $type, bool $collaborates): MockObject
+    {
+        $item       = $this->createMock($className);
+        $item->type = $type;
+        $item->method('has_collaborate')
+            ->willReturn($collaborates);
+
+        $this->libraryItemLoader->method('load')
+            ->willReturn($item);
+
+        return $item;
+    }
+
+    private function title(string $script, string $param, ?User $user = null): string
+    {
+        $_SERVER['SCRIPT_NAME'] = '/' . $script . '.php';
+        $_GET[$param]           = '42';
+
+        return new HeaderView(
+            '',
+            '',
+            $this->createMock(EnvironmentInterface::class),
+            $this->createMock(AjaxUriRetrieverInterface::class),
+            $this->createMock(CollectionRepositoryInterface::class),
+            $this->libraryItemLoader,
+            $this->createMock(PlaylistLoaderInterface::class),
+            $this->createMock(PrivateMessageRepositoryInterface::class),
+            $this->createMock(ZipHandlerInterface::class),
+            $this->createMock(SidebarViewFactoryInterface::class),
+            $user,
+            '',
+            false,
+            false,
+            false,
+            false,
+        )->getPageTitle();
+    }
+}

--- a/tests/Gui/Partial/HeaderViewTest.php
+++ b/tests/Gui/Partial/HeaderViewTest.php
@@ -52,7 +52,7 @@ class HeaderViewTest extends TestCase
     public function testAPrivateListTheViewerCannotSeeStaysAnonymous(): void
     {
         $playlist = $this->list(Playlist::class, 'private', false);
-        // the tell that the guard fired: the name is never even read
+        // the tell that the guard fired: the name is never even read, let alone shown to anyone at all
         $playlist->expects(static::never())
             ->method('get_fullname');
 
@@ -120,10 +120,9 @@ class HeaderViewTest extends TestCase
      */
     private function list(string $className, string $type, bool $collaborates): MockObject
     {
-        $item       = $this->createMock($className);
-        $item->type = $type;
-        $item->method('has_collaborate')
-            ->willReturn($collaborates);
+        $item = $this->createMock($className);
+        $item->method('isVisible')
+            ->willReturn($type === 'public' || $collaborates);
 
         $this->libraryItemLoader->method('load')
             ->willReturn($item);

--- a/tests/Gui/Partial/PageMetaTest.php
+++ b/tests/Gui/Partial/PageMetaTest.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace Ampache\Gui\Partial;
 
+use Ampache\Config\AmpConfig;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -41,6 +42,16 @@ class PageMetaTest extends TestCase
             [236, 'PT3M56S'],
             [3725, 'PT1H2M5S'],
         ];
+    }
+
+    public function testAppendsNoSvgToTheBeautifiedArtRouteToo(): void
+    {
+        PageMeta::set([], 'profile', 'An artist', 'https://x/artists.php?artist=1', 'https://x/play/art/abc123/artist/1/size600x600.png');
+
+        static::assertStringContainsString(
+            'og:image" content="https://x/play/art/abc123/artist/1/size600x600.png&amp;nosvg=1"',
+            PageMeta::render()
+        );
     }
 
     public function testAsksArtForTheRasterSinceAScraperRendersNoSvg(): void
@@ -79,6 +90,15 @@ class PageMetaTest extends TestCase
         static::assertStringContainsString('twitter:card', $html);
     }
 
+    public function testFallsBackToTheSiteDescriptionWhenTheObjectHasNone(): void
+    {
+        AmpConfig::set('site_description', 'A shared music server', true);
+
+        PageMeta::set([], 'website', 'A folder', 'https://x/folders.php?folder=1', 'https://x/image.php?object_id=1&object_type=folder&size=600x600');
+
+        static::assertStringContainsString('name="description" content="A shared music server"', PageMeta::render());
+    }
+
     public function testLeavesAnImageThatIsNotServedByArtAlone(): void
     {
         PageMeta::set([], 'music.album', 'An album', 'https://x/albums.php?album=1', 'https://x/themes/reborn/images/logo.png');
@@ -89,5 +109,10 @@ class PageMetaTest extends TestCase
     public function testRendersNothingWhenNoPageSetAnything(): void
     {
         static::assertSame('', PageMeta::render());
+    }
+
+    protected function tearDown(): void
+    {
+        AmpConfig::set('site_description', null, true);
     }
 }

--- a/tests/Gui/Partial/PageMetaTest.php
+++ b/tests/Gui/Partial/PageMetaTest.php
@@ -43,6 +43,16 @@ class PageMetaTest extends TestCase
         ];
     }
 
+    public function testAsksArtForTheRasterSinceAScraperRendersNoSvg(): void
+    {
+        PageMeta::set([], 'music.album', 'An album', 'https://x/albums.php?album=1', 'https://x/image.php?object_id=1&object_type=album&size=600x600');
+
+        static::assertStringContainsString(
+            'og:image" content="https://x/image.php?object_id=1&amp;object_type=album&amp;size=600x600&amp;nosvg=1"',
+            PageMeta::render()
+        );
+    }
+
     #[DataProvider('durations')]
     public function testDurationSpeaksIso8601(int $seconds, string $expected): void
     {
@@ -67,6 +77,13 @@ class PageMetaTest extends TestCase
         static::assertStringContainsString('content="https://x/song.php?a=1&amp;b=2"', $html);
         static::assertStringNotContainsString('</script><script>', substr($html, (int) strpos($html, 'ld+json')));
         static::assertStringContainsString('twitter:card', $html);
+    }
+
+    public function testLeavesAnImageThatIsNotServedByArtAlone(): void
+    {
+        PageMeta::set([], 'music.album', 'An album', 'https://x/albums.php?album=1', 'https://x/themes/reborn/images/logo.png');
+
+        static::assertStringContainsString('og:image" content="https://x/themes/reborn/images/logo.png"', PageMeta::render());
     }
 
     public function testRendersNothingWhenNoPageSetAnything(): void

--- a/tests/Gui/Share/ShareViewTest.php
+++ b/tests/Gui/Share/ShareViewTest.php
@@ -36,7 +36,7 @@ class ShareViewTest extends TestCase
 
     public function testTheOpenGraphTypeFollowsTheSharedObject(): void
     {
-        // a share used to announce every object as a song, so an album preview claimed to be one
+        // a share used to announce every object as a song, so an album preview once claimed to be one too
         self::assertSame('music.album', $this->ogType('album'));
         self::assertSame('music.album', $this->ogType('album_disk'));
         self::assertSame('profile', $this->ogType('artist'));

--- a/tests/Gui/Share/ShareViewTest.php
+++ b/tests/Gui/Share/ShareViewTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ */
+
+namespace Ampache\Gui\Share;
+
+use Ampache\Module\Util\AjaxUriRetrieverInterface;
+use Ampache\Repository\Model\Share;
+use PHPUnit\Framework\TestCase;
+
+class ShareViewTest extends TestCase
+{
+    public function testAnUnknownObjectIsAnnouncedAsAPlainPage(): void
+    {
+        self::assertSame('website', $this->ogType('podcast_episode'));
+        self::assertSame('website', $this->ogType(''));
+    }
+
+    public function testTheOpenGraphTypeFollowsTheSharedObject(): void
+    {
+        // a share used to announce every object as a song, so an album preview claimed to be one
+        self::assertSame('music.album', $this->ogType('album'));
+        self::assertSame('music.album', $this->ogType('album_disk'));
+        self::assertSame('profile', $this->ogType('artist'));
+        self::assertSame('music.playlist', $this->ogType('playlist'));
+        self::assertSame('music.playlist', $this->ogType('search'));
+        self::assertSame('music.song', $this->ogType('song'));
+        self::assertSame('video.other', $this->ogType('video'));
+    }
+
+    private function ogType(string $objectType): string
+    {
+        $share              = $this->createMock(Share::class);
+        $share->object_type = $objectType;
+
+        return new ShareView('', $this->createMock(AjaxUriRetrieverInterface::class), $share)->getOgType();
+    }
+}

--- a/tests/Module/Api/Ajax/Handler/DefaultAjaxHandlerTest.php
+++ b/tests/Module/Api/Ajax/Handler/DefaultAjaxHandlerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Module\Api\Ajax\Handler;
+
+use Ampache\Module\Database\Query\BrowseFactoryInterface;
+use Ampache\Module\Playback\Tmp_Playlist;
+use Ampache\Module\Util\RequestParserInterface;
+use Ampache\Module\Util\UiInterface;
+use Ampache\Repository\AlbumRepositoryInterface;
+use Ampache\Repository\Model\LibraryItemLoaderInterface;
+use Ampache\Repository\Model\Playlist;
+use Ampache\Repository\Model\User;
+use Ampache\Repository\SongRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class DefaultAjaxHandlerTest extends TestCase
+{
+    private AlbumRepositoryInterface&MockObject $albumRepository;
+    private BrowseFactoryInterface&MockObject $browseFactory;
+    private LibraryItemLoaderInterface&MockObject $libraryItemLoader;
+    private RequestParserInterface&MockObject $requestParser;
+    private SongRepositoryInterface&MockObject $songRepository;
+    private DefaultAjaxHandler $subject;
+    private UiInterface&MockObject $ui;
+
+    public function testBasketExpandsAPrivateListTheViewerCollaboratesOn(): void
+    {
+        $medias   = [['object_type' => 'song', 'object_id' => 9]];
+        $playlist = $this->playlist('private', true);
+        $playlist->expects(static::once())
+            ->method('get_medias')
+            ->willReturn($medias);
+
+        static::assertSame($medias, $this->runBasket($playlist));
+    }
+
+    public function testBasketExpandsAPublicList(): void
+    {
+        $medias   = [['object_type' => 'song', 'object_id' => 7]];
+        $playlist = $this->playlist('public', false);
+        $playlist->expects(static::once())
+            ->method('get_medias')
+            ->willReturn($medias);
+
+        static::assertSame($medias, $this->runBasket($playlist));
+    }
+
+    public function testBasketRefusesToExpandAPrivateListTheViewerCannotSee(): void
+    {
+        $playlist = $this->playlist('private', false);
+        // the tell that the guard fired: the members are never even read
+        $playlist->expects(static::never())
+            ->method('get_medias');
+
+        static::assertSame([], $this->runBasket($playlist));
+    }
+
+    protected function setUp(): void
+    {
+        $this->requestParser     = $this->createMock(RequestParserInterface::class);
+        $this->albumRepository   = $this->createMock(AlbumRepositoryInterface::class);
+        $this->songRepository    = $this->createMock(SongRepositoryInterface::class);
+        $this->ui                = $this->createMock(UiInterface::class);
+        $this->browseFactory     = $this->createMock(BrowseFactoryInterface::class);
+        $this->libraryItemLoader = $this->createMock(LibraryItemLoaderInterface::class);
+
+        $this->subject = new DefaultAjaxHandler(
+            $this->requestParser,
+            $this->albumRepository,
+            $this->songRepository,
+            $this->ui,
+            $this->browseFactory,
+            $this->libraryItemLoader,
+        );
+    }
+
+    private function playlist(string $type, bool $collaborates): Playlist&MockObject
+    {
+        $playlist       = $this->createMock(Playlist::class);
+        $playlist->type = $type;
+        $playlist->method('has_collaborate')
+            ->willReturn($collaborates);
+
+        return $playlist;
+    }
+
+    /**
+     * Runs the basket action for one playlist id and returns what was handed to the queue.
+     *
+     * @return array<mixed>
+     */
+    private function runBasket(Playlist&MockObject $playlist): array
+    {
+        $this->requestParser->method('getFromRequest')
+            ->willReturnMap([
+                ['action', 'basket'],
+                ['type', ''],
+                ['object_type', 'playlist'],
+                ['id', '42'],
+                ['object_id', ''],
+            ]);
+
+        $this->libraryItemLoader->method('load')
+            ->willReturn($playlist);
+
+        $handed = null;
+        $queue  = $this->createMock(Tmp_Playlist::class);
+        $queue->method('add_medias')
+            ->willReturnCallback(static function (array $medias) use (&$handed): void {
+                $handed = $medias;
+            });
+
+        $user = $this->createMock(User::class);
+        $user->method('getPlaylist')
+            ->willReturn($queue);
+
+        ob_start();
+        $this->subject->handle($user);
+        ob_end_clean();
+
+        return $handed ?? [];
+    }
+}

--- a/tests/Module/Api/Ajax/Handler/DefaultAjaxHandlerTest.php
+++ b/tests/Module/Api/Ajax/Handler/DefaultAjaxHandlerTest.php
@@ -29,6 +29,8 @@ use Ampache\Module\Playback\Tmp_Playlist;
 use Ampache\Module\Util\RequestParserInterface;
 use Ampache\Module\Util\UiInterface;
 use Ampache\Repository\AlbumRepositoryInterface;
+use Ampache\Repository\Model\Artist;
+use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\LibraryItemLoaderInterface;
 use Ampache\Repository\Model\Playlist;
 use Ampache\Repository\Model\User;
@@ -45,6 +47,46 @@ class DefaultAjaxHandlerTest extends TestCase
     private SongRepositoryInterface&MockObject $songRepository;
     private DefaultAjaxHandler $subject;
     private UiInterface&MockObject $ui;
+
+    public function testBasketExpandsAnObjectTypeThatIsOnlyAnAliasOfALoadableType(): void
+    {
+        $medias = [['object_type' => 'song', 'object_id' => 11]];
+        $artist = $this->createMock(Artist::class);
+        $artist->expects(static::once())
+            ->method('get_medias')
+            ->willReturn($medias);
+
+        $this->requestParser->method('getFromRequest')
+            ->willReturnMap([
+                ['action', 'basket'],
+                ['type', ''],
+                ['object_type', 'album_artist'],
+                ['id', '42'],
+                ['object_id', ''],
+            ]);
+
+        $this->libraryItemLoader->expects(static::once())
+            ->method('load')
+            ->with(LibraryItemEnum::ARTIST, 42)
+            ->willReturn($artist);
+
+        $handed = null;
+        $queue  = $this->createMock(Tmp_Playlist::class);
+        $queue->method('add_medias')
+            ->willReturnCallback(static function (array $medias) use (&$handed): void {
+                $handed = $medias;
+            });
+
+        $user = $this->createMock(User::class);
+        $user->method('getPlaylist')
+            ->willReturn($queue);
+
+        ob_start();
+        $this->subject->handle($user);
+        ob_end_clean();
+
+        static::assertSame($medias, $handed);
+    }
 
     public function testBasketExpandsAPrivateListTheViewerCollaboratesOn(): void
     {
@@ -71,7 +113,7 @@ class DefaultAjaxHandlerTest extends TestCase
     public function testBasketRefusesToExpandAPrivateListTheViewerCannotSee(): void
     {
         $playlist = $this->playlist('private', false);
-        // the tell that the guard fired: the members are never even read
+        // the tell that the guard fired: the members are never even read, let alone queued up anywhere
         $playlist->expects(static::never())
             ->method('get_medias');
 
@@ -99,16 +141,15 @@ class DefaultAjaxHandlerTest extends TestCase
 
     private function playlist(string $type, bool $collaborates): Playlist&MockObject
     {
-        $playlist       = $this->createMock(Playlist::class);
-        $playlist->type = $type;
-        $playlist->method('has_collaborate')
-            ->willReturn($collaborates);
+        $playlist = $this->createMock(Playlist::class);
+        $playlist->method('isVisible')
+            ->willReturn($type === 'public' || $collaborates);
 
         return $playlist;
     }
 
     /**
-     * Runs the basket action for one playlist id and returns what was handed to the queue.
+     * Runs the basket action for one playlist id and returns whatever ended up handed to the queue.
      *
      * @return array<mixed>
      */

--- a/tests/Module/Api/Ajax/Handler/PlaylistAjaxHandlerTest.php
+++ b/tests/Module/Api/Ajax/Handler/PlaylistAjaxHandlerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Module\Api\Ajax\Handler;
+
+use Ampache\Module\Database\Query\BrowseFactoryInterface;
+use Ampache\Module\Util\RequestParserInterface;
+use Ampache\Repository\Model\LibraryItemEnum;
+use Ampache\Repository\Model\LibraryItemLoaderInterface;
+use Ampache\Repository\Model\Playlist;
+use Ampache\Repository\Model\User;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Appending to a playlist takes the ids the caller names. A private list the caller cannot see is not
+ * one of them, or its whole content lands in a playlist they own and can read at leisure.
+ */
+class PlaylistAjaxHandlerTest extends TestCase
+{
+    private LibraryItemLoaderInterface&MockObject $libraryItemLoader;
+    private RequestParserInterface&MockObject $requestParser;
+    private PlaylistAjaxHandler $subject;
+
+    public function testAppendRefusesAPrivateSourceTheCallerCannotSee(): void
+    {
+        $target = $this->target();
+        $source = $this->source('private', false);
+
+        // the tell that the guard fired: the members are never read, and nothing is appended
+        $source->expects(static::never())
+            ->method('get_medias');
+        $target->expects(static::never())
+            ->method('add_medias');
+
+        $this->append($target, $source);
+    }
+
+    public function testAppendTakesAPrivateSourceTheCallerCollaboratesOn(): void
+    {
+        $medias = [['object_type' => 'song', 'object_id' => 3]];
+        $target = $this->target();
+        $source = $this->source('private', true);
+
+        $source->method('get_medias')
+            ->willReturn($medias);
+        $target->expects(static::once())
+            ->method('add_medias')
+            ->with($medias)
+            ->willReturn(true);
+
+        $this->append($target, $source);
+    }
+
+    public function testAppendTakesAPublicSource(): void
+    {
+        $medias = [['object_type' => 'song', 'object_id' => 5]];
+        $target = $this->target();
+        $source = $this->source('public', false);
+
+        $source->method('get_medias')
+            ->willReturn($medias);
+        $target->expects(static::once())
+            ->method('add_medias')
+            ->with($medias)
+            ->willReturn(true);
+
+        $this->append($target, $source);
+    }
+
+    protected function setUp(): void
+    {
+        $this->requestParser     = $this->createMock(RequestParserInterface::class);
+        $this->libraryItemLoader = $this->createMock(LibraryItemLoaderInterface::class);
+
+        $this->subject = new PlaylistAjaxHandler(
+            $this->requestParser,
+            $this->createMock(BrowseFactoryInterface::class),
+            $this->libraryItemLoader,
+        );
+
+        $this->requestParser->method('getFromRequest')
+            ->willReturn('append_item');
+
+        $_REQUEST['playlist_id'] = '10';
+        $_REQUEST['item_type']   = 'playlist';
+        $_REQUEST['item_id']     = '42';
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_REQUEST['playlist_id'], $_REQUEST['item_type'], $_REQUEST['item_id']);
+    }
+
+    private function append(Playlist&MockObject $target, Playlist&MockObject $source): void
+    {
+        $this->libraryItemLoader->method('load')
+            ->willReturnCallback(
+                static fn(LibraryItemEnum $type, int $id): ?Playlist => ($id === 10) ? $target : $source
+            );
+
+        ob_start();
+        $this->subject->handle($this->createMock(User::class));
+        ob_end_clean();
+    }
+
+    private function source(string $type, bool $collaborates): Playlist&MockObject
+    {
+        $source       = $this->createMock(Playlist::class);
+        $source->type = $type;
+        $source->method('has_collaborate')
+            ->willReturn($collaborates);
+
+        return $source;
+    }
+
+    private function target(): Playlist&MockObject
+    {
+        $target     = $this->createMock(Playlist::class);
+        $target->id = 10;
+        $target->method('has_collaborate')
+            ->willReturn(true);
+
+        return $target;
+    }
+}

--- a/tests/Module/Api/Ajax/Handler/PlaylistAjaxHandlerTest.php
+++ b/tests/Module/Api/Ajax/Handler/PlaylistAjaxHandlerTest.php
@@ -26,6 +26,7 @@ namespace Ampache\Module\Api\Ajax\Handler;
 
 use Ampache\Module\Database\Query\BrowseFactoryInterface;
 use Ampache\Module\Util\RequestParserInterface;
+use Ampache\Repository\Model\Artist;
 use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\LibraryItemLoaderInterface;
 use Ampache\Repository\Model\Playlist;
@@ -48,7 +49,7 @@ class PlaylistAjaxHandlerTest extends TestCase
         $target = $this->target();
         $source = $this->source('private', false);
 
-        // the tell that the guard fired: the members are never read, and nothing is appended
+        // the tell that the guard fired: the members are never read, and nothing is appended anywhere
         $source->expects(static::never())
             ->method('get_medias');
         $target->expects(static::never())
@@ -89,6 +90,30 @@ class PlaylistAjaxHandlerTest extends TestCase
         $this->append($target, $source);
     }
 
+    public function testAppendTakesASourceWhoseObjectTypeIsOnlyAnAliasOfALoadableType(): void
+    {
+        $medias = [['object_type' => 'song', 'object_id' => 8]];
+        $target = $this->target();
+        $artist = $this->createMock(Artist::class);
+        $artist->method('get_medias')
+            ->willReturn($medias);
+
+        $_REQUEST['item_type'] = 'album_artist';
+
+        $this->libraryItemLoader->method('load')
+            ->willReturnCallback(
+                static fn(LibraryItemEnum $type, int $id) => ($id === 10) ? $target : (($type === LibraryItemEnum::ARTIST) ? $artist : null)
+            );
+        $target->expects(static::once())
+            ->method('add_medias')
+            ->with($medias)
+            ->willReturn(true);
+
+        ob_start();
+        $this->subject->handle($this->createMock(User::class));
+        ob_end_clean();
+    }
+
     protected function setUp(): void
     {
         $this->requestParser     = $this->createMock(RequestParserInterface::class);
@@ -127,10 +152,9 @@ class PlaylistAjaxHandlerTest extends TestCase
 
     private function source(string $type, bool $collaborates): Playlist&MockObject
     {
-        $source       = $this->createMock(Playlist::class);
-        $source->type = $type;
-        $source->method('has_collaborate')
-            ->willReturn($collaborates);
+        $source = $this->createMock(Playlist::class);
+        $source->method('isVisible')
+            ->willReturn($type === 'public' || $collaborates);
 
         return $source;
     }

--- a/tests/Module/Api/Method/Api8/CollectionEdit8MethodTest.php
+++ b/tests/Module/Api/Method/Api8/CollectionEdit8MethodTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Module\Api\Method\Api8;
+
+use Ampache\MockeryTestCase;
+use Ampache\Module\Api\Authentication\GatekeeperInterface;
+use Ampache\Module\Api\Method\Exception\AccessFailedException;
+use Ampache\Module\Api\Output\ApiOutputInterface;
+use Ampache\Repository\CollectionRepositoryInterface;
+use Ampache\Repository\Model\Collection;
+use Ampache\Repository\Model\User;
+use Mockery\MockInterface;
+use Override;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class CollectionEdit8MethodTest extends MockeryTestCase
+{
+    private CollectionRepositoryInterface|MockInterface|null $collectionRepository;
+    private ?CollectionEdit8Method $subject;
+
+    public function testHandleAllowsMetadataEditFromOwner(): void
+    {
+        $gatekeeper = $this->mock(GatekeeperInterface::class);
+        $response   = $this->mock(ResponseInterface::class);
+        $output     = $this->mock(ApiOutputInterface::class);
+        $user       = $this->mock(User::class);
+        $collection = $this->mock(Collection::class);
+        $stream     = $this->mock(StreamInterface::class);
+
+        $this->collectionRepository->shouldReceive('findById')
+            ->with(5)
+            ->once()
+            ->andReturn($collection);
+
+        $collection->shouldReceive('isVisible')->with($user)->andReturn(true);
+        $collection->shouldReceive('has_collaborate')->with($user)->andReturn(true);
+        $collection->shouldReceive('has_access')->with($user)->andReturn(true);
+        $collection->shouldReceive('getId')->andReturn(5);
+
+        $this->collectionRepository->shouldReceive('update')
+            ->with(5, null, 'public', null, null)
+            ->once();
+
+        $output->shouldReceive('collections')
+            ->with(8, [5], $user, 'some-auth')
+            ->once()
+            ->andReturn('result');
+        $response->shouldReceive('getBody')->andReturn($stream);
+        $stream->shouldReceive('write')->with('result')->once();
+
+        $this->assertSame(
+            $response,
+            $this->subject->handle(
+                $gatekeeper,
+                $response,
+                $output,
+                ['filter' => '5', 'type' => 'public', 'api_format' => 'json', 'auth' => 'some-auth'],
+                $user,
+                8
+            )
+        );
+    }
+
+    /**
+     * A collaborator may curate the contents but must not edit the metadata (name, visibility, collaborators);
+     * asking for a metadata change with no reorder is refused, and the metadata is never written.
+     */
+    public function testHandleRefusesMetadataEditFromCollaborator(): void
+    {
+        $gatekeeper = $this->mock(GatekeeperInterface::class);
+        $response   = $this->mock(ResponseInterface::class);
+        $output     = $this->mock(ApiOutputInterface::class);
+        $user       = $this->mock(User::class);
+        $collection = $this->mock(Collection::class);
+
+        $this->collectionRepository->shouldReceive('findById')
+            ->with(5)
+            ->once()
+            ->andReturn($collection);
+
+        $collection->shouldReceive('isVisible')->with($user)->andReturn(true);
+        $collection->shouldReceive('has_collaborate')->with($user)->andReturn(true);
+        $collection->shouldReceive('has_access')->with($user)->andReturn(false);
+
+        // the metadata write must never be reached for a collaborator
+        $this->collectionRepository->shouldNotReceive('update');
+
+        $this->expectException(AccessFailedException::class);
+        $this->expectExceptionMessage(sprintf('Require: %s', 100));
+
+        $this->subject->handle(
+            $gatekeeper,
+            $response,
+            $output,
+            ['filter' => '5', 'type' => 'public', 'api_format' => 'json', 'auth' => 'some-auth'],
+            $user,
+            8
+        );
+    }
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->collectionRepository = $this->mock(CollectionRepositoryInterface::class);
+
+        $this->subject = new CollectionEdit8Method(
+            $this->collectionRepository
+        );
+    }
+}

--- a/tests/Module/Api/Method/Api8/CollectionEdit8MethodTest.php
+++ b/tests/Module/Api/Method/Api8/CollectionEdit8MethodTest.php
@@ -86,6 +86,52 @@ class CollectionEdit8MethodTest extends MockeryTestCase
     }
 
     /**
+     * A collaborator reordering the collection may not smuggle a metadata edit in on the same request; the
+     * whole request is refused, and neither the reorder nor the metadata is ever written.
+     */
+    public function testHandleRefusesAMetadataEditBundledWithAReorderFromCollaborator(): void
+    {
+        $gatekeeper = $this->mock(GatekeeperInterface::class);
+        $response   = $this->mock(ResponseInterface::class);
+        $output     = $this->mock(ApiOutputInterface::class);
+        $user       = $this->mock(User::class);
+        $collection = $this->mock(Collection::class);
+
+        $this->collectionRepository->shouldReceive('findById')
+            ->with(5)
+            ->once()
+            ->andReturn($collection);
+
+        $collection->shouldReceive('isVisible')->with($user)->andReturn(true);
+        $collection->shouldReceive('has_collaborate')->with($user)->andReturn(true);
+        $collection->shouldReceive('has_access')->with($user)->andReturn(false);
+
+        // neither the reorder nor the metadata write may be reached for a bundled request like this
+        $collection->shouldNotReceive('set_by_track_number');
+        $collection->shouldNotReceive('regenerate_track_numbers');
+        $this->collectionRepository->shouldNotReceive('update');
+
+        $this->expectException(AccessFailedException::class);
+        $this->expectExceptionMessage(sprintf('Require: %s', 100));
+
+        $this->subject->handle(
+            $gatekeeper,
+            $response,
+            $output,
+            [
+                'filter' => '5',
+                'name' => 'New name',
+                'items' => 'song:1',
+                'tracks' => '1',
+                'api_format' => 'json',
+                'auth' => 'some-auth',
+            ],
+            $user,
+            8
+        );
+    }
+
+    /**
      * A collaborator may curate the contents but must not edit the metadata (name, visibility, collaborators);
      * asking for a metadata change with no reorder is refused, and the metadata is never written.
      */
@@ -106,7 +152,7 @@ class CollectionEdit8MethodTest extends MockeryTestCase
         $collection->shouldReceive('has_collaborate')->with($user)->andReturn(true);
         $collection->shouldReceive('has_access')->with($user)->andReturn(false);
 
-        // the metadata write must never be reached for a collaborator
+        // the metadata write must never be reached for a collaborator, even with no reorder requested
         $this->collectionRepository->shouldNotReceive('update');
 
         $this->expectException(AccessFailedException::class);

--- a/tests/Module/Api/Method/Api8/PlaylistAdd8MethodTest.php
+++ b/tests/Module/Api/Method/Api8/PlaylistAdd8MethodTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Module\Api\Method\Api8;
+
+use Ampache\MockeryTestCase;
+use Ampache\Module\Api\Authentication\GatekeeperInterface;
+use Ampache\Module\Api\Method\Exception\ResultEmptyException;
+use Ampache\Module\Api\Output\ApiOutputInterface;
+use Ampache\Repository\Model\ModelFactoryInterface;
+use Ampache\Repository\Model\Playlist;
+use Ampache\Repository\Model\User;
+use Mockery\MockInterface;
+use Override;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class PlaylistAdd8MethodTest extends MockeryTestCase
+{
+    private ModelFactoryInterface|MockInterface|null $modelFactory;
+    private ?PlaylistAdd8Method $subject;
+
+    public function testHandleExpandsAListTheCallerMaySee(): void
+    {
+        $gatekeeper = $this->mock(GatekeeperInterface::class);
+        $response   = $this->mock(ResponseInterface::class);
+        $output     = $this->mock(ApiOutputInterface::class);
+        $user       = $this->mock(User::class);
+        $target     = $this->mock(Playlist::class);
+        $source     = $this->mock(Playlist::class);
+        $stream     = $this->mock(StreamInterface::class);
+
+        $this->modelFactory->shouldReceive('createPlaylist')->with(5)->once()->andReturn($target);
+        $target->shouldReceive('has_collaborate')->with($user)->andReturn(true);
+
+        $this->modelFactory->shouldReceive('createPlaylist')->with(9)->once()->andReturn($source);
+        $source->shouldReceive('isNew')->andReturn(false);
+        $source->type = 'private';
+        $source->shouldReceive('has_collaborate')->with($user)->andReturn(true);
+        $source->shouldReceive('get_songs')->andReturn([101, 102]);
+
+        $target->shouldReceive('add_songs')->with([101, 102])->once()->andReturn(true);
+
+        $output->shouldReceive('success')->andReturn('ok-result');
+        $response->shouldReceive('getBody')->andReturn($stream);
+        $stream->shouldReceive('write')->with('ok-result')->once();
+
+        $this->assertSame(
+            $response,
+            $this->subject->handle(
+                $gatekeeper,
+                $response,
+                $output,
+                ['filter' => '5', 'id' => '9', 'object_type' => 'playlist', 'api_format' => 'json', 'auth' => 'some-auth'],
+                $user,
+                8
+            )
+        );
+    }
+
+    /**
+     * Expanding another user's private list into your own playlist must be refused: the source list you
+     * neither own nor collaborate on reads as not-found, and nothing is copied into the target.
+     */
+    public function testHandleRefusesExpandingAPrivateSourceList(): void
+    {
+        $gatekeeper = $this->mock(GatekeeperInterface::class);
+        $response   = $this->mock(ResponseInterface::class);
+        $output     = $this->mock(ApiOutputInterface::class);
+        $user       = $this->mock(User::class);
+        $target     = $this->mock(Playlist::class);
+        $source     = $this->mock(Playlist::class);
+
+        $this->modelFactory->shouldReceive('createPlaylist')->with(5)->once()->andReturn($target);
+        $target->shouldReceive('has_collaborate')->with($user)->andReturn(true);
+        // the target must never receive the foreign list's songs
+        $target->shouldNotReceive('add_songs');
+
+        $this->modelFactory->shouldReceive('createPlaylist')->with(9)->once()->andReturn($source);
+        $source->shouldReceive('isNew')->andReturn(false);
+        $source->type = 'private';
+        $source->shouldReceive('has_collaborate')->with($user)->andReturn(false);
+
+        $this->expectException(ResultEmptyException::class);
+        $this->expectExceptionMessage('9');
+
+        $this->subject->handle(
+            $gatekeeper,
+            $response,
+            $output,
+            ['filter' => '5', 'id' => '9', 'object_type' => 'playlist', 'api_format' => 'json', 'auth' => 'some-auth'],
+            $user,
+            8
+        );
+    }
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->modelFactory = $this->mock(ModelFactoryInterface::class);
+
+        $this->subject = new PlaylistAdd8Method(
+            $this->modelFactory
+        );
+    }
+}

--- a/tests/Module/Api/Method/Api8/PlaylistAdd8MethodTest.php
+++ b/tests/Module/Api/Method/Api8/PlaylistAdd8MethodTest.php
@@ -57,8 +57,7 @@ class PlaylistAdd8MethodTest extends MockeryTestCase
 
         $this->modelFactory->shouldReceive('createPlaylist')->with(9)->once()->andReturn($source);
         $source->shouldReceive('isNew')->andReturn(false);
-        $source->type = 'private';
-        $source->shouldReceive('has_collaborate')->with($user)->andReturn(true);
+        $source->shouldReceive('isVisible')->with($user)->andReturn(true);
         $source->shouldReceive('get_songs')->andReturn([101, 102]);
 
         $target->shouldReceive('add_songs')->with([101, 102])->once()->andReturn(true);
@@ -95,13 +94,12 @@ class PlaylistAdd8MethodTest extends MockeryTestCase
 
         $this->modelFactory->shouldReceive('createPlaylist')->with(5)->once()->andReturn($target);
         $target->shouldReceive('has_collaborate')->with($user)->andReturn(true);
-        // the target must never receive the foreign list's songs
+        // the target must never receive the foreign list's songs once the source list is refused as private
         $target->shouldNotReceive('add_songs');
 
         $this->modelFactory->shouldReceive('createPlaylist')->with(9)->once()->andReturn($source);
         $source->shouldReceive('isNew')->andReturn(false);
-        $source->type = 'private';
-        $source->shouldReceive('has_collaborate')->with($user)->andReturn(false);
+        $source->shouldReceive('isVisible')->with($user)->andReturn(false);
 
         $this->expectException(ResultEmptyException::class);
         $this->expectExceptionMessage('9');

--- a/tests/Module/Api/Method/PlaylistEditMethodTest.php
+++ b/tests/Module/Api/Method/PlaylistEditMethodTest.php
@@ -32,6 +32,9 @@ use Ampache\Module\Api\Method\Exception\AccessFailedException;
 use Ampache\Module\Api\Method\Exception\RequestParamMissingException;
 use Ampache\Module\Api\Method\Exception\ResultEmptyException;
 use Ampache\Module\Api\Output\ApiOutputInterface;
+use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\AccessTypeEnum;
+use Ampache\Module\Authorization\Check\PrivilegeCheckerInterface;
 use Ampache\Repository\Model\ModelFactoryInterface;
 use Ampache\Repository\Model\Playlist;
 use Ampache\Repository\Model\User;
@@ -44,6 +47,7 @@ use Psr\Http\Message\StreamInterface;
 class PlaylistEditMethodTest extends MockeryTestCase
 {
     private ModelFactoryInterface|MockInterface|null $modelFactory;
+    private PrivilegeCheckerInterface|MockInterface|null $privilegeChecker;
     private ?PlaylistEditMethod $subject;
 
     /**
@@ -57,6 +61,88 @@ class PlaylistEditMethodTest extends MockeryTestCase
             'api6' => [6],
             'api8' => [8],
         ];
+    }
+
+    #[DataProvider(methodName: 'apiVersionProvider')]
+    public function testHandleLetsAnAdminHandThePlaylistOver(int $apiVersion): void
+    {
+        $gatekeeper = $this->mock(GatekeeperInterface::class);
+        $response   = $this->mock(ResponseInterface::class);
+        $output     = $this->mock(ApiOutputInterface::class);
+        $user       = $this->mock(User::class);
+        $playlist   = $this->mock(Playlist::class);
+        $stream     = $this->mock(StreamInterface::class);
+
+        $objectId = 666;
+
+        $this->mockPlaylist($playlist, $user, $objectId, true, false);
+        $playlist->name = 'some-name';
+        $playlist->type = 'private';
+        $playlist->user = 42;
+
+        $user->shouldReceive('getId')->andReturn(7);
+        $this->privilegeChecker->shouldReceive('check')
+            ->with(AccessTypeEnum::INTERFACE, AccessLevelEnum::ADMIN, 7)
+            ->once()
+            ->andReturnTrue();
+
+        $playlist->shouldReceive('update')
+            ->with([
+                'name' => 'some-name',
+                'playlist_type' => 'private',
+                'playlist_user' => 1,
+            ])
+            ->once();
+
+        $output->shouldReceive('success')->andReturn('ok');
+        $response->shouldReceive('getBody')->andReturn($stream);
+        $stream->shouldReceive('write');
+
+        $this->subject->handle(
+            $gatekeeper,
+            $response,
+            $output,
+            ['filter' => (string) $objectId, 'owner' => '1', 'api_format' => 'json', 'auth' => 'some-auth'],
+            $user,
+            $apiVersion
+        );
+    }
+
+    #[DataProvider(methodName: 'apiVersionProvider')]
+    public function testHandleRefusesToHandThePlaylistToSomebodyElse(int $apiVersion): void
+    {
+        $gatekeeper = $this->mock(GatekeeperInterface::class);
+        $response   = $this->mock(ResponseInterface::class);
+        $output     = $this->mock(ApiOutputInterface::class);
+        $user       = $this->mock(User::class);
+        $playlist   = $this->mock(Playlist::class);
+
+        $objectId = 666;
+
+        $this->mockPlaylist($playlist, $user, $objectId, true, false);
+        $playlist->name = 'some-name';
+        $playlist->type = 'private';
+        $playlist->user = 42;
+
+        $user->shouldReceive('getId')->andReturn(7);
+        $this->privilegeChecker->shouldReceive('check')
+            ->with(AccessTypeEnum::INTERFACE, AccessLevelEnum::ADMIN, 7)
+            ->once()
+            ->andReturnFalse();
+
+        // the tell that the guard fired: the playlist is never written to
+        $playlist->shouldReceive('update')->never();
+
+        $this->expectException(AccessFailedException::class);
+
+        $this->subject->handle(
+            $gatekeeper,
+            $response,
+            $output,
+            ['filter' => (string) $objectId, 'owner' => '1', 'api_format' => 'json', 'auth' => 'some-auth'],
+            $user,
+            $apiVersion
+        );
     }
 
     #[DataProvider(methodName: 'apiVersionProvider')]
@@ -253,10 +339,12 @@ class PlaylistEditMethodTest extends MockeryTestCase
     #[Override]
     protected function setUp(): void
     {
-        $this->modelFactory = $this->mock(ModelFactoryInterface::class);
+        $this->modelFactory     = $this->mock(ModelFactoryInterface::class);
+        $this->privilegeChecker = $this->mock(PrivilegeCheckerInterface::class);
 
         $this->subject = new PlaylistEditMethod(
-            $this->modelFactory
+            $this->modelFactory,
+            $this->privilegeChecker
         );
     }
 

--- a/tests/Module/Api/Method/PlaylistEditMethodTest.php
+++ b/tests/Module/Api/Method/PlaylistEditMethodTest.php
@@ -108,6 +108,49 @@ class PlaylistEditMethodTest extends MockeryTestCase
         );
     }
 
+    /**
+     * A collaborator reordering the playlist may not smuggle a metadata edit in on the same request; the
+     * whole request is refused, and neither the reorder nor the metadata is ever written.
+     */
+    #[DataProvider(methodName: 'apiVersionProvider')]
+    public function testHandleRefusesAMetadataEditBundledWithAReorderFromCollaborator(int $apiVersion): void
+    {
+        $gatekeeper = $this->mock(GatekeeperInterface::class);
+        $response   = $this->mock(ResponseInterface::class);
+        $output     = $this->mock(ApiOutputInterface::class);
+        $user       = $this->mock(User::class);
+        $playlist   = $this->mock(Playlist::class);
+
+        $objectId = 666;
+
+        $this->mockPlaylist($playlist, $user, $objectId, false, true);
+        $playlist->name = 'some-name';
+        $playlist->type = 'private';
+        $playlist->user = 42;
+
+        // neither the reorder nor the metadata write may be reached for a bundled request like this
+        $playlist->shouldReceive('set_by_track_number')->never();
+        $playlist->shouldReceive('update')->never();
+
+        $this->expectException(AccessFailedException::class);
+
+        $this->subject->handle(
+            $gatekeeper,
+            $response,
+            $output,
+            [
+                'filter' => (string) $objectId,
+                'name' => 'new-name',
+                'items' => '1',
+                'tracks' => '1',
+                'api_format' => 'json',
+                'auth' => 'some-auth',
+            ],
+            $user,
+            $apiVersion
+        );
+    }
+
     #[DataProvider(methodName: 'apiVersionProvider')]
     public function testHandleRefusesToHandThePlaylistToSomebodyElse(int $apiVersion): void
     {
@@ -190,6 +233,62 @@ class PlaylistEditMethodTest extends MockeryTestCase
                 $response,
                 $output,
                 ['filter' => (string) $objectId, 'api_format' => 'json', 'auth' => 'some-auth'],
+                $user,
+                $apiVersion
+            )
+        );
+    }
+
+    /**
+     * has_collaborate allows reordering with no ownership of the list at all, and that alone is enough
+     * to save the track order without touching name, type or owner.
+     */
+    #[DataProvider(methodName: 'apiVersionProvider')]
+    public function testHandleSavesAReorderFromACollaboratorWithNoOtherChange(int $apiVersion): void
+    {
+        $gatekeeper = $this->mock(GatekeeperInterface::class);
+        $response   = $this->mock(ResponseInterface::class);
+        $output     = $this->mock(ApiOutputInterface::class);
+        $user       = $this->mock(User::class);
+        $playlist   = $this->mock(Playlist::class);
+        $stream     = $this->mock(StreamInterface::class);
+
+        $objectId = 666;
+        $result   = 'track-result';
+
+        $this->mockPlaylist($playlist, $user, $objectId, false, true);
+
+        $playlist->shouldReceive('set_by_track_number')
+            ->with(9, 1)
+            ->once();
+        $playlist->shouldReceive('update')->never();
+
+        $output->shouldReceive('success')
+            ->with($apiVersion, 'playlist track changes saved')
+            ->once()
+            ->andReturn($result);
+
+        $response->shouldReceive('getBody')
+            ->withNoArgs()
+            ->once()
+            ->andReturn($stream);
+        $stream->shouldReceive('write')
+            ->with($result)
+            ->once();
+
+        $this->assertSame(
+            $response,
+            $this->subject->handle(
+                $gatekeeper,
+                $response,
+                $output,
+                [
+                    'filter' => (string) $objectId,
+                    'items' => '9',
+                    'tracks' => '1',
+                    'api_format' => 'json',
+                    'auth' => 'some-auth',
+                ],
                 $user,
                 $apiVersion
             )

--- a/tests/Module/Api/Method/PlaylistEditMethodTest.php
+++ b/tests/Module/Api/Method/PlaylistEditMethodTest.php
@@ -130,7 +130,7 @@ class PlaylistEditMethodTest extends MockeryTestCase
             ->once()
             ->andReturnFalse();
 
-        // the tell that the guard fired: the playlist is never written to
+        // the tell that the guard fired: the playlist is never written to when reassigning is refused
         $playlist->shouldReceive('update')->never();
 
         $this->expectException(AccessFailedException::class);

--- a/tests/Module/Application/Collection/ShowActionTest.php
+++ b/tests/Module/Application/Collection/ShowActionTest.php
@@ -74,7 +74,7 @@ class ShowActionTest extends MockeryTestCase
     {
         $collection = $this->collection(false);
 
-        // the tell that the guard fired: the members are never read and the head is told nothing
+        // the tell that the guard fired: the members are never read and the head is told nothing at all
         $collection->shouldReceive('get_items')->never();
         $this->guiFactory->shouldReceive('createCollectionViewAdapter')->never();
 

--- a/tests/Module/Application/Collection/ShowActionTest.php
+++ b/tests/Module/Application/Collection/ShowActionTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Module\Application\Collection;
+
+use Ampache\Gui\Collection\CollectionViewAdapterInterface;
+use Ampache\Gui\GuiFactoryInterface;
+use Ampache\Gui\Partial\PageMeta;
+use Ampache\MockeryTestCase;
+use Ampache\Module\Authorization\GuiGatekeeperInterface;
+use Ampache\Module\Database\Query\BrowseFactoryInterface;
+use Ampache\Module\Util\UiInterface;
+use Ampache\Repository\CollectionRepositoryInterface;
+use Ampache\Repository\Model\Collection;
+use Mockery\MockInterface;
+use Override;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+
+class ShowActionTest extends MockeryTestCase
+{
+    private BrowseFactoryInterface&MockInterface $browseFactory;
+    private CollectionRepositoryInterface&MockInterface $collectionRepository;
+    private GuiFactoryInterface&MockInterface $guiFactory;
+    private LoggerInterface&MockInterface $logger;
+    private ShowAction $subject;
+    private UiInterface&MockInterface $ui;
+
+    public function testRunDescribesACollectionTheViewerMaySee(): void
+    {
+        $collection = $this->collection(true);
+        $adapter    = $this->mock(CollectionViewAdapterInterface::class);
+
+        $collection->shouldReceive('get_fullname')->andReturn('Some list');
+        $collection->shouldReceive('getId')->andReturn(7);
+        $collection->shouldReceive('get_items')->andReturn([]);
+        $this->guiFactory->shouldReceive('createCollectionViewAdapter')->once()->andReturn($adapter);
+        $adapter->shouldReceive('render')->once()->andReturn('');
+
+        $this->ui->shouldReceive('showHeader')->once();
+        $this->ui->shouldReceive('showQueryStats')->once();
+        $this->ui->shouldReceive('showFooter')->once();
+
+        ob_start();
+        $this->subject->run($this->request(), $this->mock(GuiGatekeeperInterface::class));
+        ob_end_clean();
+
+        self::assertStringContainsString('og:title" content="Some list"', PageMeta::render());
+    }
+
+    public function testRunSaysNothingAboutACollectionTheViewerMayNotSee(): void
+    {
+        $collection = $this->collection(false);
+
+        // the tell that the guard fired: the members are never read and the head is told nothing
+        $collection->shouldReceive('get_items')->never();
+        $this->guiFactory->shouldReceive('createCollectionViewAdapter')->never();
+
+        $this->ui->shouldReceive('showHeader')->once();
+        $this->ui->shouldReceive('showQueryStats')->once();
+        $this->ui->shouldReceive('showFooter')->once();
+        $this->logger->shouldReceive('warning')->once();
+
+        ob_start();
+        $this->subject->run($this->request(), $this->mock(GuiGatekeeperInterface::class));
+        ob_end_clean();
+
+        self::assertSame('', PageMeta::render());
+    }
+
+    #[Override]
+    protected function setUp(): void
+    {
+        PageMeta::render();
+        unset($GLOBALS['user']);
+
+        $this->ui                   = $this->mock(UiInterface::class);
+        $this->logger               = $this->mock(LoggerInterface::class);
+        $this->collectionRepository = $this->mock(CollectionRepositoryInterface::class);
+        $this->browseFactory        = $this->mock(BrowseFactoryInterface::class);
+        $this->guiFactory           = $this->mock(GuiFactoryInterface::class);
+
+        $this->subject = new ShowAction(
+            $this->ui,
+            $this->logger,
+            $this->collectionRepository,
+            $this->browseFactory,
+            $this->guiFactory
+        );
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        PageMeta::render();
+    }
+
+    private function collection(bool $visible): Collection&MockInterface
+    {
+        $collection = $this->mock(Collection::class);
+        $collection->shouldReceive('isVisible')->with(null)->andReturn($visible);
+        $this->collectionRepository->shouldReceive('findById')->andReturn($collection);
+
+        return $collection;
+    }
+
+    private function request(): ServerRequestInterface&MockInterface
+    {
+        $request = $this->mock(ServerRequestInterface::class);
+        $request->shouldReceive('getQueryParams')->andReturn(['collection' => '7']);
+
+        return $request;
+    }
+}

--- a/tests/Module/Art/ArtFallbackImageTest.php
+++ b/tests/Module/Art/ArtFallbackImageTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Module\Art;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The placeholder a type falls back to. A caller naming its own file drifted from what actually shipped,
+ * so a folder was served nothing at all; the name now comes from one place and every name is checked.
+ */
+class ArtFallbackImageTest extends TestCase
+{
+    private const array SIZES = ['48x48', '128x128', '200x200', '256x256', '384x384', '768x768', '1400x1400', 'original'];
+
+    private const array TYPES = ['album', 'artist', 'folder', 'podcast', 'podcast_episode', 'live_stream'];
+
+    public function testATypeWithItsOwnPlaceholderKeepsItAndTheOthersShareOne(): void
+    {
+        self::assertSame('blankfolder', Art::fallback_image_name('folder'));
+        self::assertSame('blankpodcast', Art::fallback_image_name('podcast'));
+        self::assertSame('blankpodcast', Art::fallback_image_name('podcast_episode'));
+        self::assertSame('blankalbum', Art::fallback_image_name('album'));
+        self::assertSame('blankalbum', Art::fallback_image_name('anything else'));
+    }
+
+    public function testEveryPlaceholderIsShippedInEverySizeItCanBeAskedFor(): void
+    {
+        $images = __DIR__ . '/../../../public/images/';
+        foreach (self::TYPES as $type) {
+            $name = Art::fallback_image_name($type);
+            foreach (self::SIZES as $size) {
+                $file = $images . $name . Art::fallback_size($size) . '.png';
+                self::assertFileExists($file, sprintf('%s asked for %s', $type, $size));
+            }
+        }
+    }
+}

--- a/tests/Module/Share/ShareCreatorTest.php
+++ b/tests/Module/Share/ShareCreatorTest.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Share;
 
+use Ampache\Module\Database\Query\Smartlist;
 use Ampache\Module\System\Plugin\PluginRetrieverInterface;
 use Ampache\Repository\Model\LibraryItemEnum;
 use Ampache\Repository\Model\ModelFactoryInterface;
@@ -105,13 +106,30 @@ class ShareCreatorTest extends TestCase
         $this->modelFactory->method('createPlaylist')
             ->with(42)
             ->willReturn($playlist);
-        $playlist->type = 'private';
-        $playlist->method('has_collaborate')
+        $playlist->method('isVisible')
             ->with($user)
             ->willReturn(false);
 
         self::assertNull(
             $this->subject->create($user, LibraryItemEnum::PLAYLIST, 42)
+        );
+    }
+
+    public function testCreateReturnsNullWhenSharingAPrivateSmartlistYouCannotSee(): void
+    {
+        $user      = $this->createMock(User::class);
+        $smartlist = $this->createMock(Smartlist::class);
+
+        // a saved search is loaded as a smartlist, since the id alone cannot say what it was searching for
+        $this->modelFactory->method('createSmartlist')
+            ->with(42)
+            ->willReturn($smartlist);
+        $smartlist->method('isVisible')
+            ->with($user)
+            ->willReturn(false);
+
+        self::assertNull(
+            $this->subject->create($user, LibraryItemEnum::SEARCH, 42)
         );
     }
 

--- a/tests/Module/Share/ShareCreatorTest.php
+++ b/tests/Module/Share/ShareCreatorTest.php
@@ -24,6 +24,8 @@ namespace Ampache\Module\Share;
 
 use Ampache\Module\System\Plugin\PluginRetrieverInterface;
 use Ampache\Repository\Model\LibraryItemEnum;
+use Ampache\Repository\Model\ModelFactoryInterface;
+use Ampache\Repository\Model\Playlist;
 use Ampache\Repository\Model\User;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -32,6 +34,7 @@ use Psr\Log\LoggerInterface;
 class ShareCreatorTest extends TestCase
 {
     private LoggerInterface&MockObject $logger;
+    private ModelFactoryInterface&MockObject $modelFactory;
     private PluginRetrieverInterface&MockObject $pluginRetriever;
     private ShareCreator $subject;
 
@@ -94,14 +97,34 @@ class ShareCreatorTest extends TestCase
         self::assertNull($result);
     }
 
+    public function testCreateReturnsNullWhenSharingAPrivateListYouCannotSee(): void
+    {
+        $user     = $this->createMock(User::class);
+        $playlist = $this->createMock(Playlist::class);
+
+        $this->modelFactory->method('createPlaylist')
+            ->with(42)
+            ->willReturn($playlist);
+        $playlist->type = 'private';
+        $playlist->method('has_collaborate')
+            ->with($user)
+            ->willReturn(false);
+
+        self::assertNull(
+            $this->subject->create($user, LibraryItemEnum::PLAYLIST, 42)
+        );
+    }
+
     protected function setUp(): void
     {
         $this->pluginRetriever = $this->createMock(PluginRetrieverInterface::class);
         $this->logger          = $this->createMock(LoggerInterface::class);
+        $this->modelFactory    = $this->createMock(ModelFactoryInterface::class);
 
         $this->subject = new ShareCreator(
             $this->pluginRetriever,
             $this->logger,
+            $this->modelFactory,
         );
     }
 }

--- a/tests/Module/Util/BrandingTagsTest.php
+++ b/tests/Module/Util/BrandingTagsTest.php
@@ -152,7 +152,7 @@ class BrandingTagsTest extends TestCase
 
         $tags = $this->tags('', '', '', false);
 
-        // the icons and the site name belong to the instance, not to whatever the page shows
+        // the icons and the site name belong to the instance, not to whatever object the page shows
         self::assertStringContainsString('rel="icon"', $tags);
         self::assertStringContainsString('og:site_name" content="Dogmazic"', $tags);
         self::assertStringNotContainsString('og:image', $tags);

--- a/tests/Module/Util/BrandingTagsTest.php
+++ b/tests/Module/Util/BrandingTagsTest.php
@@ -26,12 +26,13 @@ declare(strict_types=1);
 namespace Ampache\Module\Util;
 
 use Ampache\Config\AmpConfig;
+use Ampache\Gui\Partial\PageMeta;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 
 class BrandingTagsTest extends TestCase
 {
-    private const array KEYS = ['custom_favicon', 'custom_apple_touch_icon', 'custom_share_image', 'site_title', 'site_description', 'web_path'];
+    private const array KEYS = ['custom_favicon', 'custom_apple_touch_icon', 'custom_share_image', 'custom_login_background', 'custom_login_logo', 'site_title', 'site_description', 'web_path'];
 
     private ?string $host = null;
 
@@ -61,6 +62,19 @@ class BrandingTagsTest extends TestCase
         self::assertStringContainsString('og:image" content="/ampache-card.png"', $tags);
     }
 
+    public function testAnObjectPageEmitsItsOwnPreviewAndSilencesTheGenericOne(): void
+    {
+        PageMeta::set(['Some artist'], 'music.album', 'Some album', 'https://music.example/albums.php?album=1', 'https://music.example/image.php?object_id=1');
+
+        $head = $this->head();
+
+        self::assertSame(1, substr_count($head, 'og:image'));
+        self::assertSame(1, substr_count($head, 'og:type'));
+        self::assertStringContainsString('og:type" content="music.album"', $head);
+        self::assertStringContainsString('og:image" content="https://music.example/image.php?object_id=1&amp;nosvg=1"', $head);
+        self::assertStringNotContainsString('ampache-card.png', $head);
+    }
+
     public function testAnUncustomisedInstanceGetsEverythingItShips(): void
     {
         $tags = $this->tags();
@@ -69,6 +83,15 @@ class BrandingTagsTest extends TestCase
         self::assertStringContainsString('/favicon.ico"', $tags);
         self::assertStringContainsString('rel="apple-touch-icon" href="/apple-touch-icon.png"', $tags);
         self::assertStringContainsString('og:image" content="/ampache-card.png"', $tags);
+    }
+
+    public function testAPageWithNothingToSayKeepsTheGenericPreview(): void
+    {
+        $head = $this->head();
+
+        self::assertSame(1, substr_count($head, 'og:image'));
+        self::assertStringContainsString('og:image" content="/ampache-card.png"', $head);
+        self::assertStringContainsString('og:type" content="website"', $head);
     }
 
     public function testAQuotedUrlCannotBreakOutOfTheAttribute(): void
@@ -122,6 +145,22 @@ class BrandingTagsTest extends TestCase
         self::assertStringContainsString('og:description" content="Free music, freely licensed.">', $tags);
     }
 
+    public function testTheGenericCardStandsDownForAPageThatSpeaksForItself(): void
+    {
+        AmpConfig::set('site_title', 'Dogmazic', true);
+        AmpConfig::set('site_description', 'Free music, freely licensed.', true);
+
+        $tags = $this->tags('', '', '', false);
+
+        // the icons and the site name belong to the instance, not to whatever the page shows
+        self::assertStringContainsString('rel="icon"', $tags);
+        self::assertStringContainsString('og:site_name" content="Dogmazic"', $tags);
+        self::assertStringNotContainsString('og:image', $tags);
+        self::assertStringNotContainsString('og:type', $tags);
+        self::assertStringNotContainsString('twitter:card', $tags);
+        self::assertStringNotContainsString('description', $tags);
+    }
+
     public function testTheShareImageIsMadeAbsolute(): void
     {
         // whoever renders the preview fetches it from their own server, where a bare path means nothing
@@ -146,6 +185,7 @@ class BrandingTagsTest extends TestCase
 
     protected function tearDown(): void
     {
+        PageMeta::render();
         foreach ($this->saved as $key => $value) {
             AmpConfig::set($key, $value, true);
         }
@@ -157,12 +197,20 @@ class BrandingTagsTest extends TestCase
         }
     }
 
-    private function tags(string $favicon = '', string $touch = '', string $share = ''): string
+    private function head(): string
+    {
+        ob_start();
+        Ui::show_custom_style();
+
+        return (string) ob_get_clean();
+    }
+
+    private function tags(string $favicon = '', string $touch = '', string $share = '', bool $withSocialCard = true): string
     {
         AmpConfig::set('custom_favicon', $favicon, true);
         AmpConfig::set('custom_apple_touch_icon', $touch, true);
         AmpConfig::set('custom_share_image', $share, true);
 
-        return (string) new ReflectionMethod(Ui::class, 'branding_tags')->invoke(null);
+        return (string) new ReflectionMethod(Ui::class, 'branding_tags')->invoke(null, $withSocialCard);
     }
 }

--- a/tests/Repository/Model/LibraryItemEnumTest.php
+++ b/tests/Repository/Model/LibraryItemEnumTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Ampache\Repository\Model;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class LibraryItemEnumTest extends TestCase
+{
+    /**
+     * @return list<array{string, ?LibraryItemEnum}>
+     */
+    public static function aliases(): array
+    {
+        return [
+            ['album_artist', LibraryItemEnum::ARTIST],
+            ['song_artist', LibraryItemEnum::ARTIST],
+            ['genre', LibraryItemEnum::TAG],
+            ['smartlist', LibraryItemEnum::SEARCH],
+            ['artist', LibraryItemEnum::ARTIST],
+            ['song', LibraryItemEnum::SONG],
+            ['bookmark', null],
+            ['', null],
+        ];
+    }
+
+    #[DataProvider('aliases')]
+    public function testFromObjectTypeResolvesRolesAndAlternateSpellings(string $objectType, ?LibraryItemEnum $expected): void
+    {
+        static::assertSame($expected, LibraryItemEnum::fromObjectType($objectType));
+    }
+}


### PR DESCRIPTION
Wanted to do a quick PR just with security fix and a separate SEO PR

Fail. The SEO needed this PR. For the Folder, the page can only describe itself once it knows the viewer may see it, and that check is a8821f0a4.

twitter:title/description/image are dropped => it fallback to the Open Graph (and it's official)

And for SEO, we can't have SVG art. So, added a nosvg parameters.

Idea: maybe we could allow SVG to be uploaded by user as art?