### PR TITLE
Fix 8.1.0

### DIFF
--- a/docs/CHANGELOG-API.md
+++ b/docs/CHANGELOG-API.md
@@ -1,5 +1,16 @@
 # API CHANGELOG
 
+## API 8.1.1
+
+### Fixed (811000)
+
+* `download` (API8)
+  * A container with nothing downloadable behind it — a release whose songs are all disabled, or files missing from disk — crashed the request instead of answering; it now returns 404
+* `artist`, `artists`, `artist_albums` (ALL)
+  * The albums listed for an artist included the withdrawn ones, for every caller
+* `stats` (ALL)
+  * `recent`, `highest` and `frequent` listed withdrawn releases; only `newest` carried the condition. They now answer the way every other listing does, and a manager still sees them
+
 ## API 8.1.0
 
 ### Added (810000)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed (8.1.1)
 
 * A failed database query threw an exception with no message, so a stack trace named the throw site and nothing about what broke; the statement and the driver error now travel with it
+* `admin:updateDatabase` crashed when preference maintenance ran on a half-migrated schema because it try to work on `user_preference` assuming columns a later migration adds. Now it wait for the schema to be complete
 * The now-playing refresh timer only cleared on `popstate`, so link navigation left it polling `ajax.server.php` in the background long after the page was gone
 * An existing smart playlist had no `Save as Smart Playlist` button to clone it — `smartplaylist.php` never registered the action, unlike the search page
 * A download with nothing to send died on the way out rather than saying so; `ZipArchive::close()` reports success on an archive nothing was added to but writes no file, and an album whose songs are all disabled produces exactly that

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed (8.1.1)
 
+* A failed database query threw an exception with no message, so a stack trace named the throw site and nothing about what broke; the statement and the driver error now travel with it
 * The now-playing refresh timer only cleared on `popstate`, so link navigation left it polling `ajax.server.php` in the background long after the page was gone
 * An existing smart playlist had no `Save as Smart Playlist` button to clone it — `smartplaylist.php` never registered the action, unlike the search page
 * A download with nothing to send died on the way out rather than saying so; `ZipArchive::close()` reports success on an archive nothing was added to but writes no file, and an album whose songs are all disabled produces exactly that

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,17 @@
 
 * The now-playing refresh timer only cleared on `popstate`, so link navigation left it polling `ajax.server.php` in the background long after the page was gone
 * An existing smart playlist had no `Save as Smart Playlist` button to clone it — `smartplaylist.php` never registered the action, unlike the search page
+* A download with nothing to send died on the way out rather than saying so; `ZipArchive::close()` reports success on an archive nothing was added to but writes no file, and an album whose songs are all disabled produces exactly that
+* The proof of work interstitial solved a fresh puzzle on every error the protected endpoint returned, without end, because it replayed a url whose answer had already been spent
+* A share link on a private playlist refused every visitor: the check read `VisibleItemInterface`, which also answers for a list being private, so it turned away the account-less visitor the link exists for
+* A withdrawn album stayed listed on the page of its artist for everybody, and in the api and upnp listings of the same thing; both build their own sql and never reach `Query::_get_filter_sql()`
+* The `Enabled` search rule was offered on album disks and filtered nothing, so a smart list asking for withdrawn releases returned the whole catalogue
+* A disk row gave no sign the release behind it had been withdrawn, unlike an album or artist row, and it is the template the artist page uses when albums are not grouped
+* An artist's "all songs" page hid the withdrawn tracks from a manager as well, giving them a shorter list than the album pages of that same artist
+* Drawn artwork never appeared on an install with `custom_blankalbum` set: the placeholder went straight into the `src` and the request never reached `image.php`
+* The Recent, Popular and Trending widgets, the pages behind them and the `stats` api method served withdrawn releases; only the newest lists carried the condition
+* The recently played lists — the home page, a user's page, the slideshow and the RSS feed — served withdrawn releases as well, and had never carried the condition at all
+* A withdrawn item's row is tinted instead of being told apart by comparing action icons, which read as the opposite state on a song row and on an album row
 
 ## Ampache 8.1.0
 

--- a/docs/DISABLED-ITEMS.md
+++ b/docs/DISABLED-ITEMS.md
@@ -74,12 +74,14 @@ Smart lists reach their rows without a browse and carry the same condition in `A
 `ArtistRepository::getRowsByCatalogs()`, `AlbumRepository::getIdsByCatalogs()` and `getSongs()`,
 `SongRepository::getEnabledIds()`, `getEnabledIdsByCatalog()` and `getEnabledByArtist()` - filter without
 asking anyone's level. `getAllByArtist()` deliberately does not: re-reading the tags of a withdrawn file is
-still a thing a catalogue has to do.
+still a thing a catalogue has to do, and it is also what the artist's "all songs" page reads for a manager.
 
 Anything that resolves an item by id - the object pages and the `album`, `artist` and `song` API methods -
 answers with the response an id that was never there produces, so nothing tells the caller the item exists.
-The tab title and `Share::is_valid()` follow the same rule, through `VisibleItemInterface`, which a private
-list implements for the same reason a withdrawn release does.
+The tab title follows the same rule through `VisibleItemInterface`, which a private list implements for the
+same reason a withdrawn release does. `Share::is_valid()` asks the narrower `WithdrawableInterface`: a share
+link is how a private list gets published to somebody without an account, so reading visibility there would
+refuse every one of those links.
 
 ## Database
 

--- a/docs/DISABLED-ITEMS.md
+++ b/docs/DISABLED-ITEMS.md
@@ -81,7 +81,8 @@ straight to a renderer, which does not filter them again, so `Stats` carries the
 `get_newest_sql()`, `get_recent_sql()` and `get_top_sql()`. Two things there are deliberate: the top list
 leaves it out while writing the `cache_object_count` rows, because that cache is read by everybody
 afterwards and a run made under no level would freeze a truncated list for the whole instance; and a disk
-served from that cache is not filtered, since the cached row holds the disk id and not the album's.
+read back from that cache is keyed on the disk id, so the condition resolves it through `album_disk` to
+reach the album holding the flag rather than comparing a disk id to an album id.
 
 The artist page reads `AlbumRepository::getByArtist()`, and the api and upnp listings of the same thing
 read `getAlbumByArtist()`; neither goes through a browse, so both apply the condition themselves, level

--- a/docs/DISABLED-ITEMS.md
+++ b/docs/DISABLED-ITEMS.md
@@ -76,6 +76,17 @@ Smart lists reach their rows without a browse and carry the same condition in `A
 asking anyone's level. `getAllByArtist()` deliberately does not: re-reading the tags of a withdrawn file is
 still a thing a catalogue has to do, and it is also what the artist's "all songs" page reads for a manager.
 
+The home widgets and the newest, recent and popular pages build their own statements and hand the ids
+straight to a renderer, which does not filter them again, so `Stats` carries the condition itself in
+`get_newest_sql()`, `get_recent_sql()` and `get_top_sql()`. Two things there are deliberate: the top list
+leaves it out while writing the `cache_object_count` rows, because that cache is read by everybody
+afterwards and a run made under no level would freeze a truncated list for the whole instance; and a disk
+served from that cache is not filtered, since the cached row holds the disk id and not the album's.
+
+The artist page reads `AlbumRepository::getByArtist()`, and the api and upnp listings of the same thing
+read `getAlbumByArtist()`; neither goes through a browse, so both apply the condition themselves, level
+exemption included.
+
 Anything that resolves an item by id - the object pages and the `album`, `artist` and `song` API methods -
 answers with the response an id that was never there produces, so nothing tells the caller the item exists.
 The tab title follows the same rule through `VisibleItemInterface`, which a private list implements for the

--- a/public/lib/javascript/pow.js
+++ b/public/lib/javascript/pow.js
@@ -373,16 +373,6 @@
             }
         }
 
-        /** The endpoint answered with a page rather than a file, so show it instead of going back. */
-        function showResponse(url) {
-            if (leaving || !url) {
-                return;
-            }
-
-            stop();
-            window.location.replace(url);
-        }
-
         function goBack() {
             if (leaving) {
                 return;
@@ -411,17 +401,14 @@
 
         if (sink) {
             sink.onload = function () {
-                // Same origin, so the frame's own address is readable and there is nothing to
-                // rebuild; the form action is only there in case a browser withholds it.
-                var shown = form.action;
-
-                try {
-                    shown = sink.contentWindow.location.href || shown;
-                } catch (error) {
-                    shown = form.action;
+                if (leaving) {
+                    return;
                 }
 
-                showResponse(shown);
+                // The answer is spent once it is submitted, so replaying this url would only earn a fresh
+                // challenge to solve, and the next one after that: say so and stop rather than loop.
+                stop();
+                say(text('Failed', 'The download did not start. Please try again.'));
             };
         }
 

--- a/public/lib/javascript/pow.js
+++ b/public/lib/javascript/pow.js
@@ -340,8 +340,8 @@
      * The form targets a hidden iframe, so this document stays loaded: a zip is written in full
      * before its headers are sent, and unloading here would cancel the request. A download never
      * fires `load` on the frame, so a `load` means the endpoint answered with a page instead --
-     * an error, or a fresh challenge -- and the visitor should be looking at it rather than at a
-     * frame they cannot see.
+     * an error, or a fresh challenge -- and the answer that went with it is spent either way, so
+     * there is nothing left to replay and the visitor is told rather than sent round again.
      *
      * Returning waits for the acknowledgement cookie, which arrives with the download headers and at
      * no earlier moment. Before those headers the request is still a navigation the frame owns, and

--- a/public/themes/reborn/templates/default.css
+++ b/public/themes/reborn/templates/default.css
@@ -2326,6 +2326,15 @@ a.option-list:hover {
     color: #c33;
 }
 
+/* a withdrawn item stays listed for whoever may see it, so its row has to read as different at a glance */
+table.tabledata tbody tr.withdrawn > td {
+    background-color: rgb(204 51 51 / 14%);
+}
+
+table.tabledata tbody tr.withdrawn > td:first-child {
+    box-shadow: inset 3px 0 0 #c33;
+}
+
 /* the same state, named again where the kind is read, for anyone who lands mid-page */
 .object-header-badge {
     display: inline-block;

--- a/resources/templates/album_disk_row.phtml
+++ b/resources/templates/album_disk_row.phtml
@@ -82,7 +82,10 @@ if ($this->isUsingRatings()) { ?>
     </td>
 <?php } ?>
     <td class="cel_action">
-<?php if ($album->canPostShout()) { ?>
+<?php if ($album->isDisabled()) {
+    echo $this->raw($album->getDisabledIcon());
+}
+if ($album->canPostShout()) { ?>
         <a href="<?php echo $this->e($album->getPostShoutUrl()); ?>"><?php echo $this->raw($album->getPostShoutIcon()); ?></a>
 <?php }
 if ($album->canShare()) {

--- a/resources/templates/browse/albums.phtml
+++ b/resources/templates/browse/albums.phtml
@@ -60,7 +60,7 @@ if ($browse->is_show_header()) {
     </thead>
     <tbody>
         <?php foreach ($albums as $album) { ?>
-        <tr id="<?php echo $this->e($objectType . '_' . $album->getId()); ?>" class="libitem_menu" data-object-type="<?php echo $this->e($objectType); ?>" data-object-id="<?php echo $this->e($album->getId()); ?>">
+        <tr id="<?php echo $this->e($objectType . '_' . $album->getId()); ?>" class="libitem_menu<?php echo ($album->isEnabled()) ? '' : ' withdrawn'; ?>" data-object-type="<?php echo $this->e($objectType); ?>" data-object-id="<?php echo $this->e($album->getId()); ?>">
             <?php echo $this->raw($this->renderRow($album)); ?>
         </tr>
         <?php } ?>

--- a/resources/templates/browse/artists.phtml
+++ b/resources/templates/browse/artists.phtml
@@ -58,7 +58,7 @@ if ($browse->is_show_header()) {
     </thead>
     <tbody>
         <?php foreach ($artists as $artist) { ?>
-        <tr id="artist_<?php echo $this->e($artist->getId()); ?>" class="libitem_menu" data-object-type="artist" data-object-id="<?php echo $this->e($artist->getId()); ?>">
+        <tr id="artist_<?php echo $this->e($artist->getId()); ?>" class="libitem_menu<?php echo ($artist->isEnabled()) ? '' : ' withdrawn'; ?>" data-object-type="artist" data-object-id="<?php echo $this->e($artist->getId()); ?>">
             <?php echo $this->raw($this->renderRow($artist)); ?>
         </tr>
         <?php } ?>

--- a/resources/templates/browse/songs.phtml
+++ b/resources/templates/browse/songs.phtml
@@ -65,7 +65,7 @@ if ($browse->is_show_header()) {
         </thead>
         <tbody id="sortableplaylist_<?php echo $this->e($tableKey); ?>">
             <?php foreach ($songs as $song) { ?>
-            <tr id="song_<?php echo $this->e($song->getId()); ?>">
+            <tr id="song_<?php echo $this->e($song->getId()); ?>"<?php echo ($song->isEnabled()) ? '' : ' class="withdrawn"'; ?>>
                 <?php if ($this->canMultiselect()) { ?>
                 <td class="cel_select"><?php echo ($showMultiselect) ? '<input type="checkbox" class="multiselect-item" title="' . $this->e(T_('Select')) . '" data-id="' . $this->e($song->getId()) . '" data-type="song" />' : ''; ?></td>
                 <?php } ?>

--- a/resources/templates/pow/widget.phtml
+++ b/resources/templates/pow/widget.phtml
@@ -37,7 +37,8 @@ declare(strict_types=1);
      data-text-passed="<?php echo $this->e(T_('Check passed.')); ?>"
      data-text-unsupported="<?php echo $this->e(T_('Your browser is too old to pass this check.')); ?>"
      data-text-error="<?php echo $this->e(T_('The browser check failed to run. Please reload the page.')); ?>"
-     data-text-started="<?php echo $this->e(T_('Your download has started.')); ?>">
+     data-text-started="<?php echo $this->e(T_('Your download has started.')); ?>"
+     data-text-failed="<?php echo $this->e(T_('The download did not start. Please try again.')); ?>">
     <?php // The text is replaced as the search runs, so it has to be announced, not just repainted.?>
     <p id="pow-status" class="pow-status" role="status" aria-live="polite"><?php echo $this->e(T_('Checking your browser...')); ?></p>
     <noscript>

--- a/resources/templates/song_list_panel.phtml
+++ b/resources/templates/song_list_panel.phtml
@@ -47,7 +47,7 @@ if ($this->areRatingsShown()) {
     </thead>
     <tbody>
         <?php foreach ($songs as $song) { ?>
-        <tr id="song_<?php echo $this->e($song->id); ?>">
+        <tr id="song_<?php echo $this->e($song->id); ?>"<?php echo ($song->isEnabled()) ? '' : ' class="withdrawn"'; ?>>
             <?php echo $this->raw($this->renderRow($song)); ?>
         </tr>
         <?php } ?>

--- a/src/Gui/AlbumDisk/AlbumDiskViewAdapter.php
+++ b/src/Gui/AlbumDisk/AlbumDiskViewAdapter.php
@@ -234,6 +234,11 @@ final readonly class AlbumDiskViewAdapter implements AlbumDiskViewAdapterInterfa
         );
     }
 
+    public function getDisabledIcon(): string
+    {
+        return Ui::get_material_symbol('unpublished', T_('Disabled'));
+    }
+
     public function getDisplayYear(): int
     {
         if ($this->configContainer->get('use_original_year') && $this->albumDisk->original_year) {
@@ -317,6 +322,11 @@ final readonly class AlbumDiskViewAdapter implements AlbumDiskViewAdapterInterfa
     public function getUserFlags(): string
     {
         return Userflag::show($this->albumDisk->getId(), 'album_disk');
+    }
+
+    public function isDisabled(): bool
+    {
+        return !$this->albumDisk->isEnabled();
     }
 
     public function isEditable(): bool

--- a/src/Gui/AlbumDisk/AlbumDiskViewAdapterInterface.php
+++ b/src/Gui/AlbumDisk/AlbumDiskViewAdapterInterface.php
@@ -71,6 +71,8 @@ interface AlbumDiskViewAdapterInterface
 
     public function getDirectplayButton(): string;
 
+    public function getDisabledIcon(): string;
+
     public function getDisplayYear(): int;
 
     public function getEditButtonTitle(): string;
@@ -98,6 +100,8 @@ interface AlbumDiskViewAdapterInterface
     public function getSongCount(): int;
 
     public function getUserFlags(): string;
+
+    public function isDisabled(): bool;
 
     public function isEditable(): bool;
 }

--- a/src/Module/Application/Artist/ShowAllSongsAction.php
+++ b/src/Module/Application/Artist/ShowAllSongsAction.php
@@ -60,10 +60,15 @@ final readonly class ShowAllSongsAction implements ApplicationActionInterface
 
         $artist = $this->modelFactory->createArtist($artistId);
 
+        // a manager reads the withdrawn tracks here the way the album page shows them, rather than a shorter list
+        $songIds = ($gatekeeper->mayAccess(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER))
+            ? $this->songRepository->getAllByArtist($artistId)
+            : $this->songRepository->getEnabledByArtist($artistId);
+
         $this->ui->showHeader();
         echo new ArtistPageView(
             $artist,
-            ['' => $this->songRepository->getEnabledByArtist($artistId)],
+            ['' => $songIds],
             'song',
             $this->browseFactory,
             $gatekeeper->getUser(),

--- a/src/Module/Art/Art.php
+++ b/src/Module/Art/Art.php
@@ -1240,11 +1240,6 @@ class Art extends database_object
             return '';
         }
 
-        $custom = (string) AmpConfig::get('custom_blankalbum', '');
-        if ($custom !== '') {
-            return '';
-        }
-
         return '&generate=1&template=' . rawurlencode($generated->resolveTemplate()->getId());
     }
 

--- a/src/Module/Artist/Deletion/ArtistDeleter.php
+++ b/src/Module/Artist/Deletion/ArtistDeleter.php
@@ -68,7 +68,8 @@ final readonly class ArtistDeleter implements ArtistDeleterInterface
     public function remove(
         Artist $artist,
     ): void {
-        $album_ids = $this->albumRepository->getAlbumByArtist($artist->id);
+        // every album goes with the artist, withdrawn ones included, or they outlive the row they hang off
+        $album_ids = $this->albumRepository->getAlbumByArtist($artist->id, false);
 
         $song_ids = [];
         foreach ($album_ids as $albumId) {

--- a/src/Module/Artist/Tag/ArtistTagUpdater.php
+++ b/src/Module/Artist/Tag/ArtistTagUpdater.php
@@ -52,7 +52,8 @@ final readonly class ArtistTagUpdater implements ArtistTagUpdaterInterface
         Tag::update_tag_list($tags_comma, 'artist', $artist->getId(), ($force_update) ? true : $override_childs);
 
         if ($override_childs || $add_to_childs) {
-            $albums = $this->albumRepository->getAlbumByArtist($artist->id);
+            // a withdrawn album keeps its tags in step with its artist; it is off the shelves, not gone
+            $albums = $this->albumRepository->getAlbumByArtist($artist->id, false);
 
             foreach ($albums as $albumId) {
                 $this->albumTagUpdater->updateTags(

--- a/src/Module/Database/DbaDatabaseConnection.php
+++ b/src/Module/Database/DbaDatabaseConnection.php
@@ -111,7 +111,9 @@ final class DbaDatabaseConnection implements DatabaseConnectionInterface
                 );
             }
 
-            throw new QueryFailedException();
+            // the SQL and the driver error travel with the exception, so a failing query names itself in the
+            // stack trace instead of pointing here with nothing
+            throw new QueryFailedException(trim(Dba::error() . ' ' . $sql));
         }
 
         return $result;

--- a/src/Module/Database/Query/Query.php
+++ b/src/Module/Database/Query/Query.php
@@ -30,6 +30,7 @@ use Ampache\Module\Authorization\Access;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Catalog\Catalog;
+use Ampache\Module\Database\Search\WithdrawnFilter;
 use Ampache\Module\System\AmpError;
 use Ampache\Module\System\Core;
 use Ampache\Module\System\Dba;
@@ -1131,14 +1132,11 @@ class Query
             in_array($type, ['album', 'album_disk', 'artist', 'song'], true)
             && !Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $this->user_id)
         ) {
-            // `album_disk` carries no flag of its own, so it reads the one on the album it belongs to
-            $disabled_sql = ($type === 'album_disk')
-                ? "EXISTS (SELECT 1 FROM `album` AS `album_dis` WHERE `album_dis`.`id` = `album_disk`.`album_id` AND `album_dis`.`enabled` = 1) AND "
-                : sprintf('`%s`.`enabled` = 1 AND ', $type);
+            $enabled_sql = WithdrawnFilter::condition($type) . ' AND ';
 
             $sql .= ($sql === "WHERE")
-                ? ' ' . $disabled_sql
-                : $disabled_sql;
+                ? ' ' . $enabled_sql
+                : $enabled_sql;
         }
 
         // each fragment ends in ' AND ', and a WHERE that collected no filters has to disappear completely

--- a/src/Module/Database/Search/AlbumDiskSearch.php
+++ b/src/Module/Database/Search/AlbumDiskSearch.php
@@ -110,6 +110,9 @@ final class AlbumDiskSearch implements SearchInterface
                     $where[]      = "`album`.`" . $rule[0] . sprintf('` %s ?', $operator_sql);
                     $parameters[] = $input;
                     break;
+                case 'enabled':
+                    $where[] = ($operator_sql == '1') ? "`album`.`enabled` = 1" : "`album`.`enabled` = 0";
+                    break;
                 case 'original_year':
                     $where[]    = sprintf('(`album`.`original_year` %s ? OR (`album`.`original_year` IS NULL AND `album`.`year` %s ?))', $operator_sql, $operator_sql);
                     $parameters = array_merge($parameters, [$input, $input]);

--- a/src/Module/Database/Search/AlbumDiskSearch.php
+++ b/src/Module/Database/Search/AlbumDiskSearch.php
@@ -26,9 +26,6 @@ declare(strict_types=1);
 namespace Ampache\Module\Database\Search;
 
 use Ampache\Config\AmpConfig;
-use Ampache\Module\Authorization\Access;
-use Ampache\Module\Authorization\AccessLevelEnum;
-use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Database\Query\Search;
 
 final class AlbumDiskSearch implements SearchInterface
@@ -646,12 +643,7 @@ final class AlbumDiskSearch implements SearchInterface
             }
         }
 
-        // a withdrawn item is out of a smartlist too, and unlike the catalog test it is never optional
-        if (!Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $search_user_id)) {
-            $where_sql = ($where_sql !== '' && $where_sql !== '0')
-                ? "(" . $where_sql . ") AND EXISTS (SELECT 1 FROM `album` AS `album_dis` WHERE `album_dis`.`id` = `album_disk`.`album_id` AND `album_dis`.`enabled` = 1)"
-                : "EXISTS (SELECT 1 FROM `album` AS `album_dis` WHERE `album_dis`.`id` = `album_disk`.`album_id` AND `album_dis`.`enabled` = 1)";
-        }
+        $where_sql = WithdrawnFilter::apply($where_sql, 'album_disk', $search_user_id);
 
         if ($search->catalog_id) {
             if ($where_sql !== '' && $where_sql !== '0') {

--- a/src/Module/Database/Search/AlbumSearch.php
+++ b/src/Module/Database/Search/AlbumSearch.php
@@ -26,9 +26,6 @@ declare(strict_types=1);
 namespace Ampache\Module\Database\Search;
 
 use Ampache\Config\AmpConfig;
-use Ampache\Module\Authorization\Access;
-use Ampache\Module\Authorization\AccessLevelEnum;
-use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Database\Query\Search;
 
 final class AlbumSearch implements SearchInterface
@@ -640,12 +637,7 @@ final class AlbumSearch implements SearchInterface
             }
         }
 
-        // a withdrawn item is out of a smartlist too, and unlike the catalog test it is never optional
-        if (!Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $search_user_id)) {
-            $where_sql = ($where_sql !== '' && $where_sql !== '0')
-                ? "(" . $where_sql . ") AND `album`.`enabled` = 1"
-                : "`album`.`enabled` = 1";
-        }
+        $where_sql = WithdrawnFilter::apply($where_sql, 'album', $search_user_id);
 
         if ($search->catalog_id) {
             if ($where_sql !== '' && $where_sql !== '0') {

--- a/src/Module/Database/Search/ArtistSearch.php
+++ b/src/Module/Database/Search/ArtistSearch.php
@@ -26,9 +26,6 @@ declare(strict_types=1);
 namespace Ampache\Module\Database\Search;
 
 use Ampache\Config\AmpConfig;
-use Ampache\Module\Authorization\Access;
-use Ampache\Module\Authorization\AccessLevelEnum;
-use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Database\Query\Search;
 
 final readonly class ArtistSearch implements SearchInterface
@@ -617,12 +614,7 @@ final readonly class ArtistSearch implements SearchInterface
             }
         }
 
-        // a withdrawn item is out of a smartlist too, and unlike the catalog test it is never optional
-        if (!Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $search_user_id)) {
-            $where_sql = ($where_sql !== '' && $where_sql !== '0')
-                ? "(" . $where_sql . ") AND `artist`.`enabled` = 1"
-                : "`artist`.`enabled` = 1";
-        }
+        $where_sql = WithdrawnFilter::apply($where_sql, 'artist', $search_user_id);
 
         if ($search->catalog_id) {
             if ($where_sql !== '' && $where_sql !== '0') {

--- a/src/Module/Database/Search/SongSearch.php
+++ b/src/Module/Database/Search/SongSearch.php
@@ -26,9 +26,6 @@ declare(strict_types=1);
 namespace Ampache\Module\Database\Search;
 
 use Ampache\Config\AmpConfig;
-use Ampache\Module\Authorization\Access;
-use Ampache\Module\Authorization\AccessLevelEnum;
-use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Database\Query\Search;
 
 final class SongSearch implements SearchInterface
@@ -819,12 +816,7 @@ final class SongSearch implements SearchInterface
             }
         }
 
-        // a withdrawn item is out of a smartlist too, and unlike the catalog test it is never optional
-        if (!Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $search_user_id)) {
-            $where_sql = ($where_sql !== '' && $where_sql !== '0')
-                ? "(" . $where_sql . ") AND `song`.`enabled` = 1"
-                : "`song`.`enabled` = 1";
-        }
+        $where_sql = WithdrawnFilter::apply($where_sql, 'song', $search_user_id);
 
         if ($join['catalog_map']) {
             if ($where_sql !== '' && $where_sql !== '0') {

--- a/src/Module/Database/Search/WithdrawnFilter.php
+++ b/src/Module/Database/Search/WithdrawnFilter.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Module\Database\Search;
+
+use Ampache\Module\Authorization\Access;
+use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\AccessTypeEnum;
+
+/**
+ * The condition that keeps a withdrawn release out of a listing, in one place.
+ *
+ * A browse gets it from `Query::_get_filter_sql()` and a smart list from the four search classes, which is
+ * four ways into the same rule; written out at each of them, one is eventually missed the way `album_songs`
+ * and the artist page were.
+ */
+final class WithdrawnFilter
+{
+    /**
+     * Adds the condition to a where clause already built, unless the viewer is allowed to see withdrawn items
+     */
+    public static function apply(string $whereSql, string $type, ?int $userId): string
+    {
+        if (Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $userId)) {
+            return $whereSql;
+        }
+
+        $condition = self::condition($type);
+
+        return ($whereSql !== '' && $whereSql !== '0')
+            ? '(' . $whereSql . ') AND ' . $condition
+            : $condition;
+    }
+
+    /**
+     * A disk carries no flag of its own and reads the one on the album it belongs to.
+     *
+     * `$idColumn` is what the statement already has to correlate on, and null says it reads the table holding
+     * the flag itself, which is the difference between naming the column and going through a subquery.
+     */
+    public static function condition(string $type, ?string $idColumn = null): string
+    {
+        [$table, $column] = ($type === 'album_disk')
+            ? ['album', $idColumn ?? '`album_disk`.`album_id`']
+            : [$type, $idColumn];
+
+        if (!in_array($table, ['album', 'artist', 'song'], true)) {
+            return '';
+        }
+
+        // the subquery always aliases its table: a caller that joins the same one outside would otherwise
+        // shadow it, which is why the disk condition was written with an alias in the first place
+        return ($column === null)
+            ? sprintf('`%s`.`enabled` = 1', $table)
+            : sprintf(
+                'EXISTS (SELECT 1 FROM `%1$s` AS `%1$s_wd` WHERE `%1$s_wd`.`id` = %2$s AND `%1$s_wd`.`enabled` = 1)',
+                $table,
+                $column
+            );
+    }
+}

--- a/src/Module/Database/Search/WithdrawnFilter.php
+++ b/src/Module/Database/Search/WithdrawnFilter.php
@@ -62,6 +62,15 @@ final class WithdrawnFilter
      */
     public static function condition(string $type, ?string $idColumn = null): string
     {
+        // a disk id has to be resolved to its album before the flag can be read, which is a second hop the
+        // plain form cannot make; `album_disk` here means "this column holds a disk id", not a table to read
+        if ($type === 'album_disk' && $idColumn !== null && !str_contains($idColumn, '`album_disk`.`album_id`')) {
+            return sprintf(
+                'EXISTS (SELECT 1 FROM `album_disk` AS `disk_wd` JOIN `album` AS `album_wd` ON `album_wd`.`id` = `disk_wd`.`album_id` WHERE `disk_wd`.`id` = %s AND `album_wd`.`enabled` = 1)',
+                $idColumn
+            );
+        }
+
         [$table, $column] = ($type === 'album_disk')
             ? ['album', $idColumn ?? '`album_disk`.`album_id`']
             : [$type, $idColumn];
@@ -79,5 +88,15 @@ final class WithdrawnFilter
                 $table,
                 $column
             );
+    }
+
+    /**
+     * The same question with the level asked first, for a caller that has a viewer rather than a where clause
+     */
+    public static function conditionFor(string $type, ?string $idColumn, ?int $userId): string
+    {
+        return (Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $userId))
+            ? ''
+            : self::condition($type, $idColumn);
     }
 }

--- a/src/Module/Statistics/Stats.php
+++ b/src/Module/Statistics/Stats.php
@@ -546,7 +546,7 @@ final class Stats
 
         // the newest lists reach the home page and the feeds without going through a browse, so the
         // withdrawn items have to be dropped here as well
-        $withdrawn = self::_withdrawnSql($base_type, null, $user?->getId());
+        $withdrawn = WithdrawnFilter::conditionFor($base_type, null, $user?->getId());
         if ($withdrawn !== '') {
             $where[] = $withdrawn;
         }
@@ -748,7 +748,7 @@ final class Stats
         }
 
         // the recent widgets and the api hand these ids to a renderer as they are, so nothing filters them later
-        $withdrawn = self::_withdrawnSql(
+        $withdrawn = WithdrawnFilter::conditionFor(
             ($input_type === 'album_disk') ? 'album' : $type,
             '`object_count`.`object_id`',
             ($filter_user instanceof User) ? $filter_user->getId() : null
@@ -841,6 +841,23 @@ final class Stats
             $sql .= ($allowed === [])
                 ? "AND 1 = 0 "
                 : "AND `object_count`.`user` IN (" . implode(', ', $allowed) . ") ";
+        }
+
+        // the type varies row by row here, so each flag is asked for only of the rows that carry that type
+        $viewer = Core::get_global('user');
+        foreach (['album', 'album_disk', 'artist', 'song'] as $withdrawnType) {
+            if (!str_contains($object_string, sprintf("'%s'", $withdrawnType))) {
+                continue;
+            }
+
+            $withdrawn = WithdrawnFilter::conditionFor(
+                $withdrawnType,
+                '`object_count`.`object_id`',
+                ($viewer instanceof User) ? $viewer->getId() : null
+            );
+            if ($withdrawn !== '') {
+                $sql .= sprintf("AND (`object_count`.`object_type` <> '%s' OR %s) ", $withdrawnType, $withdrawn);
+            }
         }
 
         $sql .= "ORDER BY `date` DESC LIMIT " . $limit;
@@ -1000,7 +1017,7 @@ final class Stats
             && in_array($type, ['album', 'album_disk', 'artist', 'song', 'genre', 'catalog', 'live_stream', 'video', 'podcast', 'podcast_episode', 'playlist'], true)
         ) {
             $sql       = "SELECT `object_id` AS `id`, MAX(`count`) AS `count` FROM `cache_object_count` WHERE `object_type` = '" . $type . "' AND `count_type` = '" . $count_type . "' AND `threshold` = '" . $threshold . "'";
-            $withdrawn = self::_withdrawnSql($type, '`cache_object_count`.`object_id`', $filter_user?->getId());
+            $withdrawn = WithdrawnFilter::conditionFor($type, '`cache_object_count`.`object_id`', $filter_user?->getId());
             if ($withdrawn !== '') {
                 $sql .= ' AND ' . $withdrawn;
             }
@@ -1051,8 +1068,8 @@ final class Stats
             // `$type` is rewritten above, and the cache written here is read by everybody afterwards
             if (!$addAdditionalColumns) {
                 $withdrawn = ($input_type === 'album_disk')
-                    ? self::_withdrawnSql('album', '`album_disk`.`album_id`', $filter_user?->getId())
-                    : self::_withdrawnSql($type, '`object_count`.`object_id`', $filter_user?->getId());
+                    ? WithdrawnFilter::conditionFor('album', '`album_disk`.`album_id`', $filter_user?->getId())
+                    : WithdrawnFilter::conditionFor($type, '`object_count`.`object_id`', $filter_user?->getId());
                 if ($withdrawn !== '') {
                     $sql .= ' AND ' . $withdrawn;
                 }
@@ -1437,7 +1454,7 @@ final class Stats
         }
 
         // the widget hands these ids straight to a browse renderer, which never filters them again
-        $withdrawn = self::_withdrawnSql(
+        $withdrawn = WithdrawnFilter::conditionFor(
             ($input_type === 'album_disk') ? 'album' : $type,
             ($input_type === 'album_disk') ? '`album_disk`.`album_id`' : null,
             ($filter_user instanceof User) ? $filter_user->getId() : null
@@ -1517,17 +1534,6 @@ final class Stats
                 Dba::write(sprintf('UPDATE `folder` SET `total_skip` = %s WHERE `id` IN (%s);', $decrement, implode(', ', $folder_ids)));
             }
         }
-    }
-
-    /**
-     * The withdrawal correlates on whichever id the query already carries, so a statement built on
-     * `object_count` drops a release taken off the shelves without joining the table that holds the flag.
-     */
-    private static function _withdrawnSql(string $table, ?string $idColumn, ?int $userId): string
-    {
-        return (Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $userId))
-            ? ''
-            : WithdrawnFilter::condition($table, $idColumn);
     }
 
     /**

--- a/src/Module/Statistics/Stats.php
+++ b/src/Module/Statistics/Stats.php
@@ -745,6 +745,16 @@ final class Stats
             $body .= " AND" . Catalog::get_user_filter('object_count_' . $type, $filter_user->getId());
         }
 
+        // the recent widgets and the api hand these ids to a renderer as they are, so nothing filters them later
+        $withdrawn = self::_withdrawnSql(
+            ($input_type === 'album_disk') ? 'album' : $type,
+            '`object_count`.`object_id`',
+            ($filter_user instanceof User) ? $filter_user->getId() : null
+        );
+        if ($withdrawn !== '') {
+            $body .= ' AND ' . $withdrawn;
+        }
+
         // album_disk rows are keyed on the joined table, everything else filters the object_count id directly
         $catalog_sql = Catalog::get_catalog_id_filter($input_type, $id_column, $catalog_id);
         if ($catalog_sql !== '') {
@@ -987,7 +997,13 @@ final class Stats
             && !$addAdditionalColumns
             && in_array($type, ['album', 'album_disk', 'artist', 'song', 'genre', 'catalog', 'live_stream', 'video', 'podcast', 'podcast_episode', 'playlist'], true)
         ) {
-            $sql   = "SELECT `object_id` AS `id`, MAX(`count`) AS `count` FROM `cache_object_count` WHERE `object_type` = '" . $type . "' AND `count_type` = '" . $count_type . "' AND `threshold` = '" . $threshold . "' GROUP BY `object_id`, `object_type`";
+            $sql       = "SELECT `object_id` AS `id`, MAX(`count`) AS `count` FROM `cache_object_count` WHERE `object_type` = '" . $type . "' AND `count_type` = '" . $count_type . "' AND `threshold` = '" . $threshold . "'";
+            $withdrawn = self::_withdrawnSql($type, '`cache_object_count`.`object_id`', $filter_user?->getId());
+            if ($withdrawn !== '') {
+                $sql .= ' AND ' . $withdrawn;
+            }
+
+            $sql .= " GROUP BY `object_id`, `object_type`";
             $group = '`object_id`';
         } else {
             $is_podcast = ($type === 'podcast');
@@ -1028,6 +1044,16 @@ final class Stats
                 $sql .= " WHERE `object_count`.`object_type` = '" . $type . "' AND `object_count`.`user` = " . $user->getId();
             } else {
                 $sql .= " WHERE `object_count`.`object_type` = '" . $type . "' ";
+            }
+
+            // `$type` is rewritten above, and the cache written here is read by everybody afterwards
+            if (!$addAdditionalColumns) {
+                $withdrawn = ($input_type === 'album_disk')
+                    ? self::_withdrawnSql('album', '`album_disk`.`album_id`', $filter_user?->getId())
+                    : self::_withdrawnSql($type, '`object_count`.`object_id`', $filter_user?->getId());
+                if ($withdrawn !== '') {
+                    $sql .= ' AND ' . $withdrawn;
+                }
             }
 
             if ($by_user && $filter_user?->id > 0) {
@@ -1408,6 +1434,16 @@ final class Stats
             $where[] = $catalog_sql;
         }
 
+        // the widget hands these ids straight to a browse renderer, which never filters them again
+        $withdrawn = self::_withdrawnSql(
+            ($input_type === 'album_disk') ? 'album' : $type,
+            ($input_type === 'album_disk') ? '`album_disk`.`album_id`' : $idColumn,
+            ($filter_user instanceof User) ? $filter_user->getId() : null
+        );
+        if ($withdrawn !== '') {
+            $where[] = $withdrawn;
+        }
+
         return sprintf(
             'SELECT %s AS `id`, %s AS `date` FROM `%s` WHERE %s ORDER BY %s %s, %s',
             $idColumn,
@@ -1479,6 +1515,29 @@ final class Stats
                 Dba::write(sprintf('UPDATE `folder` SET `total_skip` = %s WHERE `id` IN (%s);', $decrement, implode(', ', $folder_ids)));
             }
         }
+    }
+
+    /**
+     * The withdrawal correlates on whichever id the query already carries, so a statement built on
+     * `object_count` drops a release taken off the shelves without joining the table that holds the flag.
+     */
+    private static function _withdrawnSql(string $table, string $idColumn, ?int $userId): string
+    {
+        if (
+            !in_array($table, ['album', 'artist', 'song'], true)
+            || Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $userId)
+        ) {
+            return '';
+        }
+
+        // a statement already reading that table says so directly; the subquery is for the ones that do not join it
+        return ($idColumn === sprintf('`%s`.`id`', $table))
+            ? sprintf('`%s`.`enabled` = 1', $table)
+            : sprintf(
+                'EXISTS (SELECT 1 FROM `%1$s` WHERE `%1$s`.`id` = %2$s AND `%1$s`.`enabled` = 1)',
+                $table,
+                $idColumn
+            );
     }
 
     /**

--- a/src/Module/Statistics/Stats.php
+++ b/src/Module/Statistics/Stats.php
@@ -30,6 +30,7 @@ use Ampache\Module\Authorization\Access;
 use Ampache\Module\Authorization\AccessLevelEnum;
 use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Catalog\Catalog;
+use Ampache\Module\Database\Search\WithdrawnFilter;
 use Ampache\Module\System\Core;
 use Ampache\Module\System\Dba;
 use Ampache\Module\System\LegacyLogger;
@@ -545,8 +546,9 @@ final class Stats
 
         // the newest lists reach the home page and the feeds without going through a browse, so the
         // withdrawn items have to be dropped here as well
-        if (in_array($base_type, ['album', 'artist', 'song'], true) && !Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $user?->getId())) {
-            $where[] = sprintf('`%s`.`enabled` = 1', $base_type);
+        $withdrawn = self::_withdrawnSql($base_type, null, $user?->getId());
+        if ($withdrawn !== '') {
+            $where[] = $withdrawn;
         }
 
         //debug_event(self::class, 'get_newest_sql ' . $sql, 5);
@@ -1437,7 +1439,7 @@ final class Stats
         // the widget hands these ids straight to a browse renderer, which never filters them again
         $withdrawn = self::_withdrawnSql(
             ($input_type === 'album_disk') ? 'album' : $type,
-            ($input_type === 'album_disk') ? '`album_disk`.`album_id`' : $idColumn,
+            ($input_type === 'album_disk') ? '`album_disk`.`album_id`' : null,
             ($filter_user instanceof User) ? $filter_user->getId() : null
         );
         if ($withdrawn !== '') {
@@ -1521,23 +1523,11 @@ final class Stats
      * The withdrawal correlates on whichever id the query already carries, so a statement built on
      * `object_count` drops a release taken off the shelves without joining the table that holds the flag.
      */
-    private static function _withdrawnSql(string $table, string $idColumn, ?int $userId): string
+    private static function _withdrawnSql(string $table, ?string $idColumn, ?int $userId): string
     {
-        if (
-            !in_array($table, ['album', 'artist', 'song'], true)
-            || Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $userId)
-        ) {
-            return '';
-        }
-
-        // a statement already reading that table says so directly; the subquery is for the ones that do not join it
-        return ($idColumn === sprintf('`%s`.`id`', $table))
-            ? sprintf('`%s`.`enabled` = 1', $table)
-            : sprintf(
-                'EXISTS (SELECT 1 FROM `%1$s` WHERE `%1$s`.`id` = %2$s AND `%1$s`.`enabled` = 1)',
-                $table,
-                $idColumn
-            );
+        return (Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $userId))
+            ? ''
+            : WithdrawnFilter::condition($table, $idColumn);
     }
 
     /**

--- a/src/Module/System/Dba.php
+++ b/src/Module/System/Dba.php
@@ -44,7 +44,7 @@ class Dba
     /** @var array<string, int> $stats  */
     public static array $stats = ['query' => 0];
 
-    private static string $_error;
+    private static string $_error = '';
     private static string $_sql;
 
     /**

--- a/src/Module/System/Preference.php
+++ b/src/Module/System/Preference.php
@@ -1412,6 +1412,13 @@ class Preference extends database_object
         $repository       = self::getPreferenceRepository();
         $filterRepository = self::getCatalogFilterRepository();
 
+        // every repair below assumes the final schema, `user_preference`.`name` first of all, which a migration
+        // adds late. On a database still mid-upgrade that column is not there yet and there is nothing to repair,
+        // so leave it: the migrations finish and a later rebuild runs against the complete schema
+        if (!$repository->hasUserPreferenceName()) {
+            return;
+        }
+
         // These repair the install rather than one listener, and each reads the whole table: running them
         // once per user turned a rebuild on a large database into hours of the same three statements.
 

--- a/src/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapter.php
+++ b/src/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapter.php
@@ -52,6 +52,23 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
     ) {}
 
     /**
+     * The objects that can hold a media's art, most specific first
+     *
+     * has_art() answers for the parent (a song's album, an episode's podcast), so asking url() for the
+     * media itself served the placeholder for every song whose album holds the cover.
+     *
+     * @return list<array{string, int}>
+     */
+    public static function artSources(Song|Podcast_Episode $media): array
+    {
+        $sources = ($media instanceof Song)
+            ? [['song', $media->getId()], ['album', $media->album]]
+            : [['podcast_episode', $media->getId()], ['podcast', $media->podcast ?? 0]];
+
+        return array_values(array_filter($sources, static fn(array $source): bool => $source[1] > 0));
+    }
+
+    /**
      * Returns the itunes author of the item
      */
     public function getAuthor(): string
@@ -271,14 +288,16 @@ final readonly class PlayableItemRssItemAdapter implements RssItemInterface
     }
 
     /**
-     * Art of a single episode, its own if it has any, the feed art otherwise
+     * Art of a single media, its own if it has any, its parent's next, the feed art otherwise
      */
     private function getMediaImageUrl(Song|Podcast_Episode $media): string
     {
-        $type = $media->getMediaType()->value;
+        foreach (self::artSources($media) as [$type, $id]) {
+            if (Art::has_db($id, $type)) {
+                return Art::url($id, $type, null, 700) ?? $this->getImageUrl();
+            }
+        }
 
-        return ($media->has_art())
-            ? (Art::url($media->getId(), $type, null, 700) ?? $this->getImageUrl())
-            : $this->getImageUrl();
+        return $this->getImageUrl();
     }
 }

--- a/src/Module/Util/ZipHandler.php
+++ b/src/Module/Util/ZipHandler.php
@@ -147,6 +147,16 @@ final class ZipHandler implements ZipHandlerInterface
 
         $arc->close();
 
+        // an archive nothing was added to is never written, so streaming it would open a file that is not there
+        if (!is_file((string) $this->zipFile)) {
+            $this->logger->warning(
+                'Nothing left to zip for ' . $archiveName,
+                [LegacyLogger::CONTEXT_TYPE => self::class]
+            );
+
+            return $response->withStatus(404);
+        }
+
         $this->logger->debug(
             'Sending Zip ' . $archiveName,
             [LegacyLogger::CONTEXT_TYPE => self::class]

--- a/src/Module/Util/ZipHandlerInterface.php
+++ b/src/Module/Util/ZipHandlerInterface.php
@@ -43,6 +43,8 @@ interface ZipHandlerInterface
      * takes array of full paths to medias
      * zips them and sends them
      *
+     * Answers 404 when nothing could be added, which is what a withdrawn release or a missing file leaves behind.
+     *
      * @param string $name name of the zip file to be created
      * @param array{total_size: int, files: iterable<iterable<string>>} $files array of full paths to medias to zip create w/ call to get_media_files
      * @param bool $flat_path put the files into a single folder

--- a/src/Repository/AlbumRepository.php
+++ b/src/Repository/AlbumRepository.php
@@ -27,6 +27,9 @@ namespace Ampache\Repository;
 
 use Ampache\Config\AmpConfig;
 use Ampache\Config\ConfigurationKeyEnum;
+use Ampache\Module\Authorization\Access;
+use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Catalog\Catalog;
 use Ampache\Module\Database\database_object;
 use Ampache\Module\Database\DatabaseConnectionInterface;
@@ -371,6 +374,7 @@ final readonly class AlbumRepository implements AlbumRepositoryInterface
     ): array {
         $userId        = Core::get_global('user')?->getId();
         $catalog_where = "AND `album`.`catalog` IN (" . implode(',', Catalog::get_catalogs('', $userId, true)) . ")";
+        $catalog_where .= $this->withdrawnAlbumSql($userId);
 
         $original_year = (AmpConfig::get('use_original_year'))
             ? "IFNULL(`album`.`original_year`, `album`.`year`)"
@@ -433,6 +437,8 @@ final readonly class AlbumRepository implements AlbumRepositoryInterface
             $catalog_where = 'AND `album`.`catalog` = ?';
             $params[]      = $catalogId;
         }
+
+        $catalog_where .= $this->withdrawnAlbumSql($userId);
 
         $original_year = (AmpConfig::get('use_original_year'))
             ? "IFNULL(`album`.`original_year`, `album`.`year`)"
@@ -1259,5 +1265,16 @@ final readonly class AlbumRepository implements AlbumRepositoryInterface
                 [LegacyLogger::CONTEXT_TYPE => self::class]
             );
         }
+    }
+
+    /**
+     * The artist page and the API listings below never reach Query::_get_filter_sql(), so they read the
+     * withdrawal themselves; a manager keeps seeing the release, marked, the way every other listing shows it.
+     */
+    private function withdrawnAlbumSql(?int $userId): string
+    {
+        return (Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $userId))
+            ? ''
+            : ' AND `album`.`enabled` = 1';
     }
 }

--- a/src/Repository/AlbumRepository.php
+++ b/src/Repository/AlbumRepository.php
@@ -34,6 +34,7 @@ use Ampache\Module\Catalog\Catalog;
 use Ampache\Module\Database\database_object;
 use Ampache\Module\Database\DatabaseConnectionInterface;
 use Ampache\Module\Database\Exception\DatabaseException;
+use Ampache\Module\Database\Search\WithdrawnFilter;
 use Ampache\Module\System\Core;
 use Ampache\Module\System\LegacyLogger;
 use Ampache\Repository\Model\Album;
@@ -1268,13 +1269,13 @@ final readonly class AlbumRepository implements AlbumRepositoryInterface
     }
 
     /**
-     * The artist page and the API listings below never reach Query::_get_filter_sql(), so they read the
-     * withdrawal themselves; a manager keeps seeing the release, marked, the way every other listing shows it.
+     * The artist page and the api listing of the same thing never reach Query::_get_filter_sql(), so they read
+     * the withdrawal themselves; a manager keeps seeing the release, marked, the way every other listing does.
      */
     private function withdrawnAlbumSql(?int $userId): string
     {
         return (Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $userId))
             ? ''
-            : ' AND `album`.`enabled` = 1';
+            : ' AND ' . WithdrawnFilter::condition('album');
     }
 }

--- a/src/Repository/AlbumRepository.php
+++ b/src/Repository/AlbumRepository.php
@@ -27,9 +27,6 @@ namespace Ampache\Repository;
 
 use Ampache\Config\AmpConfig;
 use Ampache\Config\ConfigurationKeyEnum;
-use Ampache\Module\Authorization\Access;
-use Ampache\Module\Authorization\AccessLevelEnum;
-use Ampache\Module\Authorization\AccessTypeEnum;
 use Ampache\Module\Catalog\Catalog;
 use Ampache\Module\Database\database_object;
 use Ampache\Module\Database\DatabaseConnectionInterface;
@@ -372,10 +369,14 @@ final readonly class AlbumRepository implements AlbumRepositoryInterface
      */
     public function getAlbumByArtist(
         int $artistId,
+        bool $enabledOnly = true,
     ): array {
         $userId        = Core::get_global('user')?->getId();
         $catalog_where = "AND `album`.`catalog` IN (" . implode(',', Catalog::get_catalogs('', $userId, true)) . ")";
-        $catalog_where .= $this->withdrawnAlbumSql($userId);
+        if ($enabledOnly) {
+            $withdrawn = WithdrawnFilter::conditionFor('album', null, $userId);
+            $catalog_where .= ($withdrawn === '') ? '' : ' AND ' . $withdrawn;
+        }
 
         $original_year = (AmpConfig::get('use_original_year'))
             ? "IFNULL(`album`.`original_year`, `album`.`year`)"
@@ -439,7 +440,8 @@ final readonly class AlbumRepository implements AlbumRepositoryInterface
             $params[]      = $catalogId;
         }
 
-        $catalog_where .= $this->withdrawnAlbumSql($userId);
+        $withdrawn = WithdrawnFilter::conditionFor('album', null, $userId);
+        $catalog_where .= ($withdrawn === '') ? '' : ' AND ' . $withdrawn;
 
         $original_year = (AmpConfig::get('use_original_year'))
             ? "IFNULL(`album`.`original_year`, `album`.`year`)"
@@ -1266,16 +1268,5 @@ final readonly class AlbumRepository implements AlbumRepositoryInterface
                 [LegacyLogger::CONTEXT_TYPE => self::class]
             );
         }
-    }
-
-    /**
-     * The artist page and the api listing of the same thing never reach Query::_get_filter_sql(), so they read
-     * the withdrawal themselves; a manager keeps seeing the release, marked, the way every other listing does.
-     */
-    private function withdrawnAlbumSql(?int $userId): string
-    {
-        return (Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $userId))
-            ? ''
-            : ' AND ' . WithdrawnFilter::condition('album');
     }
 }

--- a/src/Repository/AlbumRepositoryInterface.php
+++ b/src/Repository/AlbumRepositoryInterface.php
@@ -103,6 +103,7 @@ interface AlbumRepositoryInterface
      */
     public function getAlbumByArtist(
         int $artistId,
+        bool $enabledOnly = true,
     ): array;
 
     /**

--- a/src/Repository/Model/Album.php
+++ b/src/Repository/Model/Album.php
@@ -54,6 +54,7 @@ use Exception;
 class Album extends database_object implements
     library_item,
     VisibleItemInterface,
+    WithdrawableInterface,
     displayable_item,
     container_item,
     CatalogItemInterface

--- a/src/Repository/Model/Album.php
+++ b/src/Repository/Model/Album.php
@@ -59,6 +59,8 @@ class Album extends database_object implements
     container_item,
     CatalogItemInterface
 {
+    use WithdrawableTrait;
+
     protected const string DB_TABLENAME = 'album';
 
     /** @var array<string, int> keyed by `check()`'s identity-column cache key, see there */
@@ -998,20 +1000,9 @@ class Album extends database_object implements
         return $this->has_art ?? false;
     }
 
-    public function isEnabled(): bool
-    {
-        return $this->enabled;
-    }
-
     public function isNew(): bool
     {
         return $this->getId() === 0;
-    }
-
-    public function isVisible(?User $user = null): bool
-    {
-        return $this->enabled
-            || ($user instanceof User && Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $user->getId()));
     }
 
     /**

--- a/src/Repository/Model/AlbumDisk.php
+++ b/src/Repository/Model/AlbumDisk.php
@@ -40,6 +40,7 @@ use Ampache\Repository\SongRepositoryInterface;
 class AlbumDisk extends database_object implements
     library_item,
     VisibleItemInterface,
+    WithdrawableInterface,
     displayable_item,
     container_item,
     CatalogItemInterface

--- a/src/Repository/Model/Artist.php
+++ b/src/Repository/Model/Artist.php
@@ -49,6 +49,7 @@ use Ampache\Repository\UserActivityRepositoryInterface;
 class Artist extends database_object implements
     library_item,
     VisibleItemInterface,
+    WithdrawableInterface,
     displayable_item,
     container_item,
     CatalogItemInterface

--- a/src/Repository/Model/Artist.php
+++ b/src/Repository/Model/Artist.php
@@ -54,6 +54,8 @@ class Artist extends database_object implements
     container_item,
     CatalogItemInterface
 {
+    use WithdrawableTrait;
+
     protected const string DB_TABLENAME = 'artist';
 
     private static array $_mapcache = [];
@@ -952,20 +954,9 @@ class Artist extends database_object implements
         return $this->has_art;
     }
 
-    public function isEnabled(): bool
-    {
-        return $this->enabled;
-    }
-
     public function isNew(): bool
     {
         return $this->getId() === 0;
-    }
-
-    public function isVisible(?User $user = null): bool
-    {
-        return $this->enabled
-            || ($user instanceof User && Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $user->getId()));
     }
 
     /**

--- a/src/Repository/Model/Share.php
+++ b/src/Repository/Model/Share.php
@@ -358,7 +358,7 @@ class Share extends database_object
         // a link handed out before a takedown must stop working with it, and the visitor has no account to
         // hold a level, so the withdrawal is read here rather than by asking who is on the other end
         $object = $this->getLibraryItemLoader()->load($this->getObjectType(), $this->object_id);
-        if ($object instanceof VisibleItemInterface && !$object->isVisible()) {
+        if ($object instanceof WithdrawableInterface && !$object->isEnabled()) {
             debug_event(self::class, 'Access Denied: shared object withdrawn ' . $this->id . '.', 3);
 
             return false;

--- a/src/Repository/Model/Song.php
+++ b/src/Repository/Model/Song.php
@@ -67,6 +67,7 @@ use Traversable;
 class Song extends database_object implements
     Media,
     VisibleItemInterface,
+    WithdrawableInterface,
     displayable_item,
     container_item,
     GarbageCollectibleInterface,
@@ -2124,6 +2125,11 @@ class Song extends database_object implements
         }
 
         return $this->has_art ?? false;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
     }
 
     public function isNew(): bool

--- a/src/Repository/Model/Song.php
+++ b/src/Repository/Model/Song.php
@@ -74,6 +74,8 @@ class Song extends database_object implements
     CatalogItemInterface,
     MetadataEnabledInterface
 {
+    use WithdrawableTrait;
+
     // the value a player or an api response passes to fill_ext_info() for the scalars, without the comment or lyrics
     public const string PARTIAL_FILTER  = 'partial';
     protected const string DB_TABLENAME = 'song';
@@ -2127,20 +2129,9 @@ class Song extends database_object implements
         return $this->has_art ?? false;
     }
 
-    public function isEnabled(): bool
-    {
-        return $this->enabled;
-    }
-
     public function isNew(): bool
     {
         return $this->getId() === 0;
-    }
-
-    public function isVisible(?User $user = null): bool
-    {
-        return $this->enabled
-            || ($user instanceof User && Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $user->getId()));
     }
 
     /**

--- a/src/Repository/Model/WithdrawableInterface.php
+++ b/src/Repository/Model/WithdrawableInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Repository\Model;
+
+/**
+ * An item that can be taken off the shelves without being deleted.
+ *
+ * Narrower than VisibleItemInterface, which also answers for a private list. A caller that means "has this
+ * been withdrawn" asks here instead, so it does not refuse a private list the viewer was handed a link to.
+ */
+interface WithdrawableInterface
+{
+    public function isEnabled(): bool;
+}

--- a/src/Repository/Model/WithdrawableTrait.php
+++ b/src/Repository/Model/WithdrawableTrait.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Repository\Model;
+
+use Ampache\Module\Authorization\Access;
+use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\AccessTypeEnum;
+
+/**
+ * The two answers an item holding its own `enabled` column gives, for the items that hold one.
+ *
+ * `AlbumDisk` carries no column and reads its album's, so it answers both for itself rather than using this.
+ */
+trait WithdrawableTrait
+{
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function isVisible(?User $user = null): bool
+    {
+        return $this->enabled
+            || ($user instanceof User && Access::check(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $user->getId()));
+    }
+}

--- a/tests/Gui/AlbumDisk/AlbumDiskViewAdapterTest.php
+++ b/tests/Gui/AlbumDisk/AlbumDiskViewAdapterTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Gui\AlbumDisk;
+
+use Ampache\Config\ConfigContainerInterface;
+use Ampache\MockeryTestCase;
+use Ampache\Module\Authorization\Check\FunctionCheckerInterface;
+use Ampache\Module\Authorization\GuiGatekeeperInterface;
+use Ampache\Module\Database\Query\Browse;
+use Ampache\Module\Util\ZipHandlerInterface;
+use Ampache\Repository\Model\AlbumDisk;
+use Ampache\Repository\Model\ModelFactoryInterface;
+use Mockery\MockInterface;
+use Override;
+
+/**
+ * A disk row is the only thing the artist page shows when albums are not grouped, so this is where a manager
+ * either learns the release has been withdrawn or does not.
+ */
+class AlbumDiskViewAdapterTest extends MockeryTestCase
+{
+    private MockInterface&AlbumDisk $albumDisk;
+    private MockInterface&Browse $browse;
+    private MockInterface&ConfigContainerInterface $configContainer;
+    private MockInterface&FunctionCheckerInterface $functionChecker;
+    private MockInterface&GuiGatekeeperInterface $gatekeeper;
+    private MockInterface&ModelFactoryInterface $modelFactory;
+    private AlbumDiskViewAdapter $subject;
+    private MockInterface&ZipHandlerInterface $zipHandler;
+
+    public function testIsDisabledFollowsTheAlbumBehindTheDisk(): void
+    {
+        $this->albumDisk->shouldReceive('isEnabled')->once()->andReturnFalse();
+
+        self::assertTrue($this->subject->isDisabled());
+    }
+
+    public function testIsDisabledIsFalseWhileTheAlbumIsOnTheShelves(): void
+    {
+        $this->albumDisk->shouldReceive('isEnabled')->once()->andReturnTrue();
+
+        self::assertFalse($this->subject->isDisabled());
+    }
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->configContainer = $this->mock(ConfigContainerInterface::class);
+        $this->modelFactory    = $this->mock(ModelFactoryInterface::class);
+        $this->zipHandler      = $this->mock(ZipHandlerInterface::class);
+        $this->functionChecker = $this->mock(FunctionCheckerInterface::class);
+        $this->gatekeeper      = $this->mock(GuiGatekeeperInterface::class);
+        $this->browse          = $this->mock(Browse::class);
+        $this->albumDisk       = $this->mock(AlbumDisk::class);
+
+        $this->subject = new AlbumDiskViewAdapter(
+            $this->configContainer,
+            $this->modelFactory,
+            $this->zipHandler,
+            $this->functionChecker,
+            $this->gatekeeper,
+            $this->browse,
+            $this->albumDisk,
+        );
+    }
+}

--- a/tests/Gui/Edit/AbstractEditFormRendererTest.php
+++ b/tests/Gui/Edit/AbstractEditFormRendererTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Gui\Edit;
+
+use Ampache\Gui\Edit\Renderer\AlbumEditFormRenderer;
+use Ampache\MockeryTestCase;
+use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\AccessTypeEnum;
+use Ampache\Module\Authorization\Check\PrivilegeCheckerInterface;
+use Ampache\Repository\Model\User;
+use Psr\Container\ContainerInterface;
+
+/**
+ * `mayDisable()` is what puts the State menu in the edit dialog, so it is the only thing standing between a
+ * listener and the field that takes a release off the shelves.
+ */
+class AbstractEditFormRendererTest extends MockeryTestCase
+{
+    public function testMayDisableIsGrantedToAManager(): void
+    {
+        $this->bootUser(42, true);
+
+        self::assertTrue((new AlbumEditFormRenderer())->mayDisable());
+    }
+
+    public function testMayDisableIsRefusedBelowManager(): void
+    {
+        $this->bootUser(42, false);
+
+        self::assertFalse((new AlbumEditFormRenderer())->mayDisable());
+    }
+
+    /**
+     * A page rendered with nobody signed in has no level to read, and asking for one would resolve to whatever
+     * the checker makes of a missing id rather than to a refusal
+     */
+    public function testMayDisableIsRefusedWithNoUserAtAll(): void
+    {
+        $privilegeChecker = $this->mock(PrivilegeCheckerInterface::class);
+        // the tell that the user is checked first: the level is never even asked for
+        $privilegeChecker->shouldNotReceive('check');
+
+        $dic = $this->mock(ContainerInterface::class);
+        $dic->shouldReceive('get')->with(PrivilegeCheckerInterface::class)->andReturn($privilegeChecker);
+
+        $GLOBALS['dic'] = $dic;
+        unset($GLOBALS['user']);
+
+        self::assertFalse((new AlbumEditFormRenderer())->mayDisable());
+    }
+
+    private function bootUser(int $userId, bool $isManager): void
+    {
+        $user     = $this->mock(User::class);
+        $user->id = $userId;
+        $user->shouldReceive('getId')->andReturn($userId);
+
+        $privilegeChecker = $this->mock(PrivilegeCheckerInterface::class);
+        $privilegeChecker->shouldReceive('check')
+            ->with(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, $userId)
+            ->andReturn($isManager);
+
+        $dic = $this->mock(ContainerInterface::class);
+        $dic->shouldReceive('get')->with(PrivilegeCheckerInterface::class)->andReturn($privilegeChecker);
+
+        $GLOBALS['dic']  = $dic;
+        $GLOBALS['user'] = $user;
+    }
+}

--- a/tests/Module/Art/GeneratedArtQueryTest.php
+++ b/tests/Module/Art/GeneratedArtQueryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Module\Art;
+
+use Ampache\Config\AmpConfig;
+use Ampache\Module\Art\Generated\GeneratedArtServiceInterface;
+use Ampache\Module\Art\Generated\Template\TemplateInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use ReflectionMethod;
+
+/**
+ * The suffix this builds is the only thing that makes a page ask for a drawn tile, so an install that never
+ * gets it never sees the feature at all, however the preference is set.
+ */
+class GeneratedArtQueryTest extends TestCase
+{
+    /**
+     * A custom placeholder used to turn the whole feature off here. The two settings answer different
+     * questions: `nosvg=1` already serves the placeholder to anything that cannot read an svg.
+     */
+    public function testACustomPlaceholderNoLongerSuppressesTheDrawnTile(): void
+    {
+        $this->bootDic(true);
+        AmpConfig::set('custom_blankalbum', 'https://example.org/blank.png', true);
+
+        self::assertStringContainsString('generate=1', $this->query());
+    }
+
+    public function testNothingIsAskedForWhileTheFeatureIsOff(): void
+    {
+        $this->bootDic(false);
+        AmpConfig::set('custom_blankalbum', '', true);
+
+        self::assertSame('', $this->query());
+    }
+
+    public function testTheTemplateRidesAlongSoAChangeOfMotifBustsTheCache(): void
+    {
+        $this->bootDic(true);
+        AmpConfig::set('custom_blankalbum', '', true);
+
+        self::assertStringContainsString('template=dark', $this->query());
+    }
+
+    private function bootDic(bool $isEnabled): void
+    {
+        $template = $this->createMock(TemplateInterface::class);
+        $template->method('getId')->willReturn('dark');
+
+        $generatedArt = $this->createMock(GeneratedArtServiceInterface::class);
+        $generatedArt->method('isEnabled')->willReturn($isEnabled);
+        $generatedArt->method('resolveTemplate')->willReturn($template);
+
+        $dic = $this->createMock(ContainerInterface::class);
+        $dic->method('get')->willReturn($generatedArt);
+
+        $GLOBALS['dic'] = $dic;
+    }
+
+    private function query(): string
+    {
+        /** @var string $result */
+        $result = new ReflectionMethod(Art::class, 'generated_art_query')->invoke(null);
+
+        return $result;
+    }
+}

--- a/tests/Module/Database/DbaDatabaseConnectionTest.php
+++ b/tests/Module/Database/DbaDatabaseConnectionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Module\Database;
+
+use Ampache\Config\AmpConfig;
+use Ampache\Module\Database\Exception\QueryFailedException;
+use Ampache\Module\System\Dba;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+/**
+ * A failing query used to throw a `QueryFailedException` with no message, so a stack trace named the throw
+ * site and nothing about what actually failed. The statement and the driver error now travel with it.
+ */
+class DbaDatabaseConnectionTest extends TestCase
+{
+    private string $database;
+    private string $hostname;
+
+    public function testAFailedQueryCarriesTheDriverErrorAndTheStatement(): void
+    {
+        // no reachable database, so `Dba::query()` returns null without touching the recorded error, and the
+        // fake driver message set below is what the exception must surface
+        AmpConfig::set('database_hostname', '', true);
+        AmpConfig::set('database_name', 'zz_no_such_db', true);
+
+        $error = new ReflectionProperty(Dba::class, '_error');
+        $error->setValue(null, "SQLSTATE[42S22]: Unknown column 'user_preference.name'");
+
+        try {
+            (new DbaDatabaseConnection())->query('DELETE FROM `user_preference` WHERE `name` = ?', ['x']);
+            self::fail('a query with no database should have thrown');
+        } catch (QueryFailedException $error) {
+            self::assertStringContainsString("Unknown column 'user_preference.name'", $error->getMessage());
+            self::assertStringContainsString('DELETE FROM `user_preference`', $error->getMessage());
+        }
+    }
+
+    protected function setUp(): void
+    {
+        $this->hostname = (string) AmpConfig::get('database_hostname', '');
+        $this->database = (string) AmpConfig::get('database_name', '');
+    }
+
+    protected function tearDown(): void
+    {
+        AmpConfig::set('database_hostname', $this->hostname, true);
+        AmpConfig::set('database_name', $this->database, true);
+    }
+}

--- a/tests/Module/Database/Query/QueryDisabledTest.php
+++ b/tests/Module/Database/Query/QueryDisabledTest.php
@@ -55,7 +55,7 @@ class QueryDisabledTest extends TestCase
         $sql = $this->sqlFor('album_disk', false);
 
         self::assertStringContainsString(
-            'EXISTS (SELECT 1 FROM `album` AS `album_dis` WHERE `album_dis`.`id` = `album_disk`.`album_id` AND `album_dis`.`enabled` = 1)',
+            'EXISTS (SELECT 1 FROM `album` AS `album_wd` WHERE `album_wd`.`id` = `album_disk`.`album_id` AND `album_wd`.`enabled` = 1)',
             $sql
         );
     }
@@ -109,7 +109,7 @@ class QueryDisabledTest extends TestCase
 
         self::assertStringNotContainsString('`album`.`enabled`', $sql);
         self::assertStringNotContainsString('`artist`.`enabled`', $sql);
-        self::assertStringNotContainsString('`album_dis`', $sql);
+        self::assertStringNotContainsString('`album_wd`', $sql);
     }
 
     private function query(bool $isManager): Query

--- a/tests/Module/Database/Search/DisabledSearchTest.php
+++ b/tests/Module/Database/Search/DisabledSearchTest.php
@@ -60,7 +60,7 @@ class DisabledSearchTest extends TestCase
     {
         return [
             ['album', '`album`.`enabled` = 1'],
-            ['album_disk', 'EXISTS (SELECT 1 FROM `album` AS `album_dis` WHERE `album_dis`.`id` = `album_disk`.`album_id` AND `album_dis`.`enabled` = 1)'],
+            ['album_disk', 'EXISTS (SELECT 1 FROM `album` AS `album_wd` WHERE `album_wd`.`id` = `album_disk`.`album_id` AND `album_wd`.`enabled` = 1)'],
             ['artist', '`artist`.`enabled` = 1'],
             ['song', '`song`.`enabled` = 1'],
         ];

--- a/tests/Module/Database/Search/DisabledSearchTest.php
+++ b/tests/Module/Database/Search/DisabledSearchTest.php
@@ -43,10 +43,24 @@ class DisabledSearchTest extends TestCase
     /**
      * @return list<array{0: string, 1: string}>
      */
+    public static function ruleProvider(): array
+    {
+        return [
+            ['album', '`album`.`enabled` = 0'],
+            ['album_disk', '`album`.`enabled` = 0'],
+            ['artist', '`artist`.`enabled` = 0'],
+            ['song', '`song`.`enabled` = 0'],
+        ];
+    }
+
+    /**
+     * @return list<array{0: string, 1: string}>
+     */
     public static function typeProvider(): array
     {
         return [
             ['album', '`album`.`enabled` = 1'],
+            ['album_disk', 'EXISTS (SELECT 1 FROM `album` AS `album_dis` WHERE `album_dis`.`id` = `album_disk`.`album_id` AND `album_dis`.`enabled` = 1)'],
             ['artist', '`artist`.`enabled` = 1'],
             ['song', '`song`.`enabled` = 1'],
         ];
@@ -91,6 +105,20 @@ class DisabledSearchTest extends TestCase
 
         self::assertSame('boolean', $search->get_rule_type_by_name('enabled'));
         self::assertContains('enabled', array_column($search->get_rule_types(), 'name'));
+    }
+
+    /**
+     * Being offered is not the same as working: `album_disk` was served the rule and had no case to answer it,
+     * so a smartlist of disks asking for withdrawn releases quietly returned the whole catalogue.
+     */
+    #[DataProvider(methodName: 'ruleProvider')]
+    public function testTheRuleProducesItsConditionOnEveryType(string $type, string $expected): void
+    {
+        $search = $this->search($type, true);
+        // set_rules() reaches an access check, so the rules are given in the shape it would have produced
+        $search->rules = [['enabled', 'equal', 0]];
+
+        self::assertStringContainsString($expected, $search->to_sql()['where_sql']);
     }
 
     private function search(string $type, bool $isManager): Search

--- a/tests/Module/Statistics/StatsTest.php
+++ b/tests/Module/Statistics/StatsTest.php
@@ -84,21 +84,39 @@ class StatsTest extends TestCase
         self::assertSame(1500000000, $this->clamp(1500000000));
     }
 
-    /**
-     * The cron cache is read by the widgets whenever it is warm, so leaving it unfiltered would serve
-     * withdrawn releases on exactly the instances that turned the cache on
-     */
     public function testTheCachedTopListCarriesTheConditionToo(): void
     {
         $this->bootDic(false);
         AmpConfig::set('cron_cache', true, true);
 
-        self::assertStringContainsString(
-            '`id` = `cache_object_count`.`object_id`',
-            Stats::get_top_sql('song')
-        );
+        try {
+            self::assertStringContainsString('`id` = `cache_object_count`.`object_id`', Stats::get_top_sql('song'));
+        } finally {
+            AmpConfig::set('cron_cache', false, true);
+        }
+    }
 
-        AmpConfig::set('cron_cache', false, true);
+    /**
+     * The cron cache is read by the widgets whenever it is warm, so leaving it unfiltered would serve
+     * withdrawn releases on exactly the instances that turned the cache on
+     */
+    /**
+     * `cache_object_count` keys a disk row on the disk id, so the flag is two hops away: reading `album`
+     * against that id compares a disk id to an album id and keeps whatever happens to collide
+     */
+    public function testTheCachedTopListOfDisksResolvesTheDiskToItsAlbum(): void
+    {
+        $this->bootDic(false);
+        AmpConfig::set('cron_cache', true, true);
+
+        try {
+            $sql = Stats::get_top_sql('album_disk');
+
+            self::assertStringContainsString('`disk_wd`.`id` = `cache_object_count`.`object_id`', $sql);
+            self::assertStringContainsString('`album_wd`.`id` = `disk_wd`.`album_id`', $sql);
+        } finally {
+            AmpConfig::set('cron_cache', false, true);
+        }
     }
 
     /**
@@ -109,9 +127,13 @@ class StatsTest extends TestCase
     {
         $this->bootDic(false);
 
-        $sql = Stats::get_top_sql('song', 0, 'stream', null, false, 0, 0, true);
+        try {
+            $sql = Stats::get_top_sql('song', 0, 'stream', null, false, 0, 0, true);
 
-        self::assertStringNotContainsString('`song`.`enabled`', $sql);
+            self::assertStringNotContainsString('`song`.`enabled`', $sql);
+        } finally {
+            AmpConfig::set('cron_cache', false, true);
+        }
     }
 
     public function testTheRecentWidgetDropsWithdrawnItemsForAListener(): void

--- a/tests/Module/Statistics/StatsTest.php
+++ b/tests/Module/Statistics/StatsTest.php
@@ -25,7 +25,12 @@ declare(strict_types=1);
 
 namespace Ampache\Module\Statistics;
 
+use Ampache\Config\AmpConfig;
+use Ampache\Module\Authorization\Check\PrivilegeCheckerInterface;
+use Ampache\Repository\CatalogRepositoryInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use ReflectionMethod;
 
 /**
@@ -79,6 +84,94 @@ class StatsTest extends TestCase
         self::assertSame(1500000000, $this->clamp(1500000000));
     }
 
+    /**
+     * The cron cache is read by the widgets whenever it is warm, so leaving it unfiltered would serve
+     * withdrawn releases on exactly the instances that turned the cache on
+     */
+    public function testTheCachedTopListCarriesTheConditionToo(): void
+    {
+        $this->bootDic(false);
+        AmpConfig::set('cron_cache', true, true);
+
+        self::assertStringContainsString(
+            '`id` = `cache_object_count`.`object_id`',
+            Stats::get_top_sql('song')
+        );
+
+        AmpConfig::set('cron_cache', false, true);
+    }
+
+    /**
+     * The cache is filled through this very statement and then read by everybody, managers included, so a run
+     * that filtered would freeze a truncated top list for the whole instance until the next sweep.
+     */
+    public function testTheCacheIsWrittenWithoutTheCondition(): void
+    {
+        $this->bootDic(false);
+
+        $sql = Stats::get_top_sql('song', 0, 'stream', null, false, 0, 0, true);
+
+        self::assertStringNotContainsString('`song`.`enabled`', $sql);
+    }
+
+    public function testTheRecentWidgetDropsWithdrawnItemsForAListener(): void
+    {
+        $this->bootDic(false);
+
+        // this path reads `album` itself, so the flag is stated directly rather than through a subquery
+        self::assertStringContainsString('`album`.`enabled` = 1', Stats::get_recent_sql('album'));
+        self::assertStringNotContainsString('`album`.`id` = `album`.`id`', Stats::get_recent_sql('album'));
+    }
+
+    public function testTheRecentWidgetKeepsWithdrawnItemsForAManager(): void
+    {
+        $this->bootDic(true);
+
+        self::assertStringNotContainsString('`album`.`enabled` = 1', Stats::get_recent_sql('album'));
+    }
+
+    /**
+     * The recent widget reads the tables holding `last_played` rather than the play history, and a disk has
+     * no flag of its own there either
+     */
+    public function testTheRecentWidgetOfDisksReadsTheAlbum(): void
+    {
+        $this->bootDic(false);
+
+        self::assertStringContainsString(
+            '`id` = `album_disk`.`album_id`',
+            Stats::get_recent_sql('album_disk')
+        );
+    }
+
+    public function testTheTopListDropsWithdrawnItemsForAListener(): void
+    {
+        $this->bootDic(false);
+
+        self::assertStringContainsString('`enabled` = 1', Stats::get_top_sql('song'));
+    }
+
+    public function testTheTopListKeepsWithdrawnItemsForAManager(): void
+    {
+        $this->bootDic(true);
+
+        self::assertStringNotContainsString('`enabled` = 1', Stats::get_top_sql('song'));
+    }
+
+    /**
+     * `$type` has become 'song' by the time the condition is built, so the column it correlates on is the
+     * tell: a disk reads the state of its album, never the state of one of its tracks
+     */
+    public function testTheTopListOfDisksReadsTheAlbumAndNotTheSong(): void
+    {
+        $this->bootDic(false);
+
+        $sql = Stats::get_top_sql('album_disk');
+
+        self::assertStringContainsString('`id` = `album_disk`.`album_id`', $sql);
+        self::assertStringNotContainsString('`song`.`enabled`', $sql);
+    }
+
     private function assertIsNow(?int $date): void
     {
         $before = time();
@@ -87,6 +180,24 @@ class StatsTest extends TestCase
 
         self::assertGreaterThanOrEqual($before, $result);
         self::assertLessThanOrEqual($after, $result);
+    }
+
+    private function bootDic(bool $isManager): void
+    {
+        $privilegeChecker = $this->createMock(PrivilegeCheckerInterface::class);
+        $privilegeChecker->method('check')->willReturn($isManager);
+
+        $catalogRepository = $this->createMock(CatalogRepositoryInterface::class);
+        $catalogRepository->method('getIds')->willReturn([]);
+
+        $dic = $this->createMock(ContainerInterface::class);
+        $dic->method('get')->willReturnCallback(fn(string $id): object => match ($id) {
+            CatalogRepositoryInterface::class => $catalogRepository,
+            PrivilegeCheckerInterface::class => $privilegeChecker,
+            default => $this->createMock(LoggerInterface::class),
+        });
+
+        $GLOBALS['dic'] = $dic;
     }
 
     private function clamp(?int $date): int

--- a/tests/Module/System/PreferenceRebuildTest.php
+++ b/tests/Module/System/PreferenceRebuildTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Module\System;
+
+use Ampache\Repository\CatalogFilterRepositoryInterface;
+use Ampache\Repository\PreferenceRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * `rebuild_all_preferences` repairs preferences assuming the final schema — `user_preference`.`name` first of
+ * all, which a migration adds late. Run mid-upgrade, before that column exists, it used to crash the whole
+ * `admin:updateDatabase`. It must stand down until the schema is complete, and it must not stand down otherwise.
+ */
+class PreferenceRebuildTest extends TestCase
+{
+    private CatalogFilterRepositoryInterface&MockObject $filterRepository;
+    private PreferenceRepositoryInterface&MockObject $preferenceRepository;
+
+    public function testRebuildDoesNothingWhileTheNameColumnIsMissing(): void
+    {
+        $this->preferenceRepository->method('hasUserPreferenceName')->willReturn(false);
+
+        // none of the repairs, which all read or write `user_preference`.`name`, may be attempted
+        $this->preferenceRepository->expects(self::never())->method('repairLanguagePreferences');
+        $this->preferenceRepository->expects(self::never())->method('collectPreferenceGarbage');
+        $this->preferenceRepository->expects(self::never())->method('getIdsMissingPreferences');
+        $this->filterRepository->expects(self::never())->method('repairDefaultGroup');
+
+        Preference::rebuild_all_preferences();
+    }
+
+    public function testRebuildRunsTheRepairsOnceTheSchemaIsComplete(): void
+    {
+        $this->preferenceRepository->method('hasUserPreferenceName')->willReturn(true);
+        // let the per-user pass over nothing so the test stays about the guard
+        $this->preferenceRepository->method('getIdsMissingPreferences')->willReturn([]);
+        $this->preferenceRepository->method('getStoredPreferences')->willReturn([]);
+        $this->preferenceRepository->method('getAllPreferences')->willReturn([]);
+        $this->preferenceRepository->method('getSystemDefaultPreferences')->willReturn([]);
+
+        // the guard let the maintenance through
+        $this->preferenceRepository->expects(self::once())->method('repairLanguagePreferences');
+        $this->preferenceRepository->expects(self::once())->method('collectPreferenceGarbage');
+
+        Preference::rebuild_all_preferences();
+    }
+
+    protected function setUp(): void
+    {
+        $this->preferenceRepository = $this->createMock(PreferenceRepositoryInterface::class);
+        $this->filterRepository     = $this->createMock(CatalogFilterRepositoryInterface::class);
+
+        $dic = $this->createMock(ContainerInterface::class);
+        $dic->method('get')->willReturnCallback(fn(string $id): object => match ($id) {
+            PreferenceRepositoryInterface::class => $this->preferenceRepository,
+            CatalogFilterRepositoryInterface::class => $this->filterRepository,
+        });
+
+        // the model reaches its repositories through the `global $dic` bridge; phpunit.xml backs globals up
+        $GLOBALS['dic'] = $dic;
+    }
+}

--- a/tests/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapterTest.php
+++ b/tests/Module/Util/Rss/Surrogate/PlayableItemRssItemAdapterTest.php
@@ -28,6 +28,8 @@ namespace Ampache\Module\Util\Rss\Surrogate;
 use Ampache\Repository\Model\library_item;
 use Ampache\Repository\Model\LibraryItemLoaderInterface;
 use Ampache\Repository\Model\ModelFactoryInterface;
+use Ampache\Repository\Model\Podcast_Episode;
+use Ampache\Repository\Model\Song;
 use Ampache\Repository\Model\User;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -39,6 +41,52 @@ class PlayableItemRssItemAdapterTest extends TestCase
     private library_item&MockObject $playable;
     private PlayableItemRssItemAdapter $subject;
     private User&MockObject $user;
+
+    public function testArtSourcesDropsAnAlbumlessSong(): void
+    {
+        $song = $this->createMock(Song::class);
+        $song->method('getId')->willReturn(49388);
+
+        self::assertSame(
+            [['song', 49388]],
+            PlayableItemRssItemAdapter::artSources($song)
+        );
+    }
+
+    public function testArtSourcesDropsAnUnsetPodcast(): void
+    {
+        $episode = $this->createMock(Podcast_Episode::class);
+        $episode->method('getId')->willReturn(666);
+
+        self::assertSame(
+            [['podcast_episode', 666]],
+            PlayableItemRssItemAdapter::artSources($episode)
+        );
+    }
+
+    public function testArtSourcesReadsTheAlbumAfterTheSong(): void
+    {
+        $song        = $this->createMock(Song::class);
+        $song->album = 7953;
+        $song->method('getId')->willReturn(49388);
+
+        self::assertSame(
+            [['song', 49388], ['album', 7953]],
+            PlayableItemRssItemAdapter::artSources($song)
+        );
+    }
+
+    public function testArtSourcesReadsThePodcastAfterTheEpisode(): void
+    {
+        $episode          = $this->createMock(Podcast_Episode::class);
+        $episode->podcast = 12;
+        $episode->method('getId')->willReturn(666);
+
+        self::assertSame(
+            [['podcast_episode', 666], ['podcast', 12]],
+            PlayableItemRssItemAdapter::artSources($episode)
+        );
+    }
 
     public function testGetOwnerNameReturnsValue(): void
     {

--- a/tests/Module/Util/ZipHandlerTest.php
+++ b/tests/Module/Util/ZipHandlerTest.php
@@ -26,8 +26,10 @@ declare(strict_types=1);
 namespace Ampache\Module\Util;
 
 use Ampache\Config\ConfigContainerInterface;
+use Ampache\Config\ConfigurationKeyEnum;
 use Ampache\MockeryTestCase;
 use Mockery\MockInterface;
+use Nyholm\Psr7\Response;
 use Override;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -66,6 +68,36 @@ class ZipHandlerTest extends MockeryTestCase
         self::assertTrue(
             $this->subject->isZipable($type)
         );
+    }
+
+    public function testZipAnswersNotFoundWhenNothingCouldBeAdded(): void
+    {
+        $this->configContainer->shouldReceive('get')
+            ->with(ConfigurationKeyEnum::ALBUM_ART_PREFERRED_FILENAME)
+            ->andReturn('folder.jpg');
+        $this->configContainer->shouldReceive('isFeatureEnabled')
+            ->with(ConfigurationKeyEnum::ART_ZIP_ADD)
+            ->andReturnFalse();
+        $this->configContainer->shouldReceive('get')
+            ->with(ConfigurationKeyEnum::FILE_ZIP_COMMENT)
+            ->andReturn('');
+        $this->logger->shouldReceive('debug')->zeroOrMoreTimes();
+        $this->logger->shouldReceive('warning')->once();
+
+        // the tell that the crash is gone: no stream is opened on an archive that was never written
+        $this->streamFactory->expects(self::never())
+            ->method('createStreamFromFile');
+
+        // zip() drops the output buffer a page request leaves open, so the test has to provide one of its own
+        ob_start();
+        $response = $this->subject->zip(
+            new Response(),
+            'Nothing To Send',
+            ['total_size' => 0, 'files' => []],
+            false
+        );
+
+        self::assertSame(404, $response->getStatusCode());
     }
 
     #[Override]

--- a/tests/Repository/AlbumRepositoryTest.php
+++ b/tests/Repository/AlbumRepositoryTest.php
@@ -483,6 +483,24 @@ class AlbumRepositoryTest extends TestCase
         $this->subject->getAlbumByArtist(42);
     }
 
+    /**
+     * Deleting an artist takes its albums with it, and retagging one carries down to them, so those two read
+     * the whole list. A filtered one leaves a withdrawn album behind with nothing above it.
+     */
+    public function testGetAlbumByArtistKeepsTheWithdrawnOnesForMaintenance(): void
+    {
+        $this->bootPrivilegeChecker(false);
+
+        $result = $this->createMock(PDOStatement::class);
+        $this->connection->expects(static::once())
+            ->method('query')
+            ->with(self::logicalNot(self::stringContains('`album`.`enabled`')))
+            ->willReturn($result);
+        $result->method('fetch')->willReturn(false);
+
+        $this->subject->getAlbumByArtist(42, false);
+    }
+
     public function testGetArtistMapReturnsArtistList(): void
     {
         $album  = $this->createMock(Album::class);

--- a/tests/Repository/AlbumRepositoryTest.php
+++ b/tests/Repository/AlbumRepositoryTest.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace Ampache\Repository;
 
 use Ampache\Config\AmpConfig;
+use Ampache\Module\Authorization\Check\PrivilegeCheckerInterface;
 use Ampache\Module\Database\DatabaseConnectionInterface;
 use Ampache\Module\Database\Exception\QueryFailedException;
 use Ampache\Module\System\LegacyLogger;
@@ -34,6 +35,7 @@ use Ampache\Repository\Model\AlbumFieldEnum;
 use PDOStatement;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use SEEC\PhpUnit\Helper\ConsecutiveParams;
 
@@ -463,6 +465,24 @@ class AlbumRepositoryTest extends TestCase
         );
     }
 
+    /**
+     * The api and upnp listings of an artist's albums do not go through a browse either, so the withdrawal
+     * has to be read here or a release taken off the shelves is handed out by every device protocol.
+     */
+    public function testGetAlbumByArtistHidesAWithdrawnAlbumFromALowerLevel(): void
+    {
+        $this->bootPrivilegeChecker(false);
+
+        $result = $this->createMock(PDOStatement::class);
+        $this->connection->expects(static::once())
+            ->method('query')
+            ->with(self::stringContains('AND `album`.`enabled` = 1'))
+            ->willReturn($result);
+        $result->method('fetch')->willReturn(false);
+
+        $this->subject->getAlbumByArtist(42);
+    }
+
     public function testGetArtistMapReturnsArtistList(): void
     {
         $album  = $this->createMock(Album::class);
@@ -492,6 +512,38 @@ class AlbumRepositoryTest extends TestCase
             [$artistId],
             $this->subject->getArtistMap($album, $objectType)
         );
+    }
+
+    /**
+     * An album taken off the shelves was still listed on the page of its artist, for everybody, because this
+     * listing builds its own sql instead of going through Query::_get_filter_sql()
+     */
+    public function testGetByArtistHidesAWithdrawnAlbumFromALowerLevel(): void
+    {
+        $this->bootPrivilegeChecker(false);
+
+        $result = $this->createMock(PDOStatement::class);
+        $this->connection->expects(static::once())
+            ->method('query')
+            ->with(self::stringContains('AND `album`.`enabled` = 1'))
+            ->willReturn($result);
+        $result->method('fetch')->willReturn(false);
+
+        $this->subject->getByArtist(42);
+    }
+
+    public function testGetByArtistLeavesTheConditionOutForAManager(): void
+    {
+        $this->bootPrivilegeChecker(true);
+
+        $result = $this->createMock(PDOStatement::class);
+        $this->connection->expects(static::once())
+            ->method('query')
+            ->with(self::logicalNot(self::stringContains('`album`.`enabled`')))
+            ->willReturn($result);
+        $result->method('fetch')->willReturn(false);
+
+        $this->subject->getByArtist(42);
     }
 
     public function testGetByMbidGroupReturnsData(): void
@@ -963,6 +1015,25 @@ class AlbumRepositoryTest extends TestCase
 
         // the object cache is a process-wide static, so a leftover entry would leak between tests
         Album::clear_cache();
+    }
+
+    private function bootPrivilegeChecker(bool $isManager): void
+    {
+        $privilegeChecker = $this->createMock(PrivilegeCheckerInterface::class);
+        $privilegeChecker->method('check')->willReturn($isManager);
+
+        // `Catalog::get_catalogs()` reaches the same container on the way through, so it cannot all be the checker
+        $catalogRepository = $this->createMock(CatalogRepositoryInterface::class);
+        $catalogRepository->method('getIds')->willReturn([]);
+
+        $dic = $this->createMock(ContainerInterface::class);
+        $dic->method('get')->willReturnCallback(
+            fn(string $id): object => ($id === PrivilegeCheckerInterface::class)
+                ? $privilegeChecker
+                : $catalogRepository
+        );
+
+        $GLOBALS['dic'] = $dic;
     }
 
     /**

--- a/tests/Repository/Model/AlbumTest.php
+++ b/tests/Repository/Model/AlbumTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Repository\Model;
+
+use Ampache\MockeryTestCase;
+use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\AccessTypeEnum;
+use Ampache\Module\Authorization\Check\PrivilegeCheckerInterface;
+use Ampache\Repository\AlbumRepositoryInterface;
+use Psr\Container\ContainerInterface;
+
+class AlbumTest extends MockeryTestCase
+{
+    /**
+     * Withdrawing a release takes its songs with it, so the cascade is part of the promise rather than a
+     * convenience: enabling a song back on its own stays possible, re-enabling the album does not happen by itself
+     */
+    public function testUpdateEnabledCarriesTheStateDownToTheSongs(): void
+    {
+        $albumRepository = $this->mock(AlbumRepositoryInterface::class);
+        $albumRepository->shouldReceive('setField')
+            ->with(666, AlbumFieldEnum::ENABLED, 0)
+            ->once();
+        $albumRepository->shouldReceive('setSongsEnabled')
+            ->with(666, false)
+            ->once();
+
+        $this->bootDic($albumRepository, true);
+
+        Album::update_enabled(false, 666);
+    }
+
+    /**
+     * The whole feature rests on this level, and nothing else stops a listener who posts the field by hand:
+     * the guard is the only thing between them and a takedown they can undo
+     */
+    public function testUpdateEnabledWritesNothingBelowManager(): void
+    {
+        $albumRepository = $this->mock(AlbumRepositoryInterface::class);
+        // the tell that the guard fired: neither the album nor its songs are touched
+        $albumRepository->shouldNotReceive('setField');
+        $albumRepository->shouldNotReceive('setSongsEnabled');
+
+        $this->bootDic($albumRepository, false);
+
+        Album::update_enabled(false, 666);
+    }
+
+    private function bootDic(AlbumRepositoryInterface $albumRepository, bool $isManager): void
+    {
+        $privilegeChecker = $this->mock(PrivilegeCheckerInterface::class);
+        $privilegeChecker->shouldReceive('check')
+            ->with(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, null)
+            ->andReturn($isManager);
+
+        $dic = $this->mock(ContainerInterface::class);
+        $dic->shouldReceive('get')->with(PrivilegeCheckerInterface::class)->andReturn($privilegeChecker);
+        $dic->shouldReceive('get')->with(AlbumRepositoryInterface::class)->andReturn($albumRepository);
+
+        $GLOBALS['dic'] = $dic;
+    }
+}

--- a/tests/Repository/Model/ArtistTest.php
+++ b/tests/Repository/Model/ArtistTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * vim:set softtabstop=4 shiftwidth=4 expandtab:
+ *
+ * LICENSE: GNU Affero General Public License, version 3 (AGPL-3.0-or-later)
+ * Copyright Ampache.org, 2001-2026
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Ampache\Repository\Model;
+
+use Ampache\MockeryTestCase;
+use Ampache\Module\Authorization\AccessLevelEnum;
+use Ampache\Module\Authorization\AccessTypeEnum;
+use Ampache\Module\Authorization\Check\PrivilegeCheckerInterface;
+use Ampache\Repository\ArtistRepositoryInterface;
+use Psr\Container\ContainerInterface;
+
+class ArtistTest extends MockeryTestCase
+{
+    /**
+     * Withdrawing an artist reaches their albums and the songs under them, and the stored counts are brought
+     * back in the same breath because every page reads the count rather than counting again
+     */
+    public function testUpdateEnabledCarriesTheStateDownAndRefreshesTheCounts(): void
+    {
+        $artistRepository = $this->mock(ArtistRepositoryInterface::class);
+        $artistRepository->shouldReceive('setField')
+            ->with(666, ArtistFieldEnum::ENABLED, 0)
+            ->once();
+        $artistRepository->shouldReceive('setChildrenEnabled')
+            ->with(666, false)
+            ->once();
+        $artistRepository->shouldReceive('updateCounts')
+            ->with(666)
+            ->once();
+
+        $this->bootDic($artistRepository, true);
+
+        Artist::update_enabled(false, 666);
+    }
+
+    /**
+     * The whole feature rests on this level, and nothing else stops a listener who posts the field by hand:
+     * the guard is the only thing between them and a takedown they can undo
+     */
+    public function testUpdateEnabledWritesNothingBelowManager(): void
+    {
+        $artistRepository = $this->mock(ArtistRepositoryInterface::class);
+        // the tell that the guard fired: neither the artist, nor its children, nor the counts are touched
+        $artistRepository->shouldNotReceive('setField');
+        $artistRepository->shouldNotReceive('setChildrenEnabled');
+        $artistRepository->shouldNotReceive('updateCounts');
+
+        $this->bootDic($artistRepository, false);
+
+        Artist::update_enabled(false, 666);
+    }
+
+    private function bootDic(ArtistRepositoryInterface $artistRepository, bool $isManager): void
+    {
+        $privilegeChecker = $this->mock(PrivilegeCheckerInterface::class);
+        $privilegeChecker->shouldReceive('check')
+            ->with(AccessTypeEnum::INTERFACE, AccessLevelEnum::MANAGER, null)
+            ->andReturn($isManager);
+
+        $dic = $this->mock(ContainerInterface::class);
+        $dic->shouldReceive('get')->with(PrivilegeCheckerInterface::class)->andReturn($privilegeChecker);
+        $dic->shouldReceive('get')->with(ArtistRepositoryInterface::class)->andReturn($artistRepository);
+
+        $GLOBALS['dic'] = $dic;
+    }
+}

--- a/tests/Repository/Model/ShareTest.php
+++ b/tests/Repository/Model/ShareTest.php
@@ -58,6 +58,31 @@ class ShareTest extends TestCase
     }
 
     /**
+     * Sharing a private list is the whole point of the link: the visitor on the other end has no account, so
+     * asking whether they may see the list would refuse every one of them.
+     */
+    public function testIsValidKeepsWorkingForAPrivatePlaylist(): void
+    {
+        AmpConfig::set('share', true, true);
+
+        $private = $this->createMock(Playlist::class);
+        // the tell that the wrong question is gone: a private list answers no here and is served anyway
+        $private->method('isVisible')->willReturn(false);
+        $this->bootLoader($private);
+
+        $subject                 = new Share();
+        $subject->id             = 666;
+        $subject->object_type    = 'playlist';
+        $subject->object_id      = 42;
+        $subject->expire_days    = 0;
+        $subject->max_counter    = 0;
+        $subject->allow_stream   = false;
+        $subject->allow_download = false;
+
+        self::assertTrue($subject->is_valid('', ''));
+    }
+
+    /**
      * A link handed out before a takedown has to stop working with it. The visitor has no account, so the
      * withdrawal is read off the item rather than from whoever is on the other end.
      */
@@ -66,7 +91,7 @@ class ShareTest extends TestCase
         AmpConfig::set('share', true, true);
 
         $withdrawn = $this->createMock(Album::class);
-        $withdrawn->method('isVisible')->willReturn(false);
+        $withdrawn->method('isEnabled')->willReturn(false);
         $this->bootLoader($withdrawn);
 
         $subject                 = new Share();


### PR DESCRIPTION
The holes in the enabled feature I sent you for 8.1.0.

Three things about it:

- the share link is a regression I introduced
- the drawn artwork => having a custom album is useful even with draw art enabled (like for RSS, or SEO). So don't force the custom blank art if there is one AND you have generate art enabled
- get_top_sql() writes the cron cache through the same statement it reads it with, so the write path is deliberately left unfiltered

I added a fix for the issue reported by Psy on Telegram in d785e71 . It may be an upgrade issue for every setup going from 7.x to 8.1